### PR TITLE
Fix codecov 0% badge and tests-container Docker socket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,12 @@ jobs:
           # project has no Kotlin source for Kover 0.9's aggregation to
           # attach to; the per-subproject report has the real data.
           files: ./etcd-recipes/build/reports/kover/report.xml
+          # Do NOT let the action auto-discover reports. Search picks up the
+          # empty root aggregate plus the examples/test-runners reports (no
+          # main source / no tests), which report 0% and, when the named file
+          # is missing after a failed run, get uploaded *instead* of it —
+          # resetting the branch's coverage to 0%.
+          disable_search: true
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,14 @@ build: clean ## Clean and run a full build, skipping tests
 tests: ## Run the full test suite against a local etcd at localhost:2379
 	./gradlew check --rerun-tasks --no-build-cache
 
-# DOCKER_HOST defaults to Docker Desktop's "raw" socket on macOS. The
-# routing socket at ~/.docker/run/docker.sock returns a redirect stub
-# that docker-java can't follow, so we point at the daemon's socket
-# directly. Override with `DOCKER_HOST=unix://...` if needed.
+# DOCKER_HOST defaults to Docker Desktop's per-user routing socket on macOS
+# (~/.docker/run/docker.sock) — the same socket `docker context` and
+# ~/.testcontainers.properties use. Current Docker Desktop builds no longer
+# serve the "raw" socket under ~/Library/Containers/...; pointing at it makes
+# Testcontainers hang waiting on a dead socket. Override with
+# `DOCKER_HOST=unix://...` if your setup differs.
 ifeq ($(shell uname -s),Darwin)
-DOCKER_HOST ?= unix://$(HOME)/Library/Containers/com.docker.docker/Data/docker.raw.sock
+DOCKER_HOST ?= unix://$(HOME)/.docker/run/docker.sock
 endif
 
 tests-tc: ## Run the full test suite under Testcontainers (no local etcd required)


### PR DESCRIPTION
Two independent CI/build-infra fixes found while diagnosing the **0% Codecov badge**.

## 1. Codecov badge stuck at 0% (`ci.yml`)

The badge tracks `master`. The most recent master run failed on a flaky test *before* `koverXmlReport` ran, so the real `etcd-recipes` report was never generated. `codecov-action` runs with `disable_search: false` (default), so it then auto-discovered and uploaded the only reports present — all empty:

```
Found 3 coverage files to report
 > build/reports/kover/report.xml                       (root aggregate — empty)
 > etcd-recipes-test-runners/build/reports/kover/report.xml  (no main src)
 > etcd-recipes-examples/build/reports/kover/report.xml      (no tests)
```

That recorded master at 0%. **Fix:** `disable_search: true` so only the named report is uploaded. On green runs the real ~88% report uploads; on a failed run the named file is simply absent and Codecov uploads nothing, so the branch keeps its last good value instead of resetting to 0%. (These empty module reports were also dragging the % down on green runs.)

> Note: master also needs the flaky-test deflake (PR #36) to go green again so the next run uploads fresh coverage. This PR ensures a failure can't zero the badge in the first place.

## 2. `make tests-container` hangs (`Makefile`)

`DOCKER_HOST` defaulted to Docker Desktop's "raw" socket (`~/Library/Containers/.../docker.raw.sock`), which current Docker Desktop no longer serves — `docker info` against it times out, so Testcontainers blocks forever. **Fix:** default to the per-user routing socket `~/.docker/run/docker.sock`, which `docker context`, `~/.testcontainers.properties`, and `build.gradle.kts`'s own fallback already use. Verified `make tests-container` now runs all five container tests to `BUILD SUCCESSFUL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)