### PR TITLE
Fix lease leaks, close-ordering, and counter races across recipes

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -89,6 +89,10 @@ constructor(
         keepAliveLease = client.keepAlive(lease)
         true
       } else {
+        // Lease leaked the original implementation: when the CAS lost or the
+        // value verification failed we returned without ever revoking the
+        // lease, so it sat in etcd until TTL — wasteful in tight retry loops.
+        client.leaseRevoke(lease)
         false
       }
     }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -240,6 +240,6 @@ constructor(
   }
 
   companion object {
-    internal fun defaultClientId() = EtcdConnector.defaultClientId(DistributedBarrierWithCount::class.simpleName!!)
+    internal fun defaultClientId() = defaultClientId(DistributedBarrierWithCount::class.simpleName!!)
   }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedDoubleBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedDoubleBarrier.kt
@@ -82,8 +82,13 @@ constructor(
   fun leave(timeout: Duration): Boolean = leaveBarrier.waitOnBarrier(timeout)
 
   override fun close() {
-    enterBarrier.close()
-    leaveBarrier.close()
+    // Without try/finally an exception from enterBarrier.close() would leak
+    // the second barrier (its watcher and dispatcher executor).
+    try {
+      enterBarrier.close()
+    } finally {
+      leaveBarrier.close()
+    }
   }
 
   companion object {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -252,11 +252,18 @@ class PathChildrenCache(
   override fun doClose() {
     checkStartCalled()
 
+    // Wait for the background loader before touching the watcher: in
+    // BUILD_INITIAL_CACHE / POST_INITIALIZED_EVENT modes the watcher is
+    // assigned inside loadDataAndStartWatcher() running on `executor`. If
+    // close() runs before that task assigns `watcher`, closing here first
+    // would no-op on a null reference and the later-assigned watcher (and
+    // its dispatcher executor) would leak.
+    startThreadComplete.waitUntilTrue()
+
     watcher?.close()
     watcher = null
 
     listeners.clear()
-    startThreadComplete.waitUntilTrue()
 
     if (userExecutor == null) (executor as ExecutorService).shutdown()
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/KeepAliveExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/KeepAliveExtensions.kt
@@ -96,8 +96,16 @@ fun Client.putValuesWithKeepAlive(
   block: () -> Unit,
 ) {
   val lease = leaseGrant(ttl)
-  for (kv in kvs) {
-    putValue(kv.first, kv.second, putOption { withLeaseId(lease.id) })
+  // Original code never revoked the lease if a put threw or if keepAliveWith
+  // could not start, so a transient etcd error during initial setup would
+  // strand a lease for ttl seconds.
+  try {
+    for (kv in kvs) {
+      putValue(kv.first, kv.second, putOption { withLeaseId(lease.id) })
+    }
+  } catch (e: Throwable) {
+    leaseRevoke(lease)
+    throw e
   }
   keepAliveWith(lease) { block() }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LeaseExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LeaseExtensions.kt
@@ -42,3 +42,17 @@ fun Client.keepAlive(lease: LeaseGrantResponse): CloseableClient =
 
 fun Client.leaseGrant(ttl: Duration): LeaseGrantResponse =
   leaseClient.grant(ttl.toDouble(DurationUnit.SECONDS).toLong()).get()
+
+/**
+ * Best-effort revoke of a lease. Failures are logged and swallowed because
+ * callers use this on cleanup paths (failed CAS, exception in put loop) where
+ * raising a secondary failure would mask the original problem; the lease's TTL
+ * is the upper bound on resource retention if the revoke RPC itself fails.
+ */
+fun Client.leaseRevoke(lease: LeaseGrantResponse) {
+  try {
+    leaseClient.revoke(lease.id).get()
+  } catch (e: Throwable) {
+    logger.debug(e) { "leaseRevoke(${lease.id}) failed; lease will expire on TTL" }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
@@ -28,6 +28,7 @@ import io.etcd.jetcd.watch.WatchResponse
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 val WatchEvent.keyAsString get() = keyValue.key.asString
 val WatchEvent.keyAsInt get() = keyValue.key.asInt
@@ -66,6 +67,13 @@ private class DispatchingWatcher(
   override fun close() {
     delegate.close()
     dispatcher.shutdown()
+    // shutdown() refuses new tasks but does not wait for the currently-running
+    // callback task. Without awaiting, the user's `block` could still be
+    // executing on the dispatcher thread after withWatcher's receiver has
+    // returned — touching state the caller assumes is no longer in use. A
+    // short bounded wait makes the close-then-touch contract real without
+    // turning into a blocker on a misbehaving callback.
+    dispatcher.awaitTermination(5, TimeUnit.SECONDS)
   }
 }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/counter/DistributedAtomicLong.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/counter/DistributedAtomicLong.kt
@@ -106,17 +106,19 @@ constructor(
     ensureStarted()
     checkCloseNotCalled()
     var count = 1
-    do {
-      val txnResponse = applyCounterTransaction(value)
-      if (!txnResponse.isSucceeded) {
-        // Crude backoff for retry
-        sleep((count * 100).random().milliseconds)
-        count++
+    while (true) {
+      val (txnResponse, committedValue) = applyCounterTransaction(value)
+      if (txnResponse.isSucceeded) {
+        // Return the value we just wrote — not a separate GET. The previous
+        // implementation re-read counterPath after a successful CAS; under
+        // contention another writer could mutate the counter between the CAS
+        // and the GET, so callers received a value they did not commit.
+        return committedValue
       }
-    } while (!txnResponse.isSucceeded)
-
-    // Return the latest value
-    return client.getValue(counterPath, -1L)
+      // Crude backoff for retry
+      sleep((count * 100).random().milliseconds)
+      count++
+    }
   }
 
   private fun createCounterIfNotPresent(): Boolean =
@@ -130,14 +132,18 @@ constructor(
       false
     }
 
-  private fun applyCounterTransaction(amount: Long): TxnResponse =
-    client.transaction {
-      val kvList: List<KeyValue> = client.getResponse(counterPath).kvs
-      check(kvList.isNotEmpty()) { "Empty KeyValue list" }
-      val kv = kvList.first()
-      If(equalTo(counterPath, CmpTarget.modRevision(kv.modRevision)))
-      Then(counterPath setTo kv.value.asLong + amount)
-    }
+  private fun applyCounterTransaction(amount: Long): Pair<TxnResponse, Long> {
+    val kvList: List<KeyValue> = client.getResponse(counterPath).kvs
+    check(kvList.isNotEmpty()) { "Empty KeyValue list" }
+    val kv = kvList.first()
+    val newValue = kv.value.asLong + amount
+    val txn =
+      client.transaction {
+        If(equalTo(counterPath, CmpTarget.modRevision(kv.modRevision)))
+        Then(counterPath setTo newValue)
+      }
+    return txn to newValue
+  }
 
   companion object {
     private val logger = KotlinLogging.logger {}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceDiscovery.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceDiscovery.kt
@@ -136,6 +136,6 @@ constructor(
   companion object {
     private val logger = KotlinLogging.logger {}
 
-    internal fun defaultClientId() = EtcdConnector.defaultClientId(ServiceDiscovery::class.simpleName!!)
+    internal fun defaultClientId() = defaultClientId(ServiceDiscovery::class.simpleName!!)
   }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -39,6 +39,7 @@ import io.etcd.recipes.common.getValue
 import io.etcd.recipes.common.isKeyPresent
 import io.etcd.recipes.common.keepAliveWith
 import io.etcd.recipes.common.leaseGrant
+import io.etcd.recipes.common.leaseRevoke
 import io.etcd.recipes.common.putOption
 import io.etcd.recipes.common.setTo
 import io.etcd.recipes.common.transaction
@@ -326,7 +327,10 @@ constructor(
 
     // Check to see if unique value was successfully set in the CAS step
     if (isLeader || !txn.isSucceeded || client.getValue(leaderPath)?.asString != uniqueToken) {
-      // Failed to become leader
+      // Failed to become leader: revoke the lease we just created so it does
+      // not linger in etcd until TTL. Without this, every losing candidate in
+      // an election leaks a lease per turnover.
+      client.leaseRevoke(lease)
       return false
     }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
@@ -92,13 +92,31 @@ constructor(
         logger.error(e) { "In start()" }
         exceptionList.value += e
       } finally {
+        // Always release the start() caller, even on failure. The previous
+        // version only counted down inside the keepAlive callback, so if the
+        // initial put / lease grant threw, start() would block on
+        // keepAliveStartedLatch forever.
+        keepAliveStartedLatch.countDown()
         startThreadComplete.set(true)
       }
     }
 
     keepAliveStartedLatch.await()
-    startCalled.store(true)
 
+    // Surface a setup failure to the caller of start() so they don't believe
+    // a non-running keepAlive is healthy. Mark startCalled only on success;
+    // marking before checking would let close() proceed past checkStartCalled()
+    // on an instance that never actually started.
+    val startupError = exceptionList.value.firstOrNull()
+    if (startupError != null) {
+      // Constructor with autoStart=true throws here; the user never gets a
+      // reference to call close(), so we must release our owned executor
+      // before propagating, otherwise the thread (and JVM exit) leaks.
+      if (userExecutor == null) (executor as ExecutorService).shutdown()
+      throw EtcdRecipeRuntimeException("start() failed: $startupError")
+    }
+
+    startCalled.store(true)
     return this
   }
 
@@ -114,6 +132,6 @@ constructor(
   companion object {
     private val logger = KotlinLogging.logger {}
 
-    internal fun defaultClientId() = EtcdConnector.defaultClientId(TransientKeyValue::class.simpleName!!)
+    internal fun defaultClientId() = defaultClientId(TransientKeyValue::class.simpleName!!)
   }
 }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/design/BugFixesTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/design/BugFixesTests.kt
@@ -1,0 +1,329 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.design
+
+import io.etcd.jetcd.options.LeaseOption
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.jetcd.watch.WatchEvent
+import io.etcd.recipes.barrier.DistributedBarrier
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.deleteKey
+import io.etcd.recipes.common.leaseGrant
+import io.etcd.recipes.common.leaseRevoke
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.common.watcher
+import io.etcd.recipes.counter.DistributedAtomicLong
+import io.etcd.recipes.keyvalue.TransientKeyValue
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests for the eight bug fixes documented in the corresponding code review.
+ * Each fix is exercised either through end-to-end behavior or, where injecting
+ * the original failure cleanly is impractical, through a structural source
+ * check that locks in the post-fix shape so a future refactor cannot silently
+ * regress.
+ */
+class BugFixesTests : StringSpec() {
+  init {
+
+    // ============================================================
+    // Fix #1: DistributedAtomicLong.modifyCounterValue must return the
+    // value it just committed, not the result of a separate GET.
+    // ============================================================
+    "fix #1: concurrent increments return distinct, contiguous values" {
+      // Under the buggy implementation the trailing `client.getValue(...)`
+      // could observe another writer's value, so two threads could see the
+      // same return value and the post-condition `set == 1..N` would fail.
+      val path = "/counters/bug-fixes/concurrent-increment"
+      val threadCount = 16
+      connectToEtcd(urls) { client ->
+        DistributedAtomicLong.delete(client, path)
+        DistributedAtomicLong(client, path).use { counter ->
+          counter.start()
+          val pool = Executors.newFixedThreadPool(threadCount)
+          val ready = CountDownLatch(threadCount)
+          val go = CountDownLatch(1)
+          val done = CountDownLatch(threadCount)
+          val results = mutableListOf<Long>()
+
+          repeat(threadCount) {
+            pool.execute {
+              try {
+                ready.countDown()
+                go.await()
+                val v = counter.increment()
+                synchronized(results) { results.add(v) }
+              } finally {
+                done.countDown()
+              }
+            }
+          }
+          ready.await()
+          // Release all threads at once to maximize contention on the CAS path.
+          go.countDown()
+          done.await(30, TimeUnit.SECONDS) shouldBe true
+          pool.shutdown()
+
+          val sorted = synchronized(results) { results.toList() }.sorted()
+          sorted shouldContainExactly (1L..threadCount.toLong()).toList()
+          counter.get() shouldBe threadCount.toLong()
+        }
+        DistributedAtomicLong.delete(client, path)
+      }
+    }
+
+    // ============================================================
+    // Fix #2: PathChildrenCache.doClose must wait for the background
+    // loader before closing the watcher; otherwise a concurrent close
+    // can leak a watcher (and its dispatcher executor) if the loader
+    // assigns it after close().
+    // ============================================================
+    "fix #2: close immediately after async start completes cleanly" {
+      // Behavioral check: with the pre-fix ordering, doClose() called
+      // watcher?.close() before waiting for the background loader, so the
+      // loader could assign a new watcher *after* close ran — leaving it
+      // unclosed and never re-checked. The fix waits for the loader before
+      // touching the watcher, so once close() returns, the cache is fully
+      // torn down. We assert close() returns and is idempotent under
+      // back-to-back start/close cycles without exceptions.
+      val path = "/caches/bug-fixes/close-after-async-start"
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        client.putValue("$path/seed", "v")
+
+        repeat(8) {
+          val cache = PathChildrenCache(client, path)
+          cache.start(buildInitial = true, waitOnStartComplete = false)
+          cache.close()
+          // Idempotent: a second close must be a no-op even if the loader
+          // finished asynchronously.
+          cache.close()
+        }
+
+        client.deleteChildren(path)
+      }
+    }
+
+    "fix #2: doClose source waits on startThreadComplete before closing the watcher" {
+      val src = readSource("src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt")
+      val waitIdx = src.indexOf("startThreadComplete.waitUntilTrue()")
+      val closeIdx = src.indexOf("watcher?.close()")
+      // Both must be present and the wait must precede the close inside doClose.
+      (waitIdx > 0) shouldBe true
+      (closeIdx > 0) shouldBe true
+      (waitIdx < closeIdx) shouldBe true
+    }
+
+    // ============================================================
+    // Fix #3: TransientKeyValue.start() must release the start latch
+    // even if the inner put / lease grant throws — otherwise start()
+    // hangs forever on a transient etcd failure.
+    // ============================================================
+    "fix #3: start() against a closed client throws within a few seconds instead of hanging" {
+      val path = "/keyvalue/bug-fixes/start-with-closed-client"
+      val client = connectToEtcd(urls)
+      client.close()
+
+      val pool = Executors.newSingleThreadExecutor()
+      val outcome = AtomicReference<Throwable?>(null)
+      val done = CountDownLatch(1)
+      pool.execute {
+        try {
+          // autoStart=true triggers start() inside the constructor; the
+          // pre-fix code blocked on keepAliveStartedLatch indefinitely here.
+          TransientKeyValue(client, path, "v", autoStart = true)
+          outcome.set(IllegalStateException("expected start() to throw"))
+        } catch (e: Throwable) {
+          outcome.set(e)
+        } finally {
+          done.countDown()
+        }
+      }
+
+      done.await(15, TimeUnit.SECONDS) shouldBe true
+      val thrown = outcome.get()
+      // Any exception (EtcdRecipeRuntimeException wrapping a jetcd failure,
+      // or the underlying gRPC error itself) is acceptable — the test is
+      // that we did not hang.
+      (thrown != null) shouldBe true
+      pool.shutdownNow()
+    }
+
+    // ============================================================
+    // Fix #4 / #5: lease leaks on failed CAS.
+    // ============================================================
+    "fix #4: LeaderSelector source revokes the lease when CAS fails" {
+      val src = readSource("src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt")
+      // The fix introduces a leaseRevoke() call on the failure branch.
+      src.contains("client.leaseRevoke(lease)") shouldBe true
+    }
+
+    "fix #5: DistributedBarrier source revokes the lease when CAS fails" {
+      val src = readSource("src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt")
+      src.contains("client.leaseRevoke(lease)") shouldBe true
+    }
+
+    "fix #5: losing setBarrier returns false cleanly and the winner remains active" {
+      // The leak-on-failed-CAS path inside setBarrier requires a true race:
+      // isKeyPresent must return false but the txn must still lose. We can't
+      // make that race deterministic from a unit test (jetcd 0.8.x exposes
+      // no list-leases API to verify a strand directly), so the fix is
+      // verified at the source level by the test below; this test just
+      // confirms behavior is uncorrupted: many losing setBarrier calls do
+      // not break the winner's barrier and each returns false promptly.
+      val path = "/barriers/bug-fixes/setbarrier-loser"
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        DistributedBarrier(client, path, leaseTtlSecs = 60).use { winner ->
+          winner.setBarrier() shouldBe true
+
+          repeat(15) {
+            DistributedBarrier(client, path, leaseTtlSecs = 60).use { loser ->
+              loser.setBarrier() shouldBe false
+            }
+          }
+
+          // Winner still holds the barrier after the losers churned.
+          winner.isBarrierSet() shouldBe true
+          winner.removeBarrier()
+        }
+        client.deleteChildren(path)
+      }
+    }
+
+    // ============================================================
+    // Fix #6: putValuesWithKeepAlive must revoke the lease on put failure.
+    // ============================================================
+    "fix #6: putValuesWithKeepAlive source revokes lease on put failure" {
+      val src = readSource("src/main/kotlin/io/etcd/recipes/common/KeepAliveExtensions.kt")
+      // The fixed body wraps the put loop in try/catch and calls leaseRevoke.
+      src.contains("leaseRevoke(lease)") shouldBe true
+      src.contains("try {") shouldBe true
+    }
+
+    // ============================================================
+    // Fix #7: DispatchingWatcher.close() must await in-flight callbacks.
+    // ============================================================
+    "fix #7: closing a watcher waits for an in-flight callback to finish" {
+      val path = "/watchers/bug-fixes/close-awaits-callback"
+      val callbackEntered = CountDownLatch(1)
+      val releaseCallback = CountDownLatch(1)
+      val callbackExited = AtomicReference(false)
+
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        val watcher =
+          client.watcher(path, WatchOption.DEFAULT) { resp ->
+            if (resp.events.any { it.eventType == WatchEvent.EventType.PUT }) {
+              callbackEntered.countDown()
+              releaseCallback.await()
+              // Sleep briefly so a buggy close() that doesn't await would
+              // race past this point.
+              Thread.sleep(200)
+              callbackExited.set(true)
+            }
+          }
+
+        client.putValue(path, "v")
+        callbackEntered.await(10, TimeUnit.SECONDS) shouldBe true
+
+        // Schedule the callback to finish on a background thread shortly
+        // after we begin closing — this gives close() something real to wait
+        // for. With the bug, close() returns immediately and the assertion
+        // below could observe callbackExited == false.
+        val helper = Executors.newSingleThreadExecutor()
+        helper.execute {
+          Thread.sleep(100)
+          releaseCallback.countDown()
+        }
+
+        watcher.close()
+        // Post-close, the callback must have finished.
+        callbackExited.get() shouldBe true
+
+        helper.shutdownNow()
+        client.deleteKey(path)
+      }
+    }
+
+    // ============================================================
+    // Fix #8: DistributedDoubleBarrier.close uses try/finally so the
+    // second barrier is always closed.
+    // ============================================================
+    "fix #8: DistributedDoubleBarrier.close closes leaveBarrier even if enterBarrier.close throws" {
+      val src = readSource("src/main/kotlin/io/etcd/recipes/barrier/DistributedDoubleBarrier.kt")
+      // The fix introduces a try/finally around enterBarrier.close().
+      src.contains("try {") shouldBe true
+      src.contains("} finally {") shouldBe true
+      src.contains("leaveBarrier.close()") shouldBe true
+    }
+
+    // ============================================================
+    // Helper: confirm leaseRevoke helper is exposed in the common package
+    // so other recipes can adopt the same pattern without re-importing
+    // jetcd directly.
+    // ============================================================
+    "helper: leaseRevoke is reachable from a Client extension" {
+      connectToEtcd(urls) { client ->
+        // Grant a short-lived lease and revoke it via the new helper. After
+        // revoke, etcd reports ttl <= 0 (or throws — both indicate the lease
+        // is no longer live).
+        val lease = client.leaseGrant(60.seconds)
+        client.leaseRevoke(lease)
+        val ttl: Long =
+          runCatching {
+            client.leaseClient
+              .timeToLive(lease.id, LeaseOption.DEFAULT)
+              .get()
+              .ttl
+          }.getOrDefault(-1L)
+        (ttl <= 0L) shouldBe true
+      }
+    }
+
+    // ============================================================
+    // Negative-control: TransientKeyValue still works against a healthy
+    // etcd. The fix changes the failure path; the success path must be
+    // unaffected.
+    // ============================================================
+    "fix #3 regression check: healthy start() still succeeds" {
+      val path = "/keyvalue/bug-fixes/healthy-start"
+      connectToEtcd(urls) { client ->
+        client.deleteKey(path)
+        TransientKeyValue(client, path, "v", autoStart = true).use {
+          // No exception thrown; doClose runs cleanly.
+        }
+        client.deleteKey(path)
+      }
+    }
+  }
+
+  private fun readSource(relativePath: String): String =
+    java.nio.file.Files.readString(java.nio.file.Path.of(relativePath))
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceCacheTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceCacheTests.kt
@@ -19,13 +19,7 @@
 package io.etcd.recipes.discovery
 
 import io.etcd.jetcd.watch.WatchEvent.EventType
-import io.etcd.recipes.common.ExceptionHolder
-import io.etcd.recipes.common.captureException
-import io.etcd.recipes.common.checkForException
-import io.etcd.recipes.common.connectToEtcd
-import io.etcd.recipes.common.nonblockingThreads
-import io.etcd.recipes.common.pollUntil
-import io.etcd.recipes.common.urls
+import io.etcd.recipes.common.*
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -33,91 +27,91 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
 
 class ServiceCacheTests : StringSpec() {
-    init {
-        "serviceCacheTest" {
-            val path = "/discovery/ServiceCacheTests"
-            val threadCount = 10
-            val serviceCount = 10
-            val name = "ServiceCacheTest"
-            val holder = ExceptionHolder()
-            val registerCounter = AtomicInteger(0)
-            val updateCounter = AtomicInteger(0)
-            val unregisterCounter = AtomicInteger(0)
-            val totalCounter = AtomicInteger(0)
+  init {
+    "serviceCacheTest" {
+      val path = "/discovery/ServiceCacheTests"
+      val threadCount = 10
+      val serviceCount = 10
+      val name = "ServiceCacheTest"
+      val holder = ExceptionHolder()
+      val registerCounter = AtomicInteger(0)
+      val updateCounter = AtomicInteger(0)
+      val unregisterCounter = AtomicInteger(0)
+      val totalCounter = AtomicInteger(0)
 
-            connectToEtcd(urls) { client ->
-                withServiceDiscovery(client, path) {
-                    withServiceCache(name) {
-                        start()
+      connectToEtcd(urls) { client ->
+        withServiceDiscovery(client, path) {
+          withServiceCache(name) {
+            start()
 
-                        instances.size shouldBe 0
-                        serviceName shouldBe name
-                        urls shouldBe urls
+            instances.size shouldBe 0
+            serviceName shouldBe name
+            urls shouldBe urls
 
-                        addListenerForChanges(object : ServiceCacheListener {
-                            override fun cacheChanged(
-                                eventType: EventType,
-                                isAdd: Boolean,
-                                serviceName: String,
-                                serviceInstance: ServiceInstance?,
-                            ) {
-                                captureException(holder) {
-                                    serviceName.split("/").first() shouldBe name
+            addListenerForChanges(object : ServiceCacheListener {
+              override fun cacheChanged(
+                eventType: EventType,
+                isAdd: Boolean,
+                serviceName: String,
+                serviceInstance: ServiceInstance?,
+              ) {
+                captureException(holder) {
+                  serviceName.split("/").first() shouldBe name
 
-                                    if (eventType == EventType.PUT) {
-                                        if (isAdd) registerCounter.incrementAndGet() else updateCounter.incrementAndGet()
+                  if (eventType == EventType.PUT) {
+                    if (isAdd) registerCounter.incrementAndGet() else updateCounter.incrementAndGet()
 
-                                        serviceInstance?.name shouldBe name
-                                    }
+                    serviceInstance?.name shouldBe name
+                  }
 
-                                    if (eventType == EventType.DELETE) {
-                                        unregisterCounter.incrementAndGet()
-                                        serviceInstance?.name shouldBe name
-                                    }
-                                }
-                            }
-                        })
-
-                        addListenerForChanges { _, _, _, _ -> totalCounter.incrementAndGet() }
-
-                        val (finishedLatch, holder2) =
-                            nonblockingThreads(threadCount) {
-                                withServiceDiscovery(client, path) {
-                                    repeat(serviceCount) {
-                                        val service = ServiceInstance(name, TestPayload(it).toJson())
-                                        logger.debug { "Registering: ${service.name} ${service.id}" }
-                                        registerService(service)
-
-                                        val payload = TestPayload.toObject(service.jsonPayload)
-                                        payload.testval = payload.testval * -1
-                                        service.jsonPayload = payload.toJson()
-                                        logger.debug { "Updating: ${service.name} ${service.id}" }
-                                        updateService(service)
-
-                                        logger.debug { "Unregistering: ${service.name} ${service.id}" }
-                                        unregisterService(service)
-                                    }
-                                }
-                            }
-                        finishedLatch.await()
-                        holder2.checkForException()
-                    }
+                  if (eventType == EventType.DELETE) {
+                    unregisterCounter.incrementAndGet()
+                    serviceInstance?.name shouldBe name
+                  }
                 }
-            }
+              }
+            })
 
-            // Wait for events to propagate to the cache listeners.
-            val expectedTotal = (threadCount * serviceCount) * 3
-            pollUntil(15.seconds) { totalCounter.get() == expectedTotal } shouldBe true
+            addListenerForChanges { _, _, _, _ -> totalCounter.incrementAndGet() }
 
-            holder.checkForException()
-            registerCounter.get() shouldBe threadCount * serviceCount
-            updateCounter.get() shouldBe threadCount * serviceCount
-            unregisterCounter.get() shouldBe threadCount * serviceCount
-            totalCounter.get() shouldBe expectedTotal
+            val (finishedLatch, holder2) =
+              nonblockingThreads(threadCount) {
+                withServiceDiscovery(client, path) {
+                  repeat(serviceCount) {
+                    val service = ServiceInstance(name, TestPayload(it).toJson())
+                    logger.debug { "Registering: ${service.name} ${service.id}" }
+                    registerService(service)
+
+                    val payload = TestPayload.toObject(service.jsonPayload)
+                    payload.testval *= -1
+                    service.jsonPayload = payload.toJson()
+                    logger.debug { "Updating: ${service.name} ${service.id}" }
+                    updateService(service)
+
+                    logger.debug { "Unregistering: ${service.name} ${service.id}" }
+                    unregisterService(service)
+                  }
+                }
+              }
+            finishedLatch.await()
+            holder2.checkForException()
+          }
         }
-    }
+      }
 
-    companion object {
-        private val logger = KotlinLogging.logger {}
+      // Wait for events to propagate to the cache listeners.
+      val expectedTotal = (threadCount * serviceCount) * 3
+      pollUntil(15.seconds) { totalCounter.get() == expectedTotal } shouldBe true
+
+      holder.checkForException()
+      registerCounter.get() shouldBe threadCount * serviceCount
+      updateCounter.get() shouldBe threadCount * serviceCount
+      unregisterCounter.get() shouldBe threadCount * serviceCount
+      totalCounter.get() shouldBe expectedTotal
     }
+  }
+
+  companion object {
+    private val logger = KotlinLogging.logger {}
+  }
 }


### PR DESCRIPTION
## Summary

Fixes eight bugs surfaced by a codebase review:

1. **`DistributedAtomicLong.modifyCounterValue`** returned a non-atomic separate GET after a successful CAS; under contention the value handed back was not the one this caller committed. Now returns the locally-known committed value.
2. **`PathChildrenCache.doClose`** closed the watcher before waiting for the background loader, so a watcher assigned late by the loader leaked. The wait now precedes the close.
3. **`TransientKeyValue.start`** counted down `keepAliveStartedLatch` only inside the keep-alive callback, so any setup failure (lease grant, put) hung `start()` forever. The latch now counts down in a `finally`, and setup failures are surfaced as `EtcdRecipeRuntimeException`.
4. **`LeaderSelector.attemptToBecomeLeader`** never revoked the lease it granted when it lost the CAS — every losing candidate leaked one lease per leadership turnover. Now revokes on the failure path.
5. **`DistributedBarrier.setBarrier`** had the same lease-leak shape on failed CAS / value verification. Now revokes.
6. **`putValuesWithKeepAlive`** never revoked the lease if a `putValue` threw mid-loop. Wraps the puts and revokes on failure.
7. **`DispatchingWatcher.close`** called `dispatcher.shutdown()` but did not wait for the in-flight callback, so the user's `block` could still be touching state after `withWatcher` returned. Adds a bounded `awaitTermination`.
8. **`DistributedDoubleBarrier.close`** ran `enterBarrier.close()` then `leaveBarrier.close()` with no `try/finally`, leaking the second barrier on the first close throwing. Now uses `try/finally`.

A new `Client.leaseRevoke` best-effort helper backs fixes 4-6.

## Test plan
- [x] New `BugFixesTests` Kotest spec — 12 cases covering each fix via behavioral checks where possible (concurrent counter race, async-start close, hanging-`start()` with closed client, dispatcher in-flight callback wait) and source-structure checks where the failure is hard to inject deterministically.
- [x] Full test suite (`./gradlew :etcd-recipes:test`) — 94 tests, 0 failures, 0 errors.
- [x] `compileKotlin` and `compileTestKotlin` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)