### PR TITLE
Revoke leases on failed CAS in barrier and leader selector

### DIFF
--- a/etcd-recipes-test-runners/build.gradle.kts
+++ b/etcd-recipes-test-runners/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.gradleup.shadow") version "9.4.1"
+    alias(libs.plugins.shadow)
 }
 
 dependencies {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -40,6 +40,7 @@ import io.etcd.recipes.common.getValue
 import io.etcd.recipes.common.isKeyPresent
 import io.etcd.recipes.common.keepAlive
 import io.etcd.recipes.common.leaseGrant
+import io.etcd.recipes.common.leaseRevoke
 import io.etcd.recipes.common.putOption
 import io.etcd.recipes.common.setTo
 import io.etcd.recipes.common.transaction
@@ -181,10 +182,14 @@ constructor(
 
       when {
         !txn.isSucceeded -> {
+          // Revoke the lease we just granted; otherwise it lingers in etcd
+          // until its TTL expires — wasteful in tight retry loops.
+          client.leaseRevoke(lease)
           throw EtcdRecipeException("Failed to set waitingPath")
         }
 
         client.getValue(myWaitingPath)?.asString != uniqueToken -> {
+          client.leaseRevoke(lease)
           throw EtcdRecipeException("Failed to assign waitingPath unique value")
         }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -272,7 +272,8 @@ constructor(
   }
 
   @Throws(EtcdRecipeException::class)
-  private fun advertiseParticipation() {
+  // internal (not private) so lease-cleanup behavior can be unit-tested directly.
+  internal fun advertiseParticipation() {
     val path = electionPath.withParticipationSuffix.appendToPath(clientId)
 
     // Wait until key goes away when previous keep alive finishes
@@ -298,6 +299,9 @@ constructor(
       }
 
     if (!txn.isSucceeded) {
+      // Revoke the lease we just granted; otherwise it lingers in etcd until
+      // its TTL expires whenever registration loses the CAS.
+      client.leaseRevoke(lease)
       throw EtcdRecipeException("Participation registration failed [$path]")
     }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCountLeaseTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCountLeaseTests.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.barrier
+
+import io.etcd.recipes.common.EtcdRecipeException
+import io.etcd.recipes.common.FailingLeaseMocks
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.verify
+
+class DistributedBarrierWithCountLeaseTests : StringSpec() {
+    init {
+        // Regression test: when the CAS that claims the waiting-path key fails,
+        // waitOnBarrier() must revoke the lease it just granted instead of
+        // letting it linger in etcd until its TTL expires.
+        "revokes the granted lease when the waiting-path CAS fails" {
+            val mocks = FailingLeaseMocks(leaseId = 42L)
+
+            DistributedBarrierWithCount(mocks.client, "/barrier", memberCount = 1).use { barrier ->
+                shouldThrow<EtcdRecipeException> { barrier.waitOnBarrier() }
+            }
+
+            verify(exactly = 1) { mocks.lease.revoke(mocks.leaseId) }
+        }
+    }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/FailingLeaseMocks.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/FailingLeaseMocks.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.Lease
+import io.etcd.jetcd.Txn
+import io.etcd.jetcd.kv.TxnResponse
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.lease.LeaseRevokeResponse
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+
+/**
+ * MockK fixture for a [Client] whose every transaction reports failure and whose
+ * lease grant returns [leaseId]. Drives a recipe's "lease granted, then CAS fails"
+ * path so a test can assert the lease is revoked. Expose [lease] so the caller can
+ * `verify { lease.revoke(leaseId) }`.
+ */
+internal class FailingLeaseMocks(
+  val leaseId: Long,
+) {
+    val lease = mockk<Lease>()
+    val client: Client
+
+    init {
+        val txn = mockk<Txn>()
+        val failedTxn = mockk<TxnResponse> { every { isSucceeded } returns false }
+        every { txn.If(*anyVararg()) } returns txn
+        every { txn.Then(*anyVararg()) } returns txn
+        every { txn.commit() } returns CompletableFuture.completedFuture(failedTxn)
+
+        val kv = mockk<KV> { every { txn() } returns txn }
+
+        val granted = mockk<LeaseGrantResponse> { every { id } returns leaseId }
+        every { lease.grant(any()) } returns CompletableFuture.completedFuture(granted)
+        every { lease.revoke(leaseId) } returns CompletableFuture.completedFuture(mockk<LeaseRevokeResponse>())
+
+        client =
+            mockk {
+                every { kvClient } returns kv
+                every { leaseClient } returns lease
+            }
+    }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorLeaseTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorLeaseTests.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.election
+
+import io.etcd.recipes.common.EtcdRecipeException
+import io.etcd.recipes.common.FailingLeaseMocks
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.concurrent.Executor
+
+class LeaderSelectorLeaseTests : StringSpec() {
+    init {
+        // Regression test: when the CAS that registers participation fails,
+        // advertiseParticipation() must revoke the lease it just granted instead
+        // of letting it linger in etcd until its TTL expires.
+        //
+        // A failing transaction also makes isKeyPresent() report absent, so the
+        // pre-CAS wait loop exits immediately rather than sleeping.
+        "revokes the granted lease when the participation CAS fails" {
+            val mocks = FailingLeaseMocks(leaseId = 99L)
+
+            val selector =
+                LeaderSelector(
+                    mocks.client,
+                    "/election",
+                    mockk<LeaderSelectorListener>(relaxed = true),
+                    leaseTtlSecs = 1L,
+                    // A direct executor avoids spinning up a real thread pool.
+                    userExecutor = Executor { it.run() },
+                )
+
+            shouldThrow<EtcdRecipeException> { selector.advertiseParticipation() }
+
+            verify(exactly = 1) { mocks.lease.revoke(mocks.leaseId) }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ gradle-wrapper = "9.5.1"
 jvm = "17"
 
 # Kotlin language and runtime
-kotlin = "2.4.0-RC"
+kotlin = "2.4.0-RC2"
 coroutines = "1.11.0"
 serialization = "1.11.0"
 
@@ -14,12 +14,13 @@ jetcd = "0.8.6"
 # Runtime libraries
 common-utils = "2.8.2"
 guava = "33.6.0-jre"
-kotlin-logging = "8.0.03"
-logback = "1.5.32"
+kotlin-logging = "8.0.4"
+logback = "1.5.33"
 
 # Testing
 junit = "6.1.0"
 kotest = "6.1.11"
+mockk = "1.14.9"
 testcontainers = "2.0.5"
 
 # Build tooling plugins
@@ -29,7 +30,7 @@ dokka = "2.2.0"
 kotlinter = "5.5.0"
 kover = "0.9.8"
 maven-publish = "0.36.0"
-shadow = "9.2.2"
+shadow = "9.4.2"
 
 [libraries]
 # Main library
@@ -50,6 +51,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 testcontainers-core = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 
 [bundles]
@@ -57,6 +59,7 @@ testing = [
   "junit-jupiter-api",
   "kotest-runner-junit5",
   "kotest-assertions-core",
+  "mockk",
   "testcontainers-core",
 ]
 testing-runtime = [


### PR DESCRIPTION
## Summary

Fixes two lease leaks where a granted etcd lease was abandoned (left to expire on its TTL) when a CAS transaction failed:

- **`DistributedBarrierWithCount.waitOnBarrier()`** — granted a lease, then threw on a failed waiting-path CAS (or failed value verification) without revoking it.
- **`LeaderSelector.advertiseParticipation()`** — granted a lease, then threw on a failed participation CAS without revoking it.

Both now revoke the lease before throwing, matching the pattern already used in `DistributedBarrier.setBarrier()`.

## Tests

- Added MockK regression tests for both paths, each verified to **fail without the fix** (the revoke is never called) and pass with it.
- Shared mock setup lives in a `FailingLeaseMocks` test fixture; `advertiseParticipation()` is `internal` (not `private`) so its lease-cleanup behavior is unit-tested directly without reflection.
- Introduced MockK into the version catalog (`libs.versions.toml`) and the `testing` bundle — the project's first mock-based tests. Neither test requires a live etcd.

## Build hygiene

- Wired `etcd-recipes-test-runners` to the shadow plugin via `alias(libs.plugins.shadow)` instead of a hardcoded version, with the catalog `shadow` entry at `9.4.2`.

(Supersedes #34, which GitHub auto-closed when its stacked base branch was deleted on merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)