### PR TITLE
Add multi-container test variant for distributed recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default help clean clean-all stop build tests tests-tc coverage kdocs \
+.PHONY: default help clean clean-all stop build tests tests-tc tests-container coverage kdocs \
         lint detekt detekt-baseline refresh versioncheck publish-local publish-local-snapshot \
         publish-snapshot publish-maven-central upgrade-wrapper \
         _check-gpg-env _require-version _require-gradle-version
@@ -54,6 +54,9 @@ endif
 
 tests-tc: ## Run the full test suite under Testcontainers (no local etcd required)
 	DOCKER_HOST="$(DOCKER_HOST)" ./gradlew check --rerun-tasks --no-build-cache -PuseTestcontainers
+
+tests-container: ## Run only the multi-container tests (each participant in its own container)
+	DOCKER_HOST="$(DOCKER_HOST)" ./gradlew :etcd-recipes:cleanTest :etcd-recipes:test --tests "io.etcd.recipes.container.*" --no-build-cache -PuseTestcontainers
 
 coverage: ## Generate Kover HTML + XML coverage reports and print the summary
 	./gradlew koverHtmlReport koverXmlReport koverLog

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,6 +81,15 @@ subprojects {
         "testRuntimeOnly"(rootProject.libs.bundles.testing.runtime)
     }
 
+    // The library's tests include a container-based variant that reads result keys
+    // written by the runners module. The runners module already depends on the library,
+    // so this is a test-only one-way dependency, not a cycle.
+    if (name == libraryName) {
+        dependencies {
+            "testImplementation"(project(":$libraryName-test-runners"))
+        }
+    }
+
     // Examples module isn't published; only the library is.
     if (name == libraryName) configurePublishing()
 
@@ -149,6 +158,27 @@ subprojects {
                 // refuses with "operation not supported". We register an
                 // explicit JVM shutdown hook in EtcdTestContainer instead.
                 environment("TESTCONTAINERS_RYUK_DISABLED", "true")
+            }
+
+            // The container-based tests (etcd-recipes/src/test/.../container) need
+            // the test-runners fat JAR to mount into each participant container.
+            // Wire it only for the library module's test task — the test-runners
+            // module's own test task (if any) has no need for it.
+            if (project.name == libraryName) {
+                // String-form dependsOn defers task-graph wiring until after all projects are
+                // configured. The path itself is captured in a doFirst so that we look up the
+                // (now-registered) shadowJar task at execution time — a configure-time lookup
+                // would race the runners project's own configuration, and passing a Provider
+                // to systemProperty just calls toString() on it.
+                dependsOn(":$libraryName-test-runners:shadowJar")
+                doFirst {
+                    systemProperty(
+                        "etcd.recipes.testRunnersJar",
+                        project(":$libraryName-test-runners")
+                            .tasks.named("shadowJar", Jar::class.java)
+                            .get().archiveFile.get().asFile.absolutePath,
+                    )
+                }
             }
         }
 

--- a/etcd-recipes-test-runners/build.gradle.kts
+++ b/etcd-recipes-test-runners/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("com.gradleup.shadow") version "9.4.1"
+}
+
+dependencies {
+    "implementation"(project(":etcd-recipes"))
+}
+
+tasks.shadowJar {
+    archiveBaseName.set("etcd-recipes-test-runners")
+    archiveClassifier.set("all")
+    archiveVersion.set("")
+    manifest {
+        attributes["Main-Class"] = "io.etcd.recipes.runners.MainKt"
+    }
+    mergeServiceFiles()
+}

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/Args.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/Args.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.runners
+
+class Args(
+  rawArgs: Array<String>,
+) {
+  private val map: Map<String, String> =
+    rawArgs.associate { arg ->
+      require(arg.startsWith("--") && arg.contains('=')) { "Expected --key=value, got: $arg" }
+      val (key, value) = arg.removePrefix("--").split('=', limit = 2)
+      key to value
+    }
+
+  fun require(key: String): String = map[key] ?: error("Missing required arg: --$key")
+
+  fun optional(key: String): String? = map[key]
+
+  fun int(key: String): Int = require(key).toInt()
+
+  fun intOr(
+    key: String,
+    default: Int,
+  ): Int = map[key]?.toInt() ?: default
+
+  fun long(key: String): Long = require(key).toLong()
+
+  fun longOr(
+    key: String,
+    default: Long,
+  ): Long = map[key]?.toLong() ?: default
+}

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/BarrierWaiterRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/BarrierWaiterRunner.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.runners
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.barrier.withDistributedBarrier
+import io.etcd.recipes.common.putValue
+import kotlinx.serialization.Serializable
+import kotlin.time.Duration.Companion.milliseconds
+
+@Serializable
+data class BarrierWaiterPayload(
+  val timeoutObserved: Boolean,
+  val unblocked: Boolean,
+  val unblockTimestampMs: Long,
+)
+
+object BarrierWaiterRunner : RecipeRunner {
+  override val recipe: String = "barrier"
+  override val role: String = "waiter"
+
+  override fun run(
+    client: Client,
+    testId: String,
+    participantId: String,
+    args: Args,
+  ): ParticipantResult {
+    val barrierPath = args.require("barrier-path")
+    val initialTimeoutMs = args.longOr("initial-timeout-ms", 1_000L)
+
+    // waitOnMissingBarriers=false: if a slow-starting container reaches its second wait
+    // after the orchestrator has already removed the barrier, return immediately rather
+    // than hanging on a watcher that will never fire (the etcd key is already gone).
+    return withDistributedBarrier(client, barrierPath, waitOnMissingBarriers = false) {
+      // Signal that this participant is about to enter the first wait. The orchestrator
+      // waits for all such signals before removing the barrier, which closes the race
+      // where a slow-starting container would otherwise observe a barrier that the
+      // orchestrator had already cleared.
+      client.putValue("/barrier-ready/$testId/$participantId", "1")
+      val timedOut = !waitOnBarrier(initialTimeoutMs.milliseconds)
+      // The first wait should time out while the controller still has the barrier set;
+      // the second wait blocks until the controller removes it.
+      val unblocked = waitOnBarrier()
+      val unblockTs = System.currentTimeMillis()
+
+      ParticipantResult(
+        testId = testId,
+        participantId = participantId,
+        role = "$recipe/$role",
+        success = timedOut && unblocked,
+        payloadJson =
+          encodePayload(
+            BarrierWaiterPayload(
+              timeoutObserved = timedOut,
+              unblocked = unblocked,
+              unblockTimestampMs = unblockTs,
+            ),
+          ),
+      )
+    }
+  }
+}

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/CounterIncrementRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/CounterIncrementRunner.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.runners
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.counter.withDistributedAtomicLong
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CounterIncrementPayload(
+  val incrementsApplied: Int,
+  val lastObservedValue: Long,
+)
+
+object CounterIncrementRunner : RecipeRunner {
+  override val recipe: String = "counter"
+  override val role: String = "incrementer"
+
+  override fun run(
+    client: Client,
+    testId: String,
+    participantId: String,
+    args: Args,
+  ): ParticipantResult {
+    val counterPath = args.require("counter-path")
+    val incrementCount = args.int("increment-count")
+
+    var last = 0L
+    withDistributedAtomicLong(client, counterPath) {
+      start()
+      repeat(incrementCount) { last = increment() }
+    }
+
+    return ParticipantResult(
+      testId = testId,
+      participantId = participantId,
+      role = "$recipe/$role",
+      success = true,
+      payloadJson =
+        encodePayload(
+          CounterIncrementPayload(
+            incrementsApplied = incrementCount,
+            lastObservedValue = last,
+          ),
+        ),
+    )
+  }
+}

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ElectionParticipantRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ElectionParticipantRunner.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.runners
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.election.LeaderSelector
+import io.etcd.recipes.election.withLeaderSelector
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ElectionParticipantPayload(
+  val tookLeadership: Boolean,
+  val relinquished: Boolean,
+  val clientId: String,
+)
+
+object ElectionParticipantRunner : RecipeRunner {
+  override val recipe: String = "election"
+  override val role: String = "participant"
+
+  override fun run(
+    client: Client,
+    testId: String,
+    participantId: String,
+    args: Args,
+  ): ParticipantResult {
+    val electionPath = args.require("election-path")
+    val clientId = "participant-$participantId"
+
+    var tookLeadership = false
+    var relinquished = false
+
+    withLeaderSelector(
+      client = client,
+      electionPath = electionPath,
+      takeLeadershipBlock = { _: LeaderSelector -> tookLeadership = true },
+      relinquishLeadershipBlock = { _: LeaderSelector -> relinquished = true },
+      clientId = clientId,
+    ) {
+      start()
+      waitOnLeadershipComplete()
+    }
+
+    return ParticipantResult(
+      testId = testId,
+      participantId = participantId,
+      role = "$recipe/$role",
+      success = tookLeadership && relinquished,
+      payloadJson =
+        encodePayload(
+          ElectionParticipantPayload(
+            tookLeadership = tookLeadership,
+            relinquished = relinquished,
+            clientId = clientId,
+          ),
+        ),
+    )
+  }
+}

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/Main.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/Main.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.runners
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.connectToEtcd
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.system.exitProcess
+
+private val logger = KotlinLogging.logger {}
+
+interface RecipeRunner {
+  val recipe: String
+  val role: String
+
+  fun run(
+    client: Client,
+    testId: String,
+    participantId: String,
+    args: Args,
+  ): ParticipantResult
+}
+
+private val runners: Map<Pair<String, String>, RecipeRunner> =
+  listOf(
+    BarrierWaiterRunner,
+    ElectionParticipantRunner,
+    QueueConsumerRunner,
+    CounterIncrementRunner,
+    ServiceRegistrationRunner,
+  ).associateBy { it.recipe to it.role }
+
+fun main(rawArgs: Array<String>) {
+  val args = Args(rawArgs)
+  val recipe = args.require("recipe")
+  val role = args.require("role")
+  val etcd = args.require("etcd")
+  val testId = args.require("test-id")
+  val participantId = args.require("participant-id")
+
+  val runner =
+    runners[recipe to role]
+      ?: error("Unknown recipe/role combination: $recipe/$role")
+
+  logger.info { "Starting runner recipe=$recipe role=$role testId=$testId participantId=$participantId" }
+
+  @Suppress("TooGenericExceptionCaught")
+  val result =
+    try {
+      connectToEtcd(listOf(etcd)) { client ->
+        val outcome = runner.run(client, testId, participantId, args)
+        client.recordResult(outcome)
+        outcome
+      }
+    } catch (t: Throwable) {
+      logger.error(t) { "Runner failed" }
+      val failure =
+        ParticipantResult(
+          testId = testId,
+          participantId = participantId,
+          role = "$recipe/$role",
+          success = false,
+          errorMessage = "${t.javaClass.simpleName}: ${t.message}",
+        )
+      runCatching {
+        connectToEtcd(listOf(etcd)) { client -> client.recordResult(failure) }
+      }
+      failure
+    }
+
+  exitProcess(if (result.success) 0 else 1)
+}

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/QueueConsumerRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/QueueConsumerRunner.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.runners
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.queue.withDistributedQueue
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class QueueConsumerPayload(
+  val items: List<String>,
+)
+
+object QueueConsumerRunner : RecipeRunner {
+  override val recipe: String = "queue"
+  override val role: String = "consumer"
+
+  override fun run(
+    client: Client,
+    testId: String,
+    participantId: String,
+    args: Args,
+  ): ParticipantResult {
+    val queuePath = args.require("queue-path")
+    val itemCount = args.int("item-count")
+
+    val items =
+      withDistributedQueue(client, queuePath) {
+        List(itemCount) { dequeue().asString }
+      }
+
+    return ParticipantResult(
+      testId = testId,
+      participantId = participantId,
+      role = "$recipe/$role",
+      success = items.size == itemCount,
+      payloadJson = encodePayload(QueueConsumerPayload(items = items)),
+    )
+  }
+}

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ResultRecorder.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ResultRecorder.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.runners
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.putValue
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+const val RESULTS_PREFIX = "/test-results"
+
+fun resultKey(
+  testId: String,
+  participantId: String,
+): String = "$RESULTS_PREFIX/$testId/$participantId"
+
+@Serializable
+data class ParticipantResult(
+  val testId: String,
+  val participantId: String,
+  val role: String,
+  val success: Boolean,
+  val errorMessage: String? = null,
+  // Recipe-specific payload encoded as JSON so the orchestrator can decode against the
+  // recipe-specific data class it expects. Avoids a sealed-class hierarchy that would force
+  // every consumer to know every recipe shape.
+  val payloadJson: String? = null,
+)
+
+private val json = Json { ignoreUnknownKeys = true }
+
+fun Client.recordResult(result: ParticipantResult) {
+  putValue(resultKey(result.testId, result.participantId), json.encodeToString(ParticipantResult.serializer(), result))
+}
+
+inline fun <reified T> encodePayload(value: T): String = Json.encodeToString(value)

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ServiceRegistrationRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ServiceRegistrationRunner.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.runners
+
+import com.pambrose.common.util.sleep
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.isKeyPresent
+import io.etcd.recipes.discovery.ServiceInstance
+import io.etcd.recipes.discovery.withServiceDiscovery
+import kotlinx.serialization.Serializable
+import kotlin.time.Duration.Companion.milliseconds
+
+@Serializable
+data class ServiceRegistrationPayload(
+  val serviceName: String,
+  val instanceId: String,
+)
+
+object ServiceRegistrationRunner : RecipeRunner {
+  override val recipe: String = "discovery"
+  override val role: String = "register"
+
+  override fun run(
+    client: Client,
+    testId: String,
+    participantId: String,
+    args: Args,
+  ): ParticipantResult {
+    val servicePath = args.require("service-path")
+    val serviceName = args.require("service-name")
+    val shutdownKey = args.require("shutdown-key")
+    val maxWaitMs = args.longOr("max-wait-ms", 60_000L)
+
+    val instance =
+      ServiceInstance(
+        name = serviceName,
+        jsonPayload = """{"participant":"$participantId"}""",
+      )
+
+    return withServiceDiscovery(client, servicePath) {
+      registerService(instance)
+
+      // Block until the orchestrator (running on the host JVM) signals shutdown
+      // by writing any value to shutdownKey. Polling is fine here — service
+      // discovery tests don't measure latency, and a watch would complicate
+      // the runner without buying anything.
+      val deadline = System.currentTimeMillis() + maxWaitMs
+      while (System.currentTimeMillis() < deadline && !client.isKeyPresent(shutdownKey)) {
+        sleep(200.milliseconds)
+      }
+
+      val signalled = client.isKeyPresent(shutdownKey)
+      unregisterService(instance)
+
+      ParticipantResult(
+        testId = testId,
+        participantId = participantId,
+        role = "$recipe/$role",
+        success = signalled,
+        payloadJson =
+          encodePayload(
+            ServiceRegistrationPayload(
+              serviceName = serviceName,
+              instanceId = instance.id,
+            ),
+          ),
+      )
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdContainerNetwork.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdContainerNetwork.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+
+/**
+ * Shared Testcontainers network plus a single etcd container reachable from
+ * both the orchestrator JVM (via the host-mapped port) and from participant
+ * containers (via the network alias [ETCD_ALIAS]). Coexists with
+ * [EtcdTestContainer]; thread-based tests continue using that.
+ */
+internal object EtcdContainerNetwork {
+  private const val ETCD_IMAGE = "gcr.io/etcd-development/etcd:v3.5.17"
+  private const val CLIENT_PORT = 2379
+  private const val PEER_PORT = 2380
+  const val ETCD_ALIAS = "etcd"
+
+  val network: Network by lazy {
+    val n = Network.newNetwork()
+    Runtime.getRuntime().addShutdownHook(Thread { runCatching { n.close() } })
+    n
+  }
+
+  private val container: GenericContainer<*> by lazy {
+    val c =
+      GenericContainer(DockerImageName.parse(ETCD_IMAGE))
+        .withNetwork(network)
+        .withNetworkAliases(ETCD_ALIAS)
+        .withExposedPorts(CLIENT_PORT, PEER_PORT)
+        .withCommand(
+          "etcd",
+          "--listen-client-urls=http://0.0.0.0:$CLIENT_PORT",
+          "--advertise-client-urls=http://0.0.0.0:$CLIENT_PORT",
+        )
+        .waitingFor(Wait.forLogMessage(".*ready to serve client requests.*\\n", 1))
+    c.start()
+    Runtime.getRuntime().addShutdownHook(Thread { runCatching { c.stop() } })
+    c
+  }
+
+  /** Endpoint reachable from the host JVM running the orchestrator test. */
+  fun hostEndpoint(): String = "http://${container.host}:${container.getMappedPort(CLIENT_PORT)}"
+
+  /** Endpoint reachable from another container attached to [network]. */
+  fun inNetworkEndpoint(): String {
+    // Force lazy init so the network and container exist before participants try to attach.
+    container.containerId
+    return "http://$ETCD_ALIAS:$CLIENT_PORT"
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ParticipantContainer.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ParticipantContainer.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction", "MatchingDeclarationName")
+
+package io.etcd.recipes.common
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import org.testcontainers.utility.MountableFile
+import java.io.File
+import java.time.Duration
+
+internal object Participant {
+  private const val RUNNER_IMAGE = "eclipse-temurin:17-jre"
+  private const val JAR_DEST = "/app/runner.jar"
+  private const val JAR_PROPERTY = "etcd.recipes.testRunnersJar"
+
+  private val runnerJarPath: String by lazy {
+    val path =
+      System.getProperty(JAR_PROPERTY)
+        ?: error(
+          "System property $JAR_PROPERTY is not set. Run tests via Gradle with -PuseTestcontainers, " +
+            "which wires the path through the test task configuration.",
+        )
+    require(File(path).isFile) { "$JAR_PROPERTY=$path does not point to a file" }
+    path
+  }
+
+  /**
+   * Build a one-shot participant container that runs `java -jar runner.jar <args>` and exits.
+   * Caller is expected to start it. Use [io.etcd.recipes.common.awaitResults] (which polls etcd
+   * for the runner-written result keys) rather than polling Docker for the container's exit
+   * status — runners write their outcome to etcd as the last step before exiting, so a result
+   * key appearing is a reliable completion signal.
+   *
+   * The startup wait strategy looks for the "Starting runner" log line emitted by Main.kt;
+   * if the JAR fails to start, [GenericContainer.start] will time out.
+   */
+  fun newContainer(
+    recipe: String,
+    role: String,
+    testId: String,
+    participantId: String,
+    extraArgs: Map<String, String> = emptyMap(),
+    startupTimeout: Duration = Duration.ofSeconds(60),
+  ): GenericContainer<*> {
+    val args =
+      mutableListOf(
+        "--recipe=$recipe",
+        "--role=$role",
+        "--etcd=${EtcdContainerNetwork.inNetworkEndpoint()}",
+        "--test-id=$testId",
+        "--participant-id=$participantId",
+      )
+    extraArgs.forEach { (k, v) -> args += "--$k=$v" }
+
+    return GenericContainer(DockerImageName.parse(RUNNER_IMAGE))
+      .withNetwork(EtcdContainerNetwork.network)
+      .withCopyFileToContainer(MountableFile.forHostPath(runnerJarPath), JAR_DEST)
+      .withCommand(*(listOf("java", "-jar", JAR_DEST) + args).toTypedArray())
+      .waitingFor(Wait.forLogMessage(".*Starting runner.*\\n", 1).withStartupTimeout(startupTimeout))
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ResultReader.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ResultReader.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.runners.ParticipantResult
+import io.etcd.recipes.runners.RESULTS_PREFIX
+import kotlinx.serialization.json.Json
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+private val json = Json { ignoreUnknownKeys = true }
+
+private fun Client.readResults(testId: String): List<ParticipantResult> =
+  getChildren("$RESULTS_PREFIX/$testId")
+    .map { (_, value) -> json.decodeFromString(ParticipantResult.serializer(), value.asString) }
+
+/**
+ * Poll the result prefix until [expectedCount] participant results are present or [timeout]
+ * elapses. Returns the parsed results keyed by participant id. Throws on timeout — the caller
+ * should treat that as a test failure.
+ */
+fun Client.awaitResults(
+  testId: String,
+  expectedCount: Int,
+  timeout: Duration,
+  poll: Duration = 200.milliseconds,
+): Map<String, ParticipantResult> {
+  val deadline = System.nanoTime() + timeout.inWholeNanoseconds
+  while (true) {
+    val results = readResults(testId)
+    if (results.size >= expectedCount) {
+      return results.associateBy { it.participantId }
+    }
+    check(System.nanoTime() < deadline) {
+      "Only ${results.size}/$expectedCount results arrived within $timeout for testId=$testId. " +
+        "Got: ${results.map { it.participantId }}"
+    }
+    Thread.sleep(poll.inWholeMilliseconds)
+  }
+}
+
+inline fun <reified T> ParticipantResult.payload(): T {
+  val payload = checkNotNull(payloadJson) { "No payload on result for participant $participantId" }
+  return Json.decodeFromString<T>(payload)
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerBarrierTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerBarrierTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.container
+
+import io.etcd.recipes.barrier.DistributedBarrier
+import io.etcd.recipes.common.EtcdContainerNetwork
+import io.etcd.recipes.common.Participant
+import io.etcd.recipes.common.awaitResults
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.getChildrenKeys
+import io.etcd.recipes.common.payload
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.runners.BarrierWaiterPayload
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+class ContainerBarrierTest :
+  StringSpec({
+    "5 waiter containers all time out then unblock when barrier is removed" {
+      assumeContainerMode()
+
+      val count = 5
+      val testId = newTestId("barrier")
+      val barrierPath = "/barriers/$testId"
+      val hostUrls = listOf(EtcdContainerNetwork.hostEndpoint())
+
+      val containers =
+        (1..count).map { i ->
+          Participant.newContainer(
+            recipe = "barrier",
+            role = "waiter",
+            testId = testId,
+            participantId = i.toString(),
+            extraArgs =
+              mapOf(
+                "barrier-path" to barrierPath,
+                "initial-timeout-ms" to "1000",
+              ),
+          )
+        }
+
+      connectToEtcd(hostUrls) { client ->
+        // Hold the DistributedBarrier open for the lifetime of the test: closing it
+        // stops the lease keep-alive, and etcd auto-deletes the barrier key once the
+        // lease TTL expires — which would race with slow container startup.
+        DistributedBarrier(client, barrierPath).use { barrier ->
+          barrier.setBarrier() shouldBe true
+
+          useContainers(containers) {
+            // Wait for every participant to write its ready key — guarantees they have
+            // entered the first waitOnBarrier() while the barrier is still set, closing
+            // the race where a slow container would see an already-cleared barrier.
+            val allReady =
+              pollUntil(30.seconds) {
+                client.getChildrenKeys("/barrier-ready/$testId").size == count
+              }
+            allReady shouldBe true
+
+            // Hold the barrier long enough for every participant's bounded first wait
+            // (initial-timeout-ms = 1s) to time out before we clear it.
+            Thread.sleep(2_000)
+
+            barrier.removeBarrier() shouldBe true
+
+            val results = client.awaitResults(testId, expectedCount = count, timeout = 30.seconds)
+            results.size shouldBe count
+            results.values.forEach { result ->
+              result.success shouldBe true
+              val payload = result.payload<BarrierWaiterPayload>()
+              payload.timeoutObserved shouldBe true
+              payload.unblocked shouldBe true
+            }
+          }
+        }
+      }
+    }
+  })

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerCounterTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerCounterTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.container
+
+import io.etcd.recipes.common.EtcdContainerNetwork
+import io.etcd.recipes.common.Participant
+import io.etcd.recipes.common.awaitResults
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.counter.withDistributedAtomicLong
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+class ContainerCounterTest :
+  StringSpec({
+    "concurrent incrementer containers produce a consistent final counter value" {
+      assumeContainerMode()
+
+      val incrementerCount = 5
+      val incrementsEach = 20
+      val expectedFinal = (incrementerCount * incrementsEach).toLong()
+      val testId = newTestId("counter")
+      val counterPath = "/counters/$testId"
+      val hostUrls = listOf(EtcdContainerNetwork.hostEndpoint())
+
+      val containers =
+        (1..incrementerCount).map { i ->
+          Participant.newContainer(
+            recipe = "counter",
+            role = "incrementer",
+            testId = testId,
+            participantId = i.toString(),
+            extraArgs =
+              mapOf(
+                "counter-path" to counterPath,
+                "increment-count" to incrementsEach.toString(),
+              ),
+          )
+        }
+
+      useContainers(containers) {
+        connectToEtcd(hostUrls) { client ->
+          val results = client.awaitResults(testId, expectedCount = incrementerCount, timeout = 60.seconds)
+          results.size shouldBe incrementerCount
+          results.values.forEach { it.success shouldBe true }
+
+          val finalValue = withDistributedAtomicLong(client, counterPath) { get() }
+          finalValue shouldBe expectedFinal
+        }
+      }
+    }
+  })

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerLeaderSelectorTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerLeaderSelectorTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.container
+
+import io.etcd.recipes.common.EtcdContainerNetwork
+import io.etcd.recipes.common.Participant
+import io.etcd.recipes.common.awaitResults
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.payload
+import io.etcd.recipes.runners.ElectionParticipantPayload
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+class ContainerLeaderSelectorTest :
+  StringSpec({
+    "every candidate container takes and relinquishes leadership exactly once" {
+      assumeContainerMode()
+
+      val count = 5
+      val testId = newTestId("election")
+      val electionPath = "/election/$testId"
+      val hostUrls = listOf(EtcdContainerNetwork.hostEndpoint())
+
+      val containers =
+        (1..count).map { i ->
+          Participant.newContainer(
+            recipe = "election",
+            role = "participant",
+            testId = testId,
+            participantId = i.toString(),
+            extraArgs = mapOf("election-path" to electionPath),
+          )
+        }
+
+      useContainers(containers) {
+        connectToEtcd(hostUrls) { client ->
+          val results = client.awaitResults(testId, expectedCount = count, timeout = 60.seconds)
+          results.size shouldBe count
+          results.values.forEach { result ->
+            result.success shouldBe true
+            val payload = result.payload<ElectionParticipantPayload>()
+            payload.tookLeadership shouldBe true
+            payload.relinquished shouldBe true
+          }
+        }
+      }
+    }
+  })

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerQueueTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerQueueTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.container
+
+import io.etcd.recipes.common.EtcdContainerNetwork
+import io.etcd.recipes.common.Participant
+import io.etcd.recipes.common.awaitResults
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.payload
+import io.etcd.recipes.queue.withDistributedQueue
+import io.etcd.recipes.runners.QueueConsumerPayload
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+class ContainerQueueTest :
+  StringSpec({
+    "5 consumer containers collectively dequeue every item the orchestrator produced" {
+      assumeContainerMode()
+
+      val consumerCount = 5
+      val itemsPerConsumer = 20
+      val total = consumerCount * itemsPerConsumer
+      val testId = newTestId("queue")
+      val queuePath = "/queues/$testId"
+      val hostUrls = listOf(EtcdContainerNetwork.hostEndpoint())
+      val produced = (1..total).map { "item-%04d".format(it) }
+
+      connectToEtcd(hostUrls) { client ->
+        // Enqueue before consumers start so they all see a fully-populated queue and
+        // assertions don't depend on race-free producer/consumer overlap.
+        withDistributedQueue(client, queuePath) { produced.forEach { enqueue(it) } }
+
+        val containers =
+          (1..consumerCount).map { i ->
+            Participant.newContainer(
+              recipe = "queue",
+              role = "consumer",
+              testId = testId,
+              participantId = i.toString(),
+              extraArgs =
+                mapOf(
+                  "queue-path" to queuePath,
+                  "item-count" to itemsPerConsumer.toString(),
+                ),
+            )
+          }
+
+        useContainers(containers) {
+          val results = client.awaitResults(testId, expectedCount = consumerCount, timeout = 60.seconds)
+          results.size shouldBe consumerCount
+
+          val dequeuedByEachConsumer = results.values.map { it.payload<QueueConsumerPayload>().items }
+          dequeuedByEachConsumer.forEach { it.size shouldBe itemsPerConsumer }
+          // Every produced item shows up exactly once across all consumers (no duplicates, no losses).
+          dequeuedByEachConsumer.flatten().sorted() shouldBe produced.sorted()
+          // Each consumer's items are in queue (FIFO) order — items are zero-padded ascending strings.
+          dequeuedByEachConsumer.forEach { it shouldBe it.sorted() }
+        }
+      }
+    }
+  })

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerServiceDiscoveryTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerServiceDiscoveryTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.container
+
+import io.etcd.recipes.common.EtcdContainerNetwork
+import io.etcd.recipes.common.Participant
+import io.etcd.recipes.common.awaitResults
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.discovery.withServiceDiscovery
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+class ContainerServiceDiscoveryTest :
+  StringSpec({
+    "3 registration containers each appear in service discovery" {
+      assumeContainerMode()
+
+      val count = 3
+      val testId = newTestId("discovery")
+      val servicePath = "/discovery/$testId"
+      val serviceName = "example-service"
+      val shutdownKey = "/discovery-shutdown/$testId"
+      val hostUrls = listOf(EtcdContainerNetwork.hostEndpoint())
+
+      val containers =
+        (1..count).map { i ->
+          Participant.newContainer(
+            recipe = "discovery",
+            role = "register",
+            testId = testId,
+            participantId = i.toString(),
+            extraArgs =
+              mapOf(
+                "service-path" to servicePath,
+                "service-name" to serviceName,
+                "shutdown-key" to shutdownKey,
+                "max-wait-ms" to "30000",
+              ),
+          )
+        }
+
+      useContainers(containers) {
+        connectToEtcd(hostUrls) { client ->
+          withServiceDiscovery(client, servicePath) {
+            // Registration happens after the runner connects to etcd, so polling beats a fixed sleep.
+            val allVisible =
+              pollUntil(15.seconds) {
+                queryForInstances(serviceName).size == count
+              }
+            allVisible shouldBe true
+          }
+
+          // Signal participants to unregister and exit.
+          client.putValue(shutdownKey, "stop")
+
+          val results = client.awaitResults(testId, expectedCount = count, timeout = 30.seconds)
+          results.size shouldBe count
+          results.values.forEach { it.success shouldBe true }
+        }
+      }
+    }
+  })

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerTestSupport.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerTestSupport.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.container
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.testcontainers.containers.GenericContainer
+import java.util.UUID
+
+/**
+ * Skips the test cleanly when run without `-PuseTestcontainers`. The container fixtures
+ * require Docker; a default `./gradlew check` should pass with the existing thread tests
+ * and quietly skip the container variants.
+ */
+internal fun assumeContainerMode() {
+  assumeTrue(
+    System.getProperty("etcd.recipes.testcontainers") == "true",
+    "Container tests require -PuseTestcontainers",
+  )
+}
+
+internal fun newTestId(prefix: String): String = "$prefix-${UUID.randomUUID().toString().take(8)}"
+
+/** Start the given containers in parallel and stop them all when [block] returns or throws. */
+internal fun <R> useContainers(
+  containers: List<GenericContainer<*>>,
+  block: () -> R,
+): R {
+  runBlocking(Dispatchers.IO) {
+    containers.map { async { it.start() } }.awaitAll()
+  }
+  try {
+    return block()
+  } finally {
+    containers.forEach { runCatching { it.stop() } }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ dokka = "2.2.0"
 kotlinter = "5.4.2"
 kover = "0.9.8"
 maven-publish = "0.36.0"
+shadow = "9.2.2"
 
 [libraries]
 # Main library
@@ -80,3 +81,6 @@ kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 # Dependency updates and publishing
 ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
+
+# Packaging
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,3 +20,4 @@ rootProject.name = "etcd-recipes"
 
 include("etcd-recipes")
 include("etcd-recipes-examples")
+include("etcd-recipes-test-runners")


### PR DESCRIPTION
## Summary
- Existing tests simulated N distributed clients with N threads in a single JVM. This adds a second variant that runs each participant as its own container, against a shared etcd container, exercising real cross-process coordination.
- New `etcd-recipes-test-runners` submodule builds a shadow fat JAR with a dispatcher `main()` that routes on `--recipe`/`--role` to per-recipe runners (barrier waiter, election participant, queue consumer, counter incrementer, service registration). Each runner writes its outcome to `/test-results/{testId}/{participantId}` as JSON.
- New `EtcdContainerNetwork`, `ParticipantContainer`, and `ResultReader` test fixtures stand up a shared Testcontainers `Network` with etcd reachable both in-network (`http://etcd:2379`) and from the host JVM.
- Five `Container*Test` classes mirror the thread-based tests for barrier, election, queue, counter, and service discovery. Tests are gated via `assumeTrue` so default `./gradlew check` skips them cleanly; under `-PuseTestcontainers` they run alongside the thread tests in ~50s.

## How to run
- `make tests-container` — only the new container tests
- `make tests-tc` — full container-mode suite (existing thread tests + new container tests)
- `./gradlew check` (no flag) — container tests skip cleanly, thread tests run as before

## Test plan
- [x] All five container tests pass under `make tests-container`
- [x] All five container tests skip under `./gradlew :etcd-recipes:test --tests \"io.etcd.recipes.container.*\"` (no `-PuseTestcontainers`)
- [x] `./gradlew lintKotlin` clean across all modules
- [x] `./gradlew :etcd-recipes:detekt` clean (one detekt issue in the runner's broad `catch (t: Throwable)` is suppressed at the call site — intentional: the dispatcher needs to convert any runner failure into a recorded result)
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)