### PR TITLE
Clean up README badges, add Makefile help, migrate detekt to v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default clean clean-all stop build tests tests-tc coverage kdocs \
+.PHONY: default help clean clean-all stop build tests tests-tc coverage kdocs \
         lint detekt detekt-baseline refresh versioncheck \
         publish-local publish-local-snapshot check-gpg-env \
         publish-snapshot publish-maven-central upgrade-wrapper
@@ -7,31 +7,49 @@
 # the command line, e.g. `make publish-snapshot VERSION=0.10.1`.
 VERSION ?= $(shell awk -F= '/^version=/ {print $$2; exit}' gradle.properties)
 
+ifeq ($(strip $(VERSION)),)
+$(error Could not determine project version from gradle.properties)
+endif
+
 # Read the Gradle wrapper version from the version catalog so
 # `make upgrade-wrapper` always tracks the catalog's `gradle` entry.
 GRADLE_VERSION ?= $(shell awk -F'"' '/^gradle = /{print $$2; exit}' gradle/libs.versions.toml)
 
+ifeq ($(strip $(GRADLE_VERSION)),)
+$(error Could not determine gradle version from gradle/libs.versions.toml)
+endif
+
+GPG_ENV = \
+	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
+	ORG_GRADLE_PROJECT_signingInMemoryKeyId="$$GPG_SIGNING_KEY_ID" \
+	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword="$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)"
+
 default: versioncheck
 
-clean:
+help: ## Show this help
+	@awk 'BEGIN { FS = ":.*?## "; printf "Usage: make <target>\n\nTargets:\n" } \
+	     /^[a-zA-Z_-]+:.*?## / { printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2 }' \
+	     $(MAKEFILE_LIST)
+
+clean: ## Run gradle clean and remove the root build/ directory
 	./gradlew clean
 	rm -rf build
 
 # Wipe every build / IDE / tool artifact a fresh checkout would not have.
 # Stops any Gradle daemons first so .gradle is not held open.
-clean-all: stop
+clean-all: stop ## Wipe all build/IDE/tool artifacts (.gradle, .kotlin, build, out, default.etcd)
 	./gradlew clean || true
 	rm -rf .gradle .kotlin build out
 	find . -type d \( -name build -o -name .gradle -o -name .kotlin -o -name out -o -name bin \) -prune -exec rm -rf {} +
 	rm -rf default.etcd
 
-stop:
+stop: ## Stop running Gradle daemons
 	./gradlew --stop
 
-build: clean
+build: clean ## Clean and run a full build, skipping tests
 	./gradlew build -xtest
 
-tests:
+tests: ## Run the full test suite against a local etcd at localhost:2379
 	./gradlew check --rerun-tasks --no-build-cache
 
 # DOCKER_HOST defaults to Docker Desktop's "raw" socket on macOS. The
@@ -42,42 +60,37 @@ ifeq ($(shell uname -s),Darwin)
 DOCKER_HOST ?= unix://$(HOME)/Library/Containers/com.docker.docker/Data/docker.raw.sock
 endif
 
-tests-tc:
+tests-tc: ## Run the full test suite under Testcontainers (no local etcd required)
 	DOCKER_HOST="$(DOCKER_HOST)" ./gradlew check --rerun-tasks --no-build-cache -PuseTestcontainers
 
-coverage:
+coverage: ## Generate Kover HTML + XML coverage reports and print the summary
 	./gradlew koverHtmlReport koverXmlReport koverLog
 
-kdocs:
+kdocs: ## Generate Dokka HTML and Javadoc documentation
 	./gradlew dokkaGenerate
 
-lint: detekt
+lint: detekt ## Run detekt and kotlinter (style + static analysis)
 	./gradlew lintKotlinMain lintKotlinTest
 
-detekt:
+detekt: ## Run detekt static analysis
 	./gradlew detekt
 
-detekt-baseline:
+detekt-baseline: ## (Re)generate detekt baseline files
 	./gradlew detektBaseline
 
-refresh:
+refresh: ## Force-refresh Gradle dependencies
 	./gradlew --refresh-dependencies
 
-versioncheck:
+versioncheck: ## Report dependencies with newer versions available
 	./gradlew dependencyUpdates --no-parallel
 
-publish-local:
+publish-local: ## Publish artifacts to ~/.m2/repository
 	./gradlew publishToMavenLocal
 
-publish-local-snapshot:
+publish-local-snapshot: ## Publish a -SNAPSHOT to ~/.m2/repository (uses VERSION= or gradle.properties)
 	./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenLocal
 
-GPG_ENV = \
-	ORG_GRADLE_PROJECT_signingInMemoryKey="$$(gpg --armor --export-secret-keys $$GPG_SIGNING_KEY_ID)" \
-	ORG_GRADLE_PROJECT_signingInMemoryKeyId="$$GPG_SIGNING_KEY_ID" \
-	ORG_GRADLE_PROJECT_signingInMemoryKeyPassword="$$(security find-generic-password -a "gpg-signing" -s "gradle-signing-password" -w)"
-
-check-gpg-env:
+check-gpg-env: ## Validate GPG signing key and keychain password are reachable
 	@if [ -z "$$GPG_SIGNING_KEY_ID" ]; then \
 		echo "Error: GPG_SIGNING_KEY_ID is not set" >&2; exit 1; \
 	fi
@@ -88,11 +101,11 @@ check-gpg-env:
 		echo "Error: keychain entry 'gradle-signing-password' (account 'gpg-signing') not found" >&2; exit 1; \
 	fi
 
-publish-snapshot: check-gpg-env
+publish-snapshot: check-gpg-env ## Publish a -SNAPSHOT to Maven Central (requires VERSION= and GPG)
 	$(GPG_ENV) ./gradlew -PoverrideVersion=$(VERSION)-SNAPSHOT publishToMavenCentral
 
-publish-maven-central: check-gpg-env
+publish-maven-central: check-gpg-env ## Publish and release the current version to Maven Central
 	$(GPG_ENV) ./gradlew publishAndReleaseToMavenCentral
 
-upgrade-wrapper:
+upgrade-wrapper: ## Upgrade the Gradle wrapper to the version pinned in libs.versions.toml
 	./gradlew wrapper --gradle-version=$(GRADLE_VERSION) --distribution-type=bin

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # etcd Recipes
 
-[![JitPack](https://jitpack.io/v/pambrose/etcd-recipes.svg)](https://jitpack.io/#pambrose/etcd-recipes)
-[![Build Status](https://app.travis-ci.com/pambrose/etcd-recipes.svg?branch=master)](https://app.travis-ci.com/pambrose/etcd-recipes)
+[![Maven Central](https://img.shields.io/maven-central/v/com.pambrose.etcd-recipes/etcd-recipes.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.pambrose.etcd-recipes/etcd-recipes)
+[![CI](https://github.com/pambrose/etcd-recipes/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/pambrose/etcd-recipes/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/e185b9c637b040bab55bdecf38b0de76)](https://www.codacy.com/manual/pambrose/etcd-recipes?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pambrose/etcd-recipes&amp;utm_campaign=Badge_Grade)
 [![codebeat badge](https://codebeat.co/badges/d61556d4-22e8-44c3-b8f8-db7613fae7fc)](https://codebeat.co/projects/github-com-pambrose-etcd-recipes-master)
 [![codecov](https://codecov.io/gh/pambrose/etcd-recipes/branch/master/graph/badge.svg)](https://codecov.io/gh/pambrose/etcd-recipes)
-[![Coverage Status](https://coveralls.io/repos/github/pambrose/etcd-recipes/badge.svg)](https://coveralls.io/github/pambrose/etcd-recipes)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pambrose_etcd-recipes&metric=alert_status)](https://sonarcloud.io/dashboard?id=pambrose_etcd-recipes)
 [![Known Vulnerabilities](https://snyk.io/test/github/pambrose/etcd-recipes/badge.svg)](https://snyk.io/test/github/pambrose/etcd-recipes)
 [![Kotlin](https://img.shields.io/badge/%20language-Kotlin-red.svg)](https://kotlinlang.org/)
@@ -110,7 +110,6 @@ etcd-recipes = { module = "com.pambrose.etcd-recipes:etcd-recipes", version.ref 
 ```groovy
 repositories {
     mavenCentral()
-    maven { url 'https://jitpack.io' }
 }
 
 dependencies {
@@ -121,13 +120,6 @@ dependencies {
 ### Maven
 
 ```xml
-<repositories>
-    <repository>
-        <id>jitpack.io</id>
-        <url>https://jitpack.io</url>
-    </repository>
-</repositories>
-
 <dependencies>
     <dependency>
         <groupId>com.pambrose.etcd-recipes</groupId>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ subprojects {
     apply(plugin = "org.jetbrains.dokka")
     apply(plugin = "org.jetbrains.dokka-javadoc")
     apply(plugin = "org.jetbrains.kotlinx.kover")
-    apply(plugin = "io.gitlab.arturbosch.detekt")
+    apply(plugin = "dev.detekt")
 }
 
 // Root-level aggregation:

--- a/etcd-recipes-examples/detekt-baseline.xml
+++ b/etcd-recipes-examples/detekt-baseline.xml
@@ -2,30 +2,17 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>MagicNumber:DistributedBarrierEarlySetExample.kt$5</ID>
-    <ID>MagicNumber:DistributedBarrierExample.kt$5</ID>
-    <ID>MagicNumber:DistributedBarrierWithCountExample.kt$30</ID>
-    <ID>MagicNumber:DistributedBarrierWithCountExample.kt$5</ID>
-    <ID>MagicNumber:DistributedBarrierWithCountExample.kt$99</ID>
-    <ID>MagicNumber:DistributedDoubleBarrierExample.kt$5</ID>
-    <ID>MagicNumber:DistributedDoubleBarrierExample.kt$99</ID>
-    <ID>MagicNumber:DistributedPriorityQueueExample.kt$5</ID>
-    <ID>MagicNumber:DistributedPriorityQueueExample.kt$50</ID>
-    <ID>MagicNumber:DistributedQueueExample.kt$5</ID>
-    <ID>MagicNumber:DistributedQueueExample.kt$50</ID>
-    <ID>MagicNumber:LeaderSelectorSerialExample.kt$100</ID>
-    <ID>MagicNumber:LeaderSelectorSerialExample.kt$5</ID>
-    <ID>MagicNumber:LeaderSelectorThreadedExample.kt$5</ID>
-    <ID>MagicNumber:SerialCountersExample.kt$25</ID>
-    <ID>MagicNumber:SerialCountersExample.kt$30</ID>
-    <ID>MagicNumber:SerialCountersExample.kt$5</ID>
-    <ID>MagicNumber:ServiceDiscoveryExample.kt$888</ID>
-    <ID>MagicNumber:ServiceDiscoveryExample.kt$999</ID>
-    <ID>MagicNumber:SetAndDeleteValue.kt$12</ID>
-    <ID>MagicNumber:SetValueAndWatch.kt$10</ID>
-    <ID>MagicNumber:SetValueWithLease.kt$12</ID>
-    <ID>MagicNumber:ThreadedCountersExample.kt$10</ID>
-    <ID>MagicNumber:ThreadedCountersExample.kt$5</ID>
-    <ID>TooGenericExceptionCaught:ServiceDiscoveryExample.kt$e: Throwable</ID>
+    <ID>MagicNumber:DistributedBarrierWithCountExample.kt:5</ID>
+    <ID>MagicNumber:DistributedBarrierWithCountExample.kt:99</ID>
+    <ID>MagicNumber:DistributedDoubleBarrierExample.kt:99</ID>
+    <ID>MagicNumber:LeaderSelectorSerialExample.kt:100</ID>
+    <ID>MagicNumber:LeaderSelectorSerialExample.kt:5</ID>
+    <ID>MagicNumber:SerialCountersExample.kt:5</ID>
+    <ID>MagicNumber:ServiceDiscoveryExample.kt:888</ID>
+    <ID>MagicNumber:SetAndDeleteValue.kt:12</ID>
+    <ID>MagicNumber:SetValueAndWatch.kt:10</ID>
+    <ID>MagicNumber:SetValueWithLease.kt:12</ID>
+    <ID>MagicNumber:ThreadedCountersExample.kt:5</ID>
+    <ID>TooGenericExceptionCaught:ServiceDiscoveryExample.kt:e: Throwable</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/etcd-recipes/detekt-baseline.xml
+++ b/etcd-recipes/detekt-baseline.xml
@@ -2,44 +2,35 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>CyclomaticComplexMethod:DistributedBarrierWithCount.kt$DistributedBarrierWithCount$@Throws(InterruptedException::class, EtcdRecipeException::class) fun waitOnBarrier(timeout: Duration): Boolean</ID>
-    <ID>LongMethod:DistributedBarrierWithCount.kt$DistributedBarrierWithCount$@Throws(InterruptedException::class, EtcdRecipeException::class) fun waitOnBarrier(timeout: Duration): Boolean</ID>
-    <ID>LongMethod:LeaderSelector.kt$LeaderSelector$fun start(): LeaderSelector</ID>
-    <ID>LongMethod:ServiceCache.kt$ServiceCache$@Synchronized fun start(): ServiceCache</ID>
-    <ID>LongParameterList:DistributedBarrier.kt$( client: Client, barrierPath: String, leaseTtlSecs: Long = EtcdConnector.DEFAULT_TTL_SECS, waitOnMissingBarriers: Boolean = true, clientId: String = defaultClientId(), receiver: DistributedBarrier.() -> T, )</ID>
-    <ID>LongParameterList:DistributedBarrierWithCount.kt$( client: Client, barrierPath: String, memberCount: Int, leaseTtlSecs: Long = EtcdConnector.DEFAULT_TTL_SECS, clientId: String = defaultClientId(), receiver: DistributedBarrierWithCount.() -> T, )</ID>
-    <ID>LongParameterList:LeaderSelector.kt$( client: Client, electionPath: String, listener: LeaderSelectorListener, leaseTtlSecs: Long = DEFAULT_TTL_SECS, userExecutor: Executor? = null, clientId: String = defaultClientId(), receiver: LeaderSelector.() -> T, )</ID>
-    <ID>LongParameterList:LeaderSelector.kt$( client: Client, electionPath: String, takeLeadershipBlock: (selector: LeaderSelector) -> Unit = {}, relinquishLeadershipBlock: (selector: LeaderSelector) -> Unit = {}, leaseTtlSecs: Long = DEFAULT_TTL_SECS, executorService: ExecutorService? = null, clientId: String = defaultClientId(), receiver: LeaderSelector.() -> T, )</ID>
-    <ID>LongParameterList:LeaderSelector.kt$LeaderSelector$( client: Client, electionPath: String, takeLeadershipBlock: (selector: LeaderSelector) -> Unit = {}, relinquishLeadershipBlock: (selector: LeaderSelector) -> Unit = {}, leaseTtlSecs: Long = DEFAULT_TTL_SECS, executorService: ExecutorService? = null, clientId: String = defaultClientId(), )</ID>
-    <ID>LongParameterList:TransientKeyValue.kt$( client: Client, keyPath: String, keyValue: String, leaseTtlSecs: Long = EtcdConnector.DEFAULT_TTL_SECS, autoStart: Boolean = true, userExecutor: Executor? = null, clientId: String = defaultClientId(), receiver: TransientKeyValue.() -> T, )</ID>
-    <ID>LongParameterList:TransientKeyValue.kt$TransientKeyValue$( client: Client, val keyPath: String, val keyValue: String, val leaseTtlSecs: Long = DEFAULT_TTL_SECS, autoStart: Boolean = true, private val userExecutor: Executor? = null, val clientId: String = defaultClientId(), )</ID>
-    <ID>LoopWithTooManyJumpStatements:AbstractQueue.kt$AbstractQueue$while</ID>
-    <ID>MagicNumber:DistributedAtomicLong.kt$DistributedAtomicLong$100</ID>
-    <ID>MagicNumber:DistributedQueue.kt$DistributedQueue$3</ID>
-    <ID>MagicNumber:KVExtensions.kt$10</ID>
-    <ID>MagicNumber:LeaderSelector.kt$LeaderSelector$3</ID>
-    <ID>MagicNumber:ShowKeys.kt$600</ID>
-    <ID>MagicNumber:WatchExtensions.kt$DispatchingWatcher$5</ID>
-    <ID>MaxLineLength:ReportLeaderTests.kt$ReportLeaderTests$// This requires a pause because reportLeader() needs to get notified (via a watcher) of the change in leadership</ID>
-    <ID>ReturnCount:LeaderSelector.kt$LeaderSelector$@Synchronized private fun attemptToBecomeLeader(client: Client): Boolean</ID>
-    <ID>SpreadOperator:ClientExtensions.kt$(*urls.toTypedArray())</ID>
-    <ID>TooGenericExceptionCaught:KeepAliveExtensions.kt$e: Throwable</ID>
-    <ID>TooGenericExceptionCaught:LeaderSelector.kt$LeaderSelector$e: Throwable</ID>
-    <ID>TooGenericExceptionCaught:LeaderSelector.kt$LeaderSelector.Companion$e: Throwable</ID>
-    <ID>TooGenericExceptionCaught:LeaseExtensions.kt$e: Throwable</ID>
-    <ID>TooGenericExceptionCaught:PathChildrenCache.kt$PathChildrenCache$e: Throwable</ID>
-    <ID>TooGenericExceptionCaught:ServiceCache.kt$ServiceCache$e: Throwable</ID>
-    <ID>TooGenericExceptionCaught:TransientKeyValue.kt$TransientKeyValue$e: Throwable</ID>
-    <ID>TooManyFunctions:KVExtensions.kt$io.etcd.recipes.common.KVExtensions.kt</ID>
-    <ID>TooManyFunctions:PathChildrenCache.kt$PathChildrenCache : EtcdConnector</ID>
-    <ID>TooManyFunctions:TxnExtensions.kt$io.etcd.recipes.common.TxnExtensions.kt</ID>
-    <ID>WildcardImport:DistributedBarrier.kt$import io.etcd.recipes.common.*</ID>
-    <ID>WildcardImport:PathChildrenCache.kt$import io.etcd.jetcd.watch.WatchEvent.EventType.*</ID>
-    <ID>WildcardImport:PathChildrenCache.kt$import io.etcd.recipes.cache.PathChildrenCache.StartMode.*</ID>
-    <ID>WildcardImport:PathChildrenCache.kt$import io.etcd.recipes.cache.PathChildrenCacheEvent.Type.*</ID>
-    <ID>WildcardImport:PathChildrenCache.kt$import io.etcd.recipes.common.*</ID>
-    <ID>WildcardImport:ServiceCache.kt$import io.etcd.jetcd.watch.WatchEvent.EventType.*</ID>
-    <ID>WildcardImport:ServiceCache.kt$import io.etcd.recipes.common.*</ID>
-    <ID>WildcardImport:ServiceCacheTests.kt$import io.etcd.recipes.common.*</ID>
+    <ID>CyclomaticComplexMethod:DistributedBarrierWithCount.kt:DistributedBarrierWithCount$@Throws(InterruptedException::class, EtcdRecipeException::class) fun waitOnBarrier: Boolean</ID>
+    <ID>LongMethod:DistributedBarrierWithCount.kt:DistributedBarrierWithCount$@Throws(InterruptedException::class, EtcdRecipeException::class) fun waitOnBarrier: Boolean</ID>
+    <ID>LongMethod:LeaderSelector.kt:LeaderSelector$fun start: LeaderSelector</ID>
+    <ID>LongMethod:ServiceCache.kt:ServiceCache$@Synchronized fun start: ServiceCache</ID>
+    <ID>LoopWithTooManyJumpStatements:AbstractQueue.kt:AbstractQueue$while</ID>
+    <ID>MagicNumber:DistributedAtomicLong.kt:DistributedAtomicLong$100</ID>
+    <ID>MagicNumber:KVExtensions.kt:10</ID>
+    <ID>MagicNumber:LeaderSelector.kt:LeaderSelector$3</ID>
+    <ID>MagicNumber:ShowKeys.kt:600</ID>
+    <ID>MagicNumber:WatchExtensions.kt:DispatchingWatcher$5</ID>
+    <ID>MaxLineLength:ReportLeaderTests.kt:ReportLeaderTests$// This requires a pause because reportLeader() needs to get notified (via a watcher) of the change in leadership</ID>
+    <ID>ReturnCount:LeaderSelector.kt:LeaderSelector$@Synchronized private fun attemptToBecomeLeader: Boolean</ID>
+    <ID>TooGenericExceptionCaught:KeepAliveExtensions.kt:e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:LeaderSelector.kt:LeaderSelector$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:LeaderSelector.kt:LeaderSelector.Companion$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:LeaseExtensions.kt:e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:PathChildrenCache.kt:PathChildrenCache$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:ServiceCache.kt:ServiceCache$e: Throwable</ID>
+    <ID>TooGenericExceptionCaught:TransientKeyValue.kt:TransientKeyValue$e: Throwable</ID>
+    <ID>TooManyFunctions:KVExtensions.kt:io.etcd.recipes.common.KVExtensions.kt</ID>
+    <ID>TooManyFunctions:PathChildrenCache.kt:PathChildrenCache : EtcdConnector</ID>
+    <ID>TooManyFunctions:TxnExtensions.kt:io.etcd.recipes.common.TxnExtensions.kt</ID>
+    <ID>WildcardImport:DistributedBarrier.kt:import io.etcd.recipes.common.*</ID>
+    <ID>WildcardImport:PathChildrenCache.kt:import io.etcd.jetcd.watch.WatchEvent.EventType.*</ID>
+    <ID>WildcardImport:PathChildrenCache.kt:import io.etcd.recipes.cache.PathChildrenCache.StartMode.*</ID>
+    <ID>WildcardImport:PathChildrenCache.kt:import io.etcd.recipes.cache.PathChildrenCacheEvent.Type.*</ID>
+    <ID>WildcardImport:PathChildrenCache.kt:import io.etcd.recipes.common.*</ID>
+    <ID>WildcardImport:ServiceCache.kt:import io.etcd.jetcd.watch.WatchEvent.EventType.*</ID>
+    <ID>WildcardImport:ServiceCache.kt:import io.etcd.recipes.common.*</ID>
+    <ID>WildcardImport:ServiceCacheTests.kt:import io.etcd.recipes.common.*</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ testcontainers = "2.0.5"
 
 # Build tooling plugins
 ben-manes-versions = "0.54.0"
-detekt = "1.23.8"
+detekt = "2.0.0-alpha.3"
 dokka = "2.2.0"
 kotlinter = "5.4.2"
 kover = "0.9.8"
@@ -69,7 +69,7 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 # Static analysis
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+detekt = { id = "dev.detekt", version.ref = "detekt" }
 kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinter" }
 
 # Coverage and docs


### PR DESCRIPTION
## Summary
- Refresh README badges: drop stale Travis/Coveralls/JitPack, add Maven Central, GitHub Actions CI, and Apache 2.0 license badges; remove the JitPack `<repositories>` block from the Maven install snippet.
- Add a `make help` target with per-target `## ...` doc comments, and fail fast in the Makefile when `VERSION` or `GRADLE_VERSION` can't be resolved.
- Migrate detekt to `2.0.0-alpha.3`: switch the plugin id from `io.gitlab.arturbosch.detekt` to `dev.detekt` and refresh both `detekt-baseline.xml` files for the new ID format.

## Test plan
- [ ] `make help` prints the target list
- [ ] `./gradlew detekt` passes against the refreshed baselines
- [ ] CI badge resolves once the workflow runs on this branch
- [ ] Maven Central badge renders the current published version

🤖 Generated with [Claude Code](https://claude.com/claude-code)