### PR TITLE
Fix Maven Central coordinates in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-05-15
+
+Maintenance release: build/static-analysis tidy-up and documentation fixes. No
+API or behavior changes.
+
+### Changed
+
+- detekt is now driven by `config/detekt/detekt.yml` layered on the bundled
+  defaults (`buildUponDefaultConfig`); `MagicNumber` and `TooManyFunctions` are
+  disabled there. Wildcard imports expanded to explicit imports, targeted
+  `@Suppress` annotations added, and both `detekt-baseline.xml` files removed. (#31)
+- Upgraded the Gradle wrapper 9.5.0 → 9.5.1. (#31)
+- Dropped the library's own `String.ensureSuffix` extension in favor of
+  `com.pambrose.common.util.ensureSuffix`. (#31)
+
+### Fixed
+
+- Maven Central coordinates in the docs were `com.pambrose.etcd-recipes:etcd-recipes`;
+  the published artifact is `com.pambrose:etcd-recipes`. Corrected the README badge
+  and dependency snippets, `llms.txt`, and `RELEASE_NOTES.md`. (#32)
+
+### Removed
+
+- Dead codebeat and SonarCloud badges from the README. (#31)
+
 ## [0.10.0] - 2026-05-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,4 +73,4 @@ Test JVMs fork per class (`forkEvery=1`) so background threads / etcd watch conn
 
 ## Versioning
 
-The current development branch is named after the version (e.g. `0.10.0`). Library version lives in `gradle.properties` (`version=...`); Kotlin/dependency versions live in `gradle/libs.versions.toml`; bump both when releasing.
+The current development branch is named after the version (e.g. `0.10.1`). Library version lives in `gradle.properties` (`version=...`); Kotlin/dependency versions live in `gradle/libs.versions.toml`; bump both when releasing.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.pambrose:etcd-recipes:0.10.0")
+    implementation("com.pambrose:etcd-recipes:0.10.1")
 }
 ```
 
@@ -97,7 +97,7 @@ If you use a version catalog (`gradle/libs.versions.toml`):
 
 ```toml
 [versions]
-etcd-recipes = "0.10.0"
+etcd-recipes = "0.10.1"
 
 [libraries]
 etcd-recipes = { module = "com.pambrose:etcd-recipes", version.ref = "etcd-recipes" }
@@ -111,7 +111,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.pambrose:etcd-recipes:0.10.0'
+    implementation 'com.pambrose:etcd-recipes:0.10.1'
 }
 ```
 
@@ -122,7 +122,7 @@ dependencies {
     <dependency>
         <groupId>com.pambrose</groupId>
         <artifactId>etcd-recipes</artifactId>
-        <version>0.10.0</version>
+        <version>0.10.1</version>
     </dependency>
 </dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # etcd Recipes
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.pambrose.etcd-recipes/etcd-recipes.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.pambrose.etcd-recipes/etcd-recipes)
+[![Maven Central](https://img.shields.io/maven-central/v/com.pambrose/etcd-recipes.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.pambrose/etcd-recipes)
 [![CI](https://github.com/pambrose/etcd-recipes/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/pambrose/etcd-recipes/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/e185b9c637b040bab55bdecf38b0de76)](https://www.codacy.com/manual/pambrose/etcd-recipes?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=pambrose/etcd-recipes&amp;utm_campaign=Badge_Grade)
@@ -89,7 +89,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.pambrose.etcd-recipes:etcd-recipes:0.10.0")
+    implementation("com.pambrose:etcd-recipes:0.10.0")
 }
 ```
 
@@ -100,7 +100,7 @@ If you use a version catalog (`gradle/libs.versions.toml`):
 etcd-recipes = "0.10.0"
 
 [libraries]
-etcd-recipes = { module = "com.pambrose.etcd-recipes:etcd-recipes", version.ref = "etcd-recipes" }
+etcd-recipes = { module = "com.pambrose:etcd-recipes", version.ref = "etcd-recipes" }
 ```
 
 ### Gradle (Groovy DSL)
@@ -111,7 +111,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.pambrose.etcd-recipes:etcd-recipes:0.10.0'
+    implementation 'com.pambrose:etcd-recipes:0.10.0'
 }
 ```
 
@@ -120,7 +120,7 @@ dependencies {
 ```xml
 <dependencies>
     <dependency>
-        <groupId>com.pambrose.etcd-recipes</groupId>
+        <groupId>com.pambrose</groupId>
         <artifactId>etcd-recipes</artifactId>
         <version>0.10.0</version>
     </dependency>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,7 +51,7 @@ settle calls to poll-based waits and forking each test class into its own JVM wi
 ### Maven coordinates
 
 ```kotlin
-implementation("com.pambrose.etcd-recipes:etcd-recipes:0.10.0")
+implementation("com.pambrose:etcd-recipes:0.10.0")
 ```
 
 See `CHANGELOG.md` for the full list of changes since 0.9.20.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,34 @@
 # Release Notes
 
+## 0.10.1 — 2026-05-15
+
+Maintenance release. No API or behavior changes — just build, static-analysis,
+and documentation tidy-up.
+
+### Highlights
+
+**detekt configuration.** Static analysis is now driven by a checked-in
+`config/detekt/detekt.yml` layered on detekt's bundled defaults. `MagicNumber` and
+`TooManyFunctions` are disabled there rather than masked by per-module
+`detekt-baseline.xml` files (both removed); wildcard imports were expanded to
+explicit imports and a handful of targeted `@Suppress` annotations added.
+
+**Gradle wrapper.** Upgraded 9.5.0 → 9.5.1.
+
+**Internal cleanup.** Dropped the library's own `String.ensureSuffix` extension in
+favor of `com.pambrose.common.util.ensureSuffix`.
+
+**Documentation.** Fixed the Maven Central coordinates throughout the docs — the
+published artifact is `com.pambrose:etcd-recipes`, not
+`com.pambrose.etcd-recipes:etcd-recipes`. Removed the dead codebeat and SonarCloud
+README badges.
+
+### Maven coordinates
+
+```kotlin
+implementation("com.pambrose:etcd-recipes:0.10.1")
+```
+
 ## 0.10.0 — 2026-05-13
 
 The 0.10.0 release modernizes the build, hardens the recipes against several races

--- a/llms.txt
+++ b/llms.txt
@@ -50,5 +50,5 @@ Every recipe has runnable `main()` demos under `etcd-recipes-examples/` in both
 ## Optional
 
 - [Source repository](https://github.com/pambrose/etcd-recipes)
-- [Maven Central artifact](https://central.sonatype.com/artifact/com.pambrose.etcd-recipes/etcd-recipes)
+- [Maven Central artifact](https://central.sonatype.com/artifact/com.pambrose/etcd-recipes)
 - [jetcd](https://github.com/etcd-io/jetcd) — the underlying etcd v3 Java client


### PR DESCRIPTION
## Summary
The docs advertised the wrong Maven coordinates. The published artifact is `com.pambrose:etcd-recipes` — the group is `com.pambrose` (per `gradle.properties`), verified against `repo1.maven.org`. The docs incorrectly used `com.pambrose.etcd-recipes` as the group.

- `README.md` — Maven Central badge (shields.io image URL + central.sonatype.com link) and all four dependency snippets (Gradle Kotlin DSL, version catalog, Gradle Groovy DSL, Maven `<groupId>`)
- `llms.txt` — Maven Central artifact link
- `RELEASE_NOTES.md` — the `implementation(...)` coordinate

## Test plan
- [x] Verified `com.pambrose:etcd-recipes` resolves on Maven Central (`repo1.maven.org/maven2/com/pambrose/etcd-recipes/maven-metadata.xml`), `com.pambrose.etcd-recipes:etcd-recipes` 404s
- [x] `grep` confirms no `com.pambrose.etcd-recipes` coordinate strings remain in docs
- Docs-only; no build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)