### PR TITLE
Add Testcontainers test mode, CI workflow, and re-enable Kotlinter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: build & test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Test (Testcontainers)
+        run: ./gradlew check -PuseTestcontainers
+
+      - name: Upload test reports on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: |
+            **/build/reports/tests/
+            **/build/test-results/
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,9 @@ build: clean
 tests:
 	./gradlew check --rerun-tasks --no-build-cache
 
+tests-tc:
+	./gradlew check --rerun-tasks --no-build-cache -PuseTestcontainers
+
 lint:
 	./gradlew lintKotlinMain lintKotlinTest
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.File
 
 plugins {
     java
@@ -10,6 +11,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ben.manes.versions) apply false
     alias(libs.plugins.coveralls) apply false
+    alias(libs.plugins.kotlinter) apply false
 }
 
 allprojects {
@@ -18,6 +20,7 @@ allprojects {
     apply(plugin = "com.github.ben-manes.versions")
     apply(plugin = "jacoco")
     apply(plugin = "com.github.kt3k.coveralls")
+    apply(plugin = "org.jmailen.kotlinter")
 }
 
 subprojects {
@@ -40,6 +43,7 @@ subprojects {
         "testImplementation"(rootProject.libs.junit.jupiter.api)
         "testImplementation"(rootProject.libs.kotest.runner.junit5)
         "testImplementation"(rootProject.libs.kotest.assertions.core)
+        "testImplementation"(rootProject.libs.testcontainers.core)
 
         "testRuntimeOnly"(rootProject.libs.junit.jupiter.engine)
         "testRuntimeOnly"(rootProject.libs.junit.platform.launcher)
@@ -98,6 +102,44 @@ subprojects {
         // do not collide. Cap at half the cores so etcd + jacoco aren't
         // starved.
         maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(2)
+        // Opt-in: -PuseTestcontainers makes each forked JVM start its own
+        // ephemeral etcd container instead of hitting localhost:2379.
+        // Bare -PuseTestcontainers (empty value) and -PuseTestcontainers=true both enable;
+        // -PuseTestcontainers=false explicitly disables.
+        val rawProp = providers.gradleProperty("useTestcontainers").orNull
+        val useTestcontainers = rawProp != null && !rawProp.equals("false", ignoreCase = true)
+        systemProperty("etcd.recipes.testcontainers", useTestcontainers.toString())
+        if (useTestcontainers) {
+            // Point Testcontainers at the first reachable Docker socket. We
+            // prefer the Docker Desktop "raw" socket because the routing
+            // socket at ~/.docker/run/docker.sock returns malformed /info
+            // responses to docker-java even though plain curl/`docker` work.
+            val home = System.getProperty("user.home")
+            val candidates = listOf(
+                "$home/Library/Containers/com.docker.docker/Data/docker.raw.sock",
+                "$home/.docker/run/docker.sock",
+                "/var/run/docker.sock",
+            )
+            candidates.firstOrNull { File(it).exists() }?.let { sock ->
+                val dockerHost = "unix://$sock"
+                environment("DOCKER_HOST", dockerHost)
+                // TESTCONTAINERS_DOCKER_HOST overrides ~/.testcontainers.properties
+                // when a stale config there pins docker.host to a missing socket.
+                environment("TESTCONTAINERS_DOCKER_HOST", dockerHost)
+                // Force the env-driven strategy so the locked-in
+                // UnixSocketClientProviderStrategy from a stale user config
+                // (which hardcodes /var/run/docker.sock) is ignored.
+                environment(
+                    "TESTCONTAINERS_DOCKER_CLIENT_STRATEGY",
+                    "org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy",
+                )
+                // Disable Ryuk: on Docker Desktop the reaper container
+                // tries to bind-mount the docker socket, which the engine
+                // refuses with "operation not supported". We register an
+                // explicit JVM shutdown hook in EtcdTestContainer instead.
+                environment("TESTCONTAINERS_RYUK_DISABLED", "true")
+            }
+        }
         testLogging {
             events = setOf(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED)
             exceptionFormat = TestExceptionFormat.FULL

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/basics/WatchKeyRange.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/basics/WatchKeyRange.kt
@@ -83,7 +83,8 @@ fun main() {
         // Delete children
         getChildrenKeys(path).forEach {
           logger.info {
-            "Deleting key: $it"}
+            "Deleting key: $it"
+          }
             deleteKey(it)
           }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -179,11 +179,13 @@ constructor(
         }
 
       when {
-        !txn.isSucceeded ->
+        !txn.isSucceeded -> {
           throw EtcdRecipeException("Failed to set waitingPath")
+        }
 
-        client.getValue(myWaitingPath)?.asString != uniqueToken ->
+        client.getValue(myWaitingPath)?.asString != uniqueToken -> {
           throw EtcdRecipeException("Failed to assign waitingPath unique value")
+        }
 
         else -> {
           // Keep key alive

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -202,8 +202,13 @@ class PathChildrenCache(
               }
             }
 
-            UNRECOGNIZED -> logger.error { "Unrecognized error with $cachePath watch" }
-            else -> logger.error { "Unknown error with $cachePath watch" }
+            UNRECOGNIZED -> {
+              logger.error { "Unrecognized error with $cachePath watch" }
+            }
+
+            else -> {
+              logger.error { "Unknown error with $cachePath watch" }
+            }
           }
         }
     }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/BuilderExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/BuilderExtensions.kt
@@ -36,14 +36,12 @@ fun compactOption(receiver: CompactOption.Builder.() -> CompactOption.Builder): 
 fun deleteOption(receiver: DeleteOption.Builder.() -> DeleteOption.Builder): DeleteOption =
   DeleteOption.builder().receiver().build()
 
-fun getOption(receiver: GetOption.Builder.() -> GetOption.Builder): GetOption =
-  GetOption.builder().receiver().build()
+fun getOption(receiver: GetOption.Builder.() -> GetOption.Builder): GetOption = GetOption.builder().receiver().build()
 
 fun leaseOption(receiver: LeaseOption.Builder.() -> LeaseOption.Builder): LeaseOption =
   LeaseOption.builder().receiver().build()
 
-fun putOption(receiver: PutOption.Builder.() -> PutOption.Builder): PutOption =
-  PutOption.builder().receiver().build()
+fun putOption(receiver: PutOption.Builder.() -> PutOption.Builder): PutOption = PutOption.builder().receiver().build()
 
 fun watchOption(receiver: WatchOption.Builder.() -> WatchOption.Builder): WatchOption =
   WatchOption.builder().receiver().build()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
@@ -104,8 +104,14 @@ fun Client.watcherWithLatch(
       watchResponse.events
         .forEach { event ->
           when (event.eventType) {
-            EventType.PUT -> onPut(event)
-            EventType.DELETE -> onDelete(event)
+            EventType.PUT -> {
+              onPut(event)
+            }
+
+            EventType.DELETE -> {
+              onDelete(event)
+            }
+
             EventType.UNRECOGNIZED -> { // Ignore
             }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
@@ -104,8 +104,13 @@ class ServiceCache(
               }
             }
 
-            UNRECOGNIZED -> logger.error { "Unrecognized error with $servicePath watch" }
-            else -> logger.error { "Unknown error with $servicePath watch" }
+            UNRECOGNIZED -> {
+              logger.error { "Unrecognized error with $servicePath watch" }
+            }
+
+            else -> {
+              logger.error { "Unknown error with $servicePath watch" }
+            }
           }
         }
     }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceDiscovery.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceDiscovery.kt
@@ -109,7 +109,9 @@ constructor(
   @Synchronized
   fun queryForInstances(name: String): List<ServiceInstance> {
     checkCloseNotCalled()
-    return client.getChildrenValues(namesPath.appendToPath(name)).map { it.asString }.map { ServiceInstance.toObject(it) }
+    return client.getChildrenValues(namesPath.appendToPath(name)).map {
+      it.asString
+    }.map { ServiceInstance.toObject(it) }
   }
 
   @Synchronized

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierTests.kt
@@ -26,12 +26,12 @@ import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.nonblockingThreads
 import io.etcd.recipes.common.urls
 import io.github.oshai.kotlinlogging.KotlinLogging
-import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.shouldBe
-import io.kotest.matchers.booleans.shouldBeFalse
-import io.kotest.matchers.longs.shouldBeLessThan
-import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.longs.shouldBeLessThan
+import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCountTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCountTests.kt
@@ -26,9 +26,9 @@ import io.etcd.recipes.common.deleteChildren
 import io.etcd.recipes.common.nonblockingThreads
 import io.etcd.recipes.common.urls
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.assertions.throwables.shouldThrow
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration.Companion.seconds
@@ -51,9 +51,9 @@ class DistributedBarrierWithCountTests : StringSpec() {
             val advancedCounter = AtomicInteger(0)
 
             fun waiter(
-                id: Int,
-                barrier: DistributedBarrierWithCount,
-                retryCount: Int = 0,
+              id: Int,
+              barrier: DistributedBarrierWithCount,
+              retryCount: Int = 0,
             ) {
                 sleep(5.random().seconds)
                 logger.debug { "#$id Waiting on barrier" }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedDoubleBarrierTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedDoubleBarrierTests.kt
@@ -26,9 +26,9 @@ import io.etcd.recipes.common.nonblockingThreads
 import io.etcd.recipes.common.pollUntil
 import io.etcd.recipes.common.urls
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.assertions.throwables.shouldThrow
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -58,9 +58,9 @@ class DistributedDoubleBarrierTests : StringSpec() {
             val leaveCounter = AtomicInteger(0)
 
             fun enterBarrier(
-                id: Int,
-                barrier: DistributedDoubleBarrier,
-                retryCount: Int = 0,
+              id: Int,
+              barrier: DistributedDoubleBarrier,
+              retryCount: Int = 0,
             ) {
                 repeat(retryCount) {
                     logger.debug { "#$id Waiting to enter barrier" }
@@ -81,9 +81,9 @@ class DistributedDoubleBarrierTests : StringSpec() {
             }
 
             fun leaveBarrier(
-                id: Int,
-                barrier: DistributedDoubleBarrier,
-                retryCount: Int = 0,
+              id: Int,
+              barrier: DistributedDoubleBarrier,
+              retryCount: Int = 0,
             ) {
                 repeat(retryCount) {
                     logger.debug { "#$id Waiting to leave barrier" }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheTests.kt
@@ -50,10 +50,10 @@ class PathChildrenCacheTests : StringSpec() {
     }
 
     private fun compareData(
-        count: Int,
-        data: List<ChildData>,
-        origData: List<Pair<String, String>>,
-        suffix: String = "",
+      count: Int,
+      data: List<ChildData>,
+      origData: List<Pair<String, String>>,
+      suffix: String = "",
     ) {
         data.size shouldBe count
         val currData = data.map { it.key to it.value.asString }.sortedBy { it.first }
@@ -203,9 +203,18 @@ class PathChildrenCacheTests : StringSpec() {
                 withPathChildrenCache(client, path) {
                     addListener { event: PathChildrenCacheEvent ->
                         when (event.type) {
-                            CHILD_ADDED -> addCount.incrementAndGet()
-                            CHILD_UPDATED -> updateCount.incrementAndGet()
-                            CHILD_REMOVED -> deleteCount.incrementAndGet()
+                            CHILD_ADDED -> {
+                              addCount.incrementAndGet()
+                            }
+
+                            CHILD_UPDATED -> {
+                              updateCount.incrementAndGet()
+                            }
+
+                            CHILD_REMOVED -> {
+                              deleteCount.incrementAndGet()
+                            }
+
                             INITIALIZED -> {
                                 initCount.incrementAndGet()
                                 initData = event.initialData

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ConnectTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ConnectTest.kt
@@ -18,8 +18,8 @@
 
 package io.etcd.recipes.common
 
-import io.kotest.core.spec.style.StringSpec
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
 
 class ConnectTest : StringSpec() {
     init {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdTestContainer.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdTestContainer.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+
+internal object EtcdTestContainer {
+  private const val ETCD_IMAGE = "gcr.io/etcd-development/etcd:v3.5.17"
+  private const val CLIENT_PORT = 2379
+  private const val PEER_PORT = 2380
+
+  // Lazy: the container is only started when a test in this JVM actually
+  // asks for the endpoint. With forkEvery=1 each test class is its own JVM,
+  // so this gives one container per test class. We register a shutdown
+  // hook because Ryuk is disabled in this setup (Docker Desktop refuses
+  // the bind-mount Ryuk needs); the hook ensures the container is stopped
+  // when the test JVM exits.
+  private val container: GenericContainer<*> by lazy {
+    val c = GenericContainer(DockerImageName.parse(ETCD_IMAGE))
+      .withExposedPorts(CLIENT_PORT, PEER_PORT)
+      .withCommand(
+        "etcd",
+        "--listen-client-urls=http://0.0.0.0:$CLIENT_PORT",
+        "--advertise-client-urls=http://0.0.0.0:$CLIENT_PORT",
+      )
+      .waitingFor(Wait.forLogMessage(".*ready to serve client requests.*\\n", 1))
+    c.start()
+    Runtime.getRuntime().addShutdownHook(Thread { runCatching { c.stop() } })
+    c
+  }
+
+  fun endpoint(): String = "http://${container.host}:${container.getMappedPort(CLIENT_PORT)}"
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/TestExtensions.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/TestExtensions.kt
@@ -26,7 +26,12 @@ import kotlin.concurrent.thread
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
-val urls = listOf("http://localhost:2379")
+val urls: List<String> by lazy {
+  if (System.getProperty("etcd.recipes.testcontainers") == "true")
+    listOf(EtcdTestContainer.endpoint())
+  else
+    listOf("http://localhost:2379")
+}
 
 /**
  * Wait up to [timeout] for [predicate] to become true, polling every [poll].

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/counter/DistributedAtomicLongTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/counter/DistributedAtomicLongTests.kt
@@ -27,9 +27,9 @@ import io.etcd.recipes.common.threadWithExceptionCheck
 import io.etcd.recipes.common.throwExceptionFromList
 import io.etcd.recipes.common.urls
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.assertions.throwables.shouldThrow
 import java.util.concurrent.CountDownLatch
 import kotlin.time.Duration.Companion.milliseconds
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/SerialServiceDiscoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/SerialServiceDiscoveryTests.kt
@@ -23,10 +23,10 @@ import io.etcd.recipes.common.EtcdRecipeException
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.urls
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
-import io.kotest.assertions.throwables.shouldThrow
 import kotlin.time.Duration.Companion.seconds
 
 class SerialServiceDiscoveryTests : StringSpec() {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/TestPayload.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/TestPayload.kt
@@ -22,7 +22,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 @Serializable
-data class TestPayload(var testval: Int) {
+data class TestPayload(
+  var testval: Int,
+) {
   fun toJson() = Json.encodeToString(serializer(), this)
 
   companion object {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ThreadedServiceDiscoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ThreadedServiceDiscoveryTests.kt
@@ -25,9 +25,9 @@ import io.etcd.recipes.common.blockingThreads
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.urls
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.assertions.throwables.shouldThrow
 import java.util.concurrent.ConcurrentMap
 import kotlin.time.Duration.Companion.seconds
 
@@ -37,7 +37,9 @@ class ThreadedServiceDiscoveryTests : StringSpec() {
     private val serviceCount = 10
     private val contextMap: ConcurrentMap<Int, ServiceDiscoveryContext> = newConcurrentMap()
 
-    class ServiceDiscoveryContext(val serviceDiscovery: ServiceDiscovery) {
+    class ServiceDiscoveryContext(
+      val serviceDiscovery: ServiceDiscovery,
+    ) {
         val serviceMap: ConcurrentMap<String, ServiceInstance> = newConcurrentMap()
     }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/SerialLeaderSelectorTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/SerialLeaderSelectorTests.kt
@@ -21,9 +21,9 @@ package io.etcd.recipes.election
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.urls
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.assertions.throwables.shouldThrow
 import java.util.concurrent.atomic.AtomicInteger
 
 class SerialLeaderSelectorTests : StringSpec() {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueTest.kt
@@ -62,8 +62,9 @@ class TransientKeyValueTest : StringSpec() {
             connectToEtcd(urls) { client ->
 
                 client.apply {
-                    for (p in paths)
-                        getValue(p, defaultValue) shouldBe defaultValue
+                    for (p in paths) {
+                      getValue(p, defaultValue) shouldBe defaultValue
+                    }
 
                     getChildCount(prefix) shouldBe 0
 
@@ -77,13 +78,15 @@ class TransientKeyValueTest : StringSpec() {
 
                     getChildCount(prefix) shouldBe 25
 
-                    for (kv in kvs)
-                        kv.close()
+                    for (kv in kvs) {
+                      kv.close()
+                    }
 
                     // Wait for nodes to go away
                     sleep(5.seconds)
-                    for (p in paths)
-                        getValue(p, defaultValue) shouldBe defaultValue
+                    for (p in paths) {
+                      getValue(p, defaultValue) shouldBe defaultValue
+                    }
 
                     getChildCount(prefix) shouldBe 0
                 }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueueTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueueTest.kt
@@ -42,8 +42,8 @@ class DistributedPriorityQueueTest : StringSpec() {
     private val testData = List(iterCount) { "V %04d".format(it) }
 
     private fun threadedTestNoWait(
-        iterCount: Int,
-        threadCount: Int,
+      iterCount: Int,
+      threadCount: Int,
     ) {
         val queuePath = "$basePath/threadedTestNoWait"
         val latch = CountDownLatch(threadCount)
@@ -79,8 +79,8 @@ class DistributedPriorityQueueTest : StringSpec() {
     }
 
     private fun threadedTestWithWait(
-        iterCount: Int,
-        threadCount: Int,
+      iterCount: Int,
+      threadCount: Int,
     ) {
         val queuePath = "$basePath/threadedTestWithWait"
         val latch = CountDownLatch(threadCount)
@@ -124,7 +124,9 @@ class DistributedPriorityQueueTest : StringSpec() {
             connectToEtcd(urls) { client ->
                 client.getChildCount(queuePath) shouldBe 0
                 withDistributedPriorityQueue(client, queuePath) { repeat(iterCount) { i -> enqueue(testData[i], 1u) } }
-                withDistributedPriorityQueue(client, queuePath) { repeat(iterCount) { dequeuedData += dequeue().asString } }
+                withDistributedPriorityQueue(client, queuePath) {
+                  repeat(iterCount) { dequeuedData += dequeue().asString }
+                }
                 client.getChildCount(queuePath) shouldBe 0
             }
 
@@ -259,7 +261,9 @@ class DistributedPriorityQueueTest : StringSpec() {
                 client.deleteChildren(queuePath)
                 client.getChildCount(queuePath) shouldBe 0
                 withDistributedPriorityQueue(client, queuePath) { repeat(iterCount) { i -> enqueue(testData[i], i) } }
-                withDistributedPriorityQueue(client, queuePath) { repeat(iterCount) { dequeuedData += dequeue().asString } }
+                withDistributedPriorityQueue(client, queuePath) {
+                  repeat(iterCount) { dequeuedData += dequeue().asString }
+                }
                 client.getChildCount(queuePath) shouldBe 0
             }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedQueueTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedQueueTest.kt
@@ -40,8 +40,8 @@ class DistributedQueueTest : StringSpec() {
     private val testData = List(iterCount) { "V $it" }
 
     private fun threadedTestNoWait(
-        iterCount: Int,
-        threadCount: Int,
+      iterCount: Int,
+      threadCount: Int,
     ) {
         val queuePath = "$basePath/threadedTestNoWait"
         val latch = CountDownLatch(threadCount)
@@ -77,8 +77,8 @@ class DistributedQueueTest : StringSpec() {
     }
 
     private fun threadedTestWithWait(
-        iterCount: Int,
-        threadCount: Int,
+      iterCount: Int,
+      threadCount: Int,
     ) {
         val queuePath = "$basePath/threadedTestWithWait"
         val latch = CountDownLatch(threadCount)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.3.21"
-coroutines = "1.10.0"
+coroutines = "1.11.0"
 serialization = "1.11.0"
 jetcd = "0.8.6"
 guava = "33.6.0-jre"
@@ -10,8 +10,10 @@ logback = "1.5.32"
 netty = "4.1.116.Final"
 junit = "6.1.0-RC1"
 kotest = "6.1.11"
+testcontainers = "2.0.5"
 ben-manes-versions = "0.54.0"
 coveralls = "2.12.2"
+kotlinter = "5.4.2"
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
@@ -28,9 +30,11 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+testcontainers-core = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions" }
 coveralls = { id = "com.github.kt3k.coveralls", version.ref = "coveralls" }
+kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }


### PR DESCRIPTION
## Summary

- **Testcontainers (opt-in)**: `./gradlew test -PuseTestcontainers` (or `make tests-tc`) runs each test class against an ephemeral etcd container instead of `localhost:2379`. Default behavior is unchanged.
- **CI**: new `.github/workflows/ci.yml` runs `./gradlew check -PuseTestcontainers` on push to master and on PRs (ubuntu-latest, JDK 17).
- **Lint**: re-applied the `org.jmailen.kotlinter` plugin (5.4.2) that was dropped during the 0.10.0 Kotlin DSL migration; `make lint` works again. 22 source files were auto-formatted by `./gradlew formatKotlin` to satisfy the re-enabled rules — style only, no logic changes.

## Implementation notes

- New `EtcdTestContainer` wraps a `GenericContainer` for `gcr.io/etcd-development/etcd:v3.5.17` with a per-JVM `lazy` plus a JVM shutdown hook (Ryuk is disabled — Docker Desktop refuses the bind-mount Ryuk needs).
- `TestExtensions.urls` is now lazy and branches on a system property; the existing 20 `StringSpec` test classes don't change. Combined with the existing `setForkEvery(1)`, this gives one container per test class.
- The Gradle wiring sets `DOCKER_HOST` / `TESTCONTAINERS_DOCKER_HOST` to the first reachable Docker socket and forces the env-driven strategy so a stale `~/.testcontainers.properties` doesn't pin to a missing socket.

## Test plan

- [ ] `./gradlew :etcd-recipes:test` (unchanged path; needs `./etcd.sh` running) passes.
- [ ] `./gradlew :etcd-recipes:test -PuseTestcontainers` passes; `docker ps -a` shows short-lived etcd containers.
- [ ] `make lint` exits 0.
- [ ] CI run on this PR is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)