### PR TITLE
Simplify multi-container test runners

### DIFF
--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/BarrierWaiterRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/BarrierWaiterRunner.kt
@@ -48,29 +48,21 @@ object BarrierWaiterRunner : RecipeRunner {
     // after the orchestrator has already removed the barrier, return immediately rather
     // than hanging on a watcher that will never fire (the etcd key is already gone).
     return withDistributedBarrier(client, barrierPath, waitOnMissingBarriers = false) {
-      // Signal that this participant is about to enter the first wait. The orchestrator
-      // waits for all such signals before removing the barrier, which closes the race
-      // where a slow-starting container would otherwise observe a barrier that the
-      // orchestrator had already cleared.
+      // The orchestrator waits for every ready key before removing the barrier — closes
+      // the race where a slow-starting container would see an already-cleared barrier.
       client.putValue("/barrier-ready/$testId/$participantId", "1")
       val timedOut = !waitOnBarrier(initialTimeoutMs.milliseconds)
-      // The first wait should time out while the controller still has the barrier set;
-      // the second wait blocks until the controller removes it.
       val unblocked = waitOnBarrier()
-      val unblockTs = System.currentTimeMillis()
 
-      ParticipantResult(
+      result(
         testId = testId,
         participantId = participantId,
-        role = "$recipe/$role",
         success = timedOut && unblocked,
-        payloadJson =
-          encodePayload(
-            BarrierWaiterPayload(
-              timeoutObserved = timedOut,
-              unblocked = unblocked,
-              unblockTimestampMs = unblockTs,
-            ),
+        payload =
+          BarrierWaiterPayload(
+            timeoutObserved = timedOut,
+            unblocked = unblocked,
+            unblockTimestampMs = System.currentTimeMillis(),
           ),
       )
     }

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/CounterIncrementRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/CounterIncrementRunner.kt
@@ -47,17 +47,14 @@ object CounterIncrementRunner : RecipeRunner {
       repeat(incrementCount) { last = increment() }
     }
 
-    return ParticipantResult(
+    return result(
       testId = testId,
       participantId = participantId,
-      role = "$recipe/$role",
       success = true,
-      payloadJson =
-        encodePayload(
-          CounterIncrementPayload(
-            incrementsApplied = incrementCount,
-            lastObservedValue = last,
-          ),
+      payload =
+        CounterIncrementPayload(
+          incrementsApplied = incrementCount,
+          lastObservedValue = last,
         ),
     )
   }

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ElectionParticipantRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ElectionParticipantRunner.kt
@@ -57,18 +57,15 @@ object ElectionParticipantRunner : RecipeRunner {
       waitOnLeadershipComplete()
     }
 
-    return ParticipantResult(
+    return result(
       testId = testId,
       participantId = participantId,
-      role = "$recipe/$role",
       success = tookLeadership && relinquished,
-      payloadJson =
-        encodePayload(
-          ElectionParticipantPayload(
-            tookLeadership = tookLeadership,
-            relinquished = relinquished,
-            clientId = clientId,
-          ),
+      payload =
+        ElectionParticipantPayload(
+          tookLeadership = tookLeadership,
+          relinquished = relinquished,
+          clientId = clientId,
         ),
     )
   }

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/Main.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/Main.kt
@@ -37,6 +37,20 @@ interface RecipeRunner {
   ): ParticipantResult
 }
 
+internal inline fun <reified P> RecipeRunner.result(
+  testId: String,
+  participantId: String,
+  success: Boolean,
+  payload: P,
+): ParticipantResult =
+  ParticipantResult(
+    testId = testId,
+    participantId = participantId,
+    role = "$recipe/$role",
+    success = success,
+    payloadJson = encodePayload(payload),
+  )
+
 private val runners: Map<Pair<String, String>, RecipeRunner> =
   listOf(
     BarrierWaiterRunner,

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/QueueConsumerRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/QueueConsumerRunner.kt
@@ -46,12 +46,11 @@ object QueueConsumerRunner : RecipeRunner {
         List(itemCount) { dequeue().asString }
       }
 
-    return ParticipantResult(
+    return result(
       testId = testId,
       participantId = participantId,
-      role = "$recipe/$role",
       success = items.size == itemCount,
-      payloadJson = encodePayload(QueueConsumerPayload(items = items)),
+      payload = QueueConsumerPayload(items = items),
     )
   }
 }

--- a/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ServiceRegistrationRunner.kt
+++ b/etcd-recipes-test-runners/src/main/kotlin/io/etcd/recipes/runners/ServiceRegistrationRunner.kt
@@ -56,29 +56,27 @@ object ServiceRegistrationRunner : RecipeRunner {
     return withServiceDiscovery(client, servicePath) {
       registerService(instance)
 
-      // Block until the orchestrator (running on the host JVM) signals shutdown
-      // by writing any value to shutdownKey. Polling is fine here — service
-      // discovery tests don't measure latency, and a watch would complicate
-      // the runner without buying anything.
+      // Block until the orchestrator (host JVM) writes shutdownKey.
       val deadline = System.currentTimeMillis() + maxWaitMs
-      while (System.currentTimeMillis() < deadline && !client.isKeyPresent(shutdownKey)) {
+      var signalled = false
+      while (System.currentTimeMillis() < deadline) {
+        if (client.isKeyPresent(shutdownKey)) {
+          signalled = true
+          break
+        }
         sleep(200.milliseconds)
       }
 
-      val signalled = client.isKeyPresent(shutdownKey)
       unregisterService(instance)
 
-      ParticipantResult(
+      result(
         testId = testId,
         participantId = participantId,
-        role = "$recipe/$role",
         success = signalled,
-        payloadJson =
-          encodePayload(
-            ServiceRegistrationPayload(
-              serviceName = serviceName,
-              instanceId = instance.id,
-            ),
+        payload =
+          ServiceRegistrationPayload(
+            serviceName = serviceName,
+            instanceId = instance.id,
           ),
       )
     }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerTestSupport.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/container/ContainerTestSupport.kt
@@ -51,6 +51,8 @@ internal fun <R> useContainers(
   try {
     return block()
   } finally {
-    containers.forEach { runCatching { it.stop() } }
+    runBlocking(Dispatchers.IO) {
+      containers.map { async { runCatching { it.stop() } } }.awaitAll()
+    }
   }
 }


### PR DESCRIPTION
## Summary
Follow-up cleanups identified by a code-review pass over the multi-container test variant landed in #28. No behavior changes; all five container tests pass before and after.

- `RecipeRunner.result(...)` helper folds the repeated `ParticipantResult` construction across the five runners (eliminates the duplicated `role = "$recipe/$role"` / `payloadJson = encodePayload(...)` plumbing).
- `ContainerTestSupport.useContainers` now stops containers in parallel via `awaitAll`, matching the parallel start path.
- `ServiceRegistrationRunner` drops a redundant `isKeyPresent` query after the polling loop — captures the signalled state inside the loop instead.
- A couple of narrating comments trimmed; comments that explain non-obvious race-condition fixes and Gradle/etcd workarounds are kept.

## Test plan
- [x] `make tests-container` — all five container tests pass (faster than before, mostly from parallel shutdown)
- [x] `./gradlew lintKotlin` clean
- [x] `./gradlew :etcd-recipes-test-runners:detekt` clean
- [ ] CI run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)