### PR TITLE
Refresh project documentation for 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,60 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.10.html).
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-05-13
 
-## [0.1.0] - 2019-10-14
 ### Added
-- Initial commit.
+
+- Multi-container test variant. Each distributed-recipe participant now runs in its own
+  container against a shared etcd container, complementing the existing thread-based
+  tests. Lives in `etcd-recipes-test-runners/` (a runnable shadow JAR dispatched by
+  `--recipe`/`--role`) plus `ContainerBarrierTest`, `ContainerLeaderSelectorTest`,
+  `ContainerQueueTest`, `ContainerCounterTest`, and `ContainerServiceDiscoveryTest`.
+  Gated by `-PuseTestcontainers`. (#28, #29)
+- `make tests-container` target for running just the multi-container tests.
+- Testcontainers test mode: `-PuseTestcontainers` (or `make tests-tc`) runs every test
+  against an ephemeral etcd container instead of `localhost:2379`. (#24)
+- CI workflow (`.github/workflows/ci.yml`) running `check` under Testcontainers on
+  pushes and PRs to `master`. (#24)
+- Dokka-generated API docs, Kover coverage reports, Codecov upload, and Detekt v2
+  static analysis. (#25, #26)
+- Kotest test framework alongside the existing JUnit 5 setup; new tests use
+  `StringSpec` with an `init {}` block. (#20)
 
 ### Changed
 
-### Removed
+- Replaced Jacoco with [Kover](https://github.com/Kotlin/kotlinx-kover) for coverage. (#25)
+- Replaced Java DSL build with Gradle 9 + Kotlin DSL; dependency versions moved to a
+  Gradle version catalog (`gradle/libs.versions.toml`). (#20)
+- Test suite is ~7× faster after switching fixed `sleep(...)` settle calls to poll-based
+  waits, plus parallel forking via `maxParallelForks`. Each test class runs in its own
+  forked JVM (`forkEvery=1`) so background threads can't leak across specs.
+- Migrated atomic primitives to the stdlib `kotlin.concurrent.atomics` package; dropped
+  the `kotlinx-atomicfu` plugin and its compile-time dependency.
+- `Makefile` rewritten with lazy version guards, a `help` target, and `lintKotlin` as
+  the lint entry point. (#26, #27)
 
+### Fixed
+
+- Lease leaks, close-ordering, and counter races across recipes. (#23)
+- `ServiceCache.close()` deadlock when no watch events arrived; `LeaderSelector` could
+  not be reused after `close()`; `DistributedBarrierWithCount.waitOnBarrier` missed peer
+  joins because it watched a per-client unique path instead of the shared waiting
+  prefix. (#22)
+- Vert.x event-loop deadlocks in `LeaderSelector` and `AbstractQueue` caused by
+  callbacks holding locks across gRPC responses. (#21)
+
+## [0.9.20] - 2021-08-08
+
+- Earlier history not transcribed; see git tags for individual releases between
+  0.1.0 (2019-10-14) and 0.9.20.
+
+## [0.1.0] - 2019-10-14
+
+### Added
+
+- Initial commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Build, Test, Lint
 
-JDK 17 toolchain (configured in `build.gradle.kts` via `kotlin { jvmToolchain(17) }`). Gradle wrapper is pinned to 9.5.0. Common entry points are in the `Makefile`:
+JDK 17 toolchain (configured in `build.gradle.kts` via `kotlin { jvmToolchain(17) }`). Gradle wrapper is pinned to 9.5.0. Common entry points are in the `Makefile` (`make help` lists everything):
 
 - `make build` — `./gradlew clean build -xtest` (build without running tests)
-- `make tests` — `./gradlew check jacocoTestReport` (runs all tests + coverage)
-- `make lint` — `./gradlew lintKotlinMain lintKotlinTest`
+- `make tests` — full test suite against a local etcd at `localhost:2379`
+- `make tests-tc` — full suite against an ephemeral Testcontainers etcd (no local etcd needed)
+- `make tests-container` — multi-container tests only (each participant in its own container)
+- `make lint` — `./gradlew lintKotlin detekt`
+- `make coverage` — Kover HTML + XML reports + summary
+- `make kdocs` — Dokka HTML / Javadoc
 - `make versioncheck` — `./gradlew dependencyUpdates --no-parallel`
 - `make refresh` — refresh dependencies
 - `make upgrade-wrapper` — bumps the Gradle wrapper
@@ -21,15 +25,17 @@ Run a single test class:
 ```
 ./gradlew :etcd-recipes:test --tests "io.etcd.recipes.barrier.DistributedBarrierTests"
 ```
-Tests use JUnit 5 (`useJUnitPlatform()`) plus Kluent assertions; some tests use Kotest. When adding new Kotlin tests, prefer Kotest with `StringSpec()` and an `init {}` block, plus MockK where appropriate.
+Tests use JUnit 5 (`useJUnitPlatform()`) plus Kotest and Kluent assertions. When adding new Kotlin tests, prefer Kotest with `StringSpec()` and an `init {}` block, plus MockK where appropriate. Coverage is Kover (the project moved off Jacoco in 0.10.0).
 
 ## Running etcd locally
 
-Tests and examples expect a local etcd at `http://localhost:2379`. Start one with the helper script:
+The `make tests` target and the examples expect a local etcd at `http://localhost:2379`. Start one with the helper script:
 ```
 ./etcd.sh
 ```
 which runs `etcd --listen-client-urls=http://localhost:2379 --advertise-client-urls=http://localhost:2379`. The local data directory `default.etcd/` is gitignored.
+
+`make tests-tc` and `make tests-container` use Testcontainers and require Docker — no local etcd is needed for those.
 
 ## Module Layout
 
@@ -39,13 +45,14 @@ Multi-module Gradle build (`settings.gradle.kts`):
   - `barrier/` — `DistributedBarrier`, `DistributedBarrierWithCount`, `DistributedDoubleBarrier`
   - `cache/` — `PathChildrenCache`
   - `counter/` — `DistributedAtomicLong`
-  - `discovery/` — `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`
-  - `election/` — `LeaderSelector`, `LeaderReporter`
+  - `discovery/` — `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`, `ServiceProvider`
+  - `election/` — `LeaderSelector`, `LeaderSelectorListener`, `Participant`
   - `keyvalue/` — `TransientKeyValue`
   - `queue/` — `DistributedQueue`, `DistributedPriorityQueue` (share `AbstractQueue`)
   - `common/` — extension functions over jetcd's `Client`/`KV`/`Lease`/`Watch`/`Txn` and shared base infrastructure (see below)
   - `util/` — small CLI utilities (`ShowKeys`, etc.)
 - **`etcd-recipes-examples/`** — runnable Java and Kotlin examples mirroring each recipe; useful as living documentation. Examples are typically `main()` programs that call into the library.
+- **`etcd-recipes-test-runners/`** — test-only module. A runnable shadow JAR with a dispatcher `main()` that routes on `--recipe`/`--role` to per-recipe runners (barrier waiter, election participant, queue consumer, counter incrementer, service registration). Used by the container-based tests under `etcd-recipes/src/test/kotlin/io/etcd/recipes/container/`; each participant runs as its own Testcontainers container against a shared etcd container. Wired into the library's test task only when `-PuseTestcontainers` is set.
 
 ## Architecture notes
 
@@ -55,7 +62,15 @@ The recipes are layered on a thin Kotlin extension layer over jetcd, not a wrapp
 - **`EtcdConnector`** (`common/EtcdConnector.kt`) is the shared base for stateful recipes. It owns the jetcd `Client`, tracks `startCalled` / `closeCalled` lifecycle (atomic flags), accumulates background-thread exceptions in `exceptionList`, and implements `Closeable`. Recipes generally follow a `start()` … `close()` lifecycle and surface async failures via `exceptions` rather than throwing from a worker thread.
 - **`EtcdRecipeException` / `EtcdRecipeRuntimeException`** are the library's own exception types — prefer these over leaking jetcd exception types.
 - **Concurrency**: recipes rely on `kotlinx-coroutines`, `kotlin.concurrent.atomics` (stdlib `AtomicBoolean` / `AtomicReference`), and helpers from `com.pambrose.common-utils` (`BooleanMonitor`). Several Kotlin opt-ins are enabled compiler-wide: `kotlin.time.ExperimentalTime`, `kotlin.ExperimentalUnsignedTypes`, `kotlin.concurrent.atomics.ExperimentalAtomicApi` — assume these are available without per-file `@OptIn`.
+- **Watcher callbacks** run on jetcd's Vert.x event loop. Anything that needs another gRPC response (or contends with a lock the caller holds while waiting on gRPC) will deadlock the event loop. The `Client.watcher` extension hops callbacks onto a dedicated single-thread executor; recipes should still avoid blocking the callback on locks held by callers waiting on gRPC.
+
+## Tests
+
+- **Thread-based** (`*Tests.kt` under each recipe directory) — N threads in a single JVM simulate distributed clients via `blockingThreads(...)` / `nonblockingThreads(...)` in `etcd-recipes/src/test/kotlin/io/etcd/recipes/common/TestExtensions.kt`.
+- **Container-based** (`etcd-recipes/src/test/kotlin/io/etcd/recipes/container/Container*Test.kt`) — each participant runs as its own container coordinating through a shared etcd container. Uses `EtcdContainerNetwork`, `Participant.newContainer(...)`, and `Client.awaitResults(...)` from the `common/` test fixtures. The runners write their outcome to `/test-results/{testId}/{participantId}` as JSON; orchestrators decode the per-recipe payload type via the `ParticipantResult.payload<T>()` extension. Gated by `assumeTrue(testcontainers=true)` so default `./gradlew check` skips them cleanly.
+
+Test JVMs fork per class (`forkEvery=1`) so background threads / etcd watch connections from one spec don't interfere with the next. `maxParallelForks = cores/2` lets multiple test classes run concurrently against the same etcd; each test namespaces its keys by class name to avoid collisions.
 
 ## Versioning
 
-The current development branch is named after the version (e.g. `0.9.22`). Library version is defined in `build.gradle.kts`; Kotlin/dependency versions live in `gradle.properties`; bump both when releasing.
+The current development branch is named after the version (e.g. `0.10.0`). Library version lives in `gradle.properties` (`version=...`); Kotlin/dependency versions live in `gradle/libs.versions.toml`; bump both when releasing.

--- a/README.md
+++ b/README.md
@@ -135,31 +135,48 @@ JDK 17 is required (the build is configured with a Kotlin JVM toolchain of 17). 
 is checked in, so no local Gradle install is needed.
 
 ```
-./gradlew clean build -xtest    # build without running tests
-./gradlew check                 # run all tests + jacoco coverage
-./gradlew lintKotlinMain lintKotlinTest
+./gradlew clean build -xtest      # build without running tests
+./gradlew check                   # run all tests + Kover coverage
+./gradlew lintKotlin              # kotlinter + detekt
 ```
 
-A `Makefile` wraps the most common entry points:
+A `Makefile` wraps the most common entry points (`make help` lists everything):
 
 ```
-make build          # ./gradlew clean build -xtest
-make tests          # ./gradlew check jacocoTestReport
-make lint           # ./gradlew lintKotlinMain lintKotlinTest
-make versioncheck   # ./gradlew dependencyUpdates --no-parallel
+make build              # clean + build, skipping tests
+make tests              # full test suite against a local etcd at localhost:2379
+make tests-tc           # full test suite against an ephemeral Testcontainers etcd
+make tests-container    # multi-container variant: each participant in its own container
+make lint               # kotlinter + detekt
+make coverage           # Kover HTML + XML reports
+make kdocs              # Dokka HTML / Javadoc
+make versioncheck       # gradle dependencyUpdates
 ```
 
-The integration tests and examples expect a local etcd at `http://localhost:2379`. Start one with:
+`make tests` and the examples expect a local etcd at `http://localhost:2379`. Start one with:
 
 ```
 ./etcd.sh
 ```
+
+`make tests-tc` and `make tests-container` stand up etcd via Testcontainers and require Docker.
 
 To run a single test class:
 
 ```
 ./gradlew :etcd-recipes:test --tests "io.etcd.recipes.barrier.DistributedBarrierTests"
 ```
+
+### Test variants
+
+Two complementary variants of the distributed-coordination tests live in the repo:
+
+- **Thread-based** (`*Tests.kt` under each recipe directory) — N threads in a single JVM
+  simulate distributed clients. Fast; runs by default.
+- **Container-based** (`container/Container*Test.kt`) — each participant runs in its own
+  container against a shared etcd container, exercising true cross-process coordination.
+  Built from the `etcd-recipes-test-runners` submodule's shadow JAR. Gated by
+  `-PuseTestcontainers`; run via `make tests-container`.
 
 ## Contributing
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,57 @@
+# Release Notes
+
+## 0.10.0 — 2026-05-13
+
+The 0.10.0 release modernizes the build, hardens the recipes against several races
+discovered under heavier test coverage, and adds a second test variant that drives
+each distributed participant from its own container.
+
+### Highlights
+
+**Multi-container test variant.** The thread-based tests simulate distributed clients
+with N threads in a single JVM. A new variant runs each participant as its own
+container coordinating through a shared etcd container. Five tests cover the
+coordination-heavy recipes (barrier, leader election, queue, counter, service
+discovery). Live alongside the thread tests under `-PuseTestcontainers`, or invoked
+directly with `make tests-container`.
+
+**Testcontainers test mode.** `-PuseTestcontainers` (also `make tests-tc`) runs every
+test against an ephemeral etcd container instead of `localhost:2379`. CI exercises
+this mode on every push and PR.
+
+**Build modernization.** Gradle 9 with the Kotlin DSL; dependencies tracked in
+`gradle/libs.versions.toml`; Dokka for API docs; Kover (replacing Jacoco) for coverage
+with Codecov upload; Detekt v2 for static analysis; Kotest alongside JUnit 5.
+
+**Concurrency fixes.** Several long-standing races have been closed:
+
+- Vert.x event-loop deadlocks in `LeaderSelector` and `AbstractQueue` where callbacks
+  held a lock while a gRPC response was pending.
+- `ServiceCache.close()` deadlock when no watch events ever arrived; the
+  `startThreadComplete` signal now fires in `start()` rather than inside the watcher
+  callback.
+- `LeaderSelector` could not be reused after `close()` because the internal
+  `ExecutorService` was shut down; `start()` now re-creates the executor if necessary.
+- `DistributedBarrierWithCount.waitOnBarrier` watched a per-client unique path rather
+  than the shared waiting prefix, so peer joins were missed and the barrier could
+  hang.
+- Lease leaks, close-ordering bugs, and counter races across recipes.
+
+**Performance.** The test suite is ~7× faster after switching fixed `sleep(...)`
+settle calls to poll-based waits and forking each test class into its own JVM with
+`maxParallelForks`.
+
+### Upgrading
+
+- JDK 17 toolchain (was JDK 8 in earlier releases).
+- `kotlinx-atomicfu` has been removed in favor of `kotlin.concurrent.atomics` from
+  the stdlib. Recipes that previously imported `kotlinx.atomicfu.AtomicBoolean` should
+  now import `kotlin.concurrent.atomics.AtomicBoolean` and use `.load()` / `.store()`.
+
+### Maven coordinates
+
+```kotlin
+implementation("com.pambrose.etcd-recipes:etcd-recipes:0.10.0")
+```
+
+See `CHANGELOG.md` for the full list of changes since 0.9.20.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,54 @@
+# etcd-recipes
+
+> Kotlin/Java/JVM client library for [etcd](https://etcd.io) v3, built on top of
+> [jetcd](https://github.com/etcd-io/jetcd). Provides higher-level distributed
+> coordination primitives — barriers, leader election, queues, distributed counters,
+> service discovery, key/prefix caches — analogous to what
+> [Apache Curator](https://curator.apache.org) provides for ZooKeeper.
+
+The library is a thin Kotlin extension layer over jetcd, not a wrapper. New recipes
+compose the `common/` extensions (`ClientExtensions`, `KVExtensions`, `LeaseExtensions`,
+`WatchExtensions`, `TxnExtensions`, `ByteSequenceExtensions`) rather than reaching into
+jetcd directly. Stateful recipes extend `EtcdConnector` (in `common/`), which owns the
+jetcd `Client`, tracks `startCalled` / `closeCalled`, and accumulates background-thread
+exceptions for the caller to inspect rather than throwing from worker threads.
+
+JDK 17+ runtime. Compiler-wide opt-ins for `kotlin.time.ExperimentalTime`,
+`kotlin.ExperimentalUnsignedTypes`, and `kotlin.concurrent.atomics.ExperimentalAtomicApi`.
+
+## Docs
+
+- [README](README.md): library overview, usage examples, build/test instructions
+- [CHANGELOG](CHANGELOG.md): version history
+- [CLAUDE.md](CLAUDE.md): contributor guide aimed at LLM tooling — module layout, architecture, build entry points
+- [RELEASE_NOTES](RELEASE_NOTES.md): release-by-release highlights
+
+## Recipes
+
+- `io.etcd.recipes.barrier` — `DistributedBarrier`, `DistributedBarrierWithCount`, `DistributedDoubleBarrier`
+- `io.etcd.recipes.cache` — `PathChildrenCache` (key-prefix cache with PUT/UPDATE/DELETE listeners)
+- `io.etcd.recipes.counter` — `DistributedAtomicLong`
+- `io.etcd.recipes.discovery` — `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`, `ServiceProvider`
+- `io.etcd.recipes.election` — `LeaderSelector`, `LeaderSelectorListener`, `Participant`
+- `io.etcd.recipes.keyvalue` — `TransientKeyValue` (lease-backed key/value)
+- `io.etcd.recipes.queue` — `DistributedQueue`, `DistributedPriorityQueue`
+- `io.etcd.recipes.common` — Kotlin extensions over jetcd `Client`/`KV`/`Lease`/`Watch`/`Txn`
+
+## Examples
+
+Every recipe has runnable `main()` demos under `etcd-recipes-examples/` in both
+[Kotlin](etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/) and
+[Java](etcd-recipes-examples/src/main/java/io/etcd/recipes/examples/).
+
+## Testing
+
+- `make tests` — thread-based tests against a local etcd at `localhost:2379`
+- `make tests-tc` — same suite against a Testcontainers-managed etcd (no local etcd needed)
+- `make tests-container` — multi-container variant: each participant runs in its own
+  container coordinating through a shared etcd container
+
+## Optional
+
+- [Source repository](https://github.com/pambrose/etcd-recipes)
+- [Maven Central artifact](https://central.sonatype.com/artifact/com.pambrose.etcd-recipes/etcd-recipes)
+- [jetcd](https://github.com/etcd-io/jetcd) — the underlying etcd v3 Java client


### PR DESCRIPTION
## Summary
Bring the docs in line with everything that's landed since 0.9.20.

- `CHANGELOG.md` — add 0.10.0 (2026-05-13) section grouping the changes by Added / Changed / Fixed with PR references.
- `RELEASE_NOTES.md` (new) — narrative summary of 0.10.0 plus an upgrade note covering JDK 17 and the `kotlinx.atomicfu` → `kotlin.concurrent.atomics` migration.
- `llms.txt` (new) — llmstxt.org-style entry point pointing at README, CHANGELOG, CLAUDE.md, and RELEASE_NOTES, with a recipe inventory and test-variant summary.
- `README.md` — replace stale make-target references (`jacocoTestReport`, etc.) with the current set (`tests-tc`, `tests-container`, `coverage`, `kdocs`) and add a 'Test variants' section.
- `CLAUDE.md` — document the new `etcd-recipes-test-runners` submodule and container-based test fixtures, mention Kover (not Jacoco), call out the Vert.x event-loop watcher-callback constraint, and point the version field at `gradle.properties`.

## Test plan
- [x] No code changes; doc-only.
- [x] Cross-checked version numbers and the 0.10.0 release date across all five files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)