### PR TITLE
Fix lease leaks and surface keep-alive stream failures

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -99,7 +99,7 @@ constructor(
 
       // Check to see if unique value was successfully set in the CAS step
       if (txn.isSucceeded && client.getValue(barrierPath)?.asString == uniqueToken) {
-        keepAliveLease = client.keepAlive(lease)
+        keepAliveLease = client.keepAlive(lease) { e -> exceptionList.value += e }
         true
       } else {
         // Lease leaked the original implementation: when the CAS lost or the

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -195,7 +195,7 @@ constructor(
 
         else -> {
           // Keep key alive
-          keepAliveLease = client.keepAlive(lease)
+          keepAliveLease = client.keepAlive(lease) { e -> exceptionList.value += e }
 
           checkWaiterCount()
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/KeepAliveExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/KeepAliveExtensions.kt
@@ -50,7 +50,7 @@ fun Client.putValueWithKeepAlive(
   keyval: ByteSequence,
   ttlSecs: Long,
   block: () -> Unit,
-) = putValuesWithKeepAlive(listOf(keyName to keyval), ttlSecs, block)
+) = putValuesWithKeepAlive(listOf(keyName to keyval), ttlSecs, block = block)
 
 @JvmName("putValueWithKeepAliveDur")
 fun Client.putValueWithKeepAlive(
@@ -82,18 +82,20 @@ fun Client.putValueWithKeepAlive(
   keyval: ByteSequence,
   ttl: Duration,
   block: () -> Unit,
-) = putValuesWithKeepAlive(listOf(keyName to keyval), ttl, block)
+) = putValuesWithKeepAlive(listOf(keyName to keyval), ttl, block = block)
 
 fun Client.putValuesWithKeepAlive(
   kvs: Collection<Pair<String, ByteSequence>>,
   ttlSecs: Long,
+  onKeepAliveError: (Throwable) -> Unit = {},
   block: () -> Unit,
-) = putValuesWithKeepAlive(kvs, ttlSecs.seconds, block)
+) = putValuesWithKeepAlive(kvs, ttlSecs.seconds, onKeepAliveError, block)
 
 @Suppress("TooGenericExceptionCaught")
 fun Client.putValuesWithKeepAlive(
   kvs: Collection<Pair<String, ByteSequence>>,
   ttl: Duration,
+  onKeepAliveError: (Throwable) -> Unit = {},
   block: () -> Unit,
 ) {
   val lease = leaseGrant(ttl)
@@ -108,5 +110,7 @@ fun Client.putValuesWithKeepAlive(
     leaseRevoke(lease)
     throw e
   }
-  keepAliveWith(lease) { block() }
+  // onKeepAliveError lets a holder observe the keep-alive dying after setup
+  // succeeds (renewal stream errors or stops) rather than only on close().
+  keepAliveWith(lease, onKeepAliveError) { block() }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LeaseExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LeaseExtensions.kt
@@ -21,6 +21,7 @@ package io.etcd.recipes.common
 
 import io.etcd.jetcd.Client
 import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
 import io.etcd.jetcd.support.CloseableClient
 import io.etcd.jetcd.support.Observers
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -31,13 +32,37 @@ private val logger = KotlinLogging.logger {}
 
 fun <T> Client.keepAliveWith(
   lease: LeaseGrantResponse,
+  onKeepAliveError: (Throwable) -> Unit = {},
   block: () -> T,
-): T = keepAlive(lease).use { block.invoke() }
+): T = keepAlive(lease, onKeepAliveError).use { block.invoke() }
 
-fun Client.keepAlive(lease: LeaseGrantResponse): CloseableClient =
+// onNext stays at debug (one entry per renewal is noisy), but onError/onCompleted
+// must not be silent: this is the lease-liveness primitive for every recipe that
+// holds a lease, and a stream that errors or completes means renewal has stopped
+// and the lease (and its bound keys) will expire on TTL while the recipe still
+// looks healthy. jetcd's Observers.observer { } leaves both as no-ops, so surface
+// them at error/warn AND invoke [onKeepAliveError] so a holder (e.g. an
+// EtcdConnector subclass) can record the failure on its exceptions list. Neither
+// callback fires on our own CloseableClient.close() — both mean renewal genuinely
+// stopped — so onCompleted synthesizes a throwable for the same callback.
+@JvmOverloads
+fun Client.keepAlive(
+  lease: LeaseGrantResponse,
+  onKeepAliveError: (Throwable) -> Unit = {},
+): CloseableClient =
   leaseClient.keepAlive(
     lease.id,
-    Observers.observer { next -> logger.debug { "KeepAlive next resp: $next" } },
+    Observers.builder<LeaseKeepAliveResponse>()
+      .onNext { next -> logger.debug { "KeepAlive next resp: $next" } }
+      .onError { e ->
+        logger.error(e) { "KeepAlive stream errored for lease ${lease.id}; lease will expire on its TTL" }
+        onKeepAliveError(e)
+      }
+      .onCompleted {
+        logger.warn { "KeepAlive completed for lease ${lease.id}; renewal stopped, lease expires on TTL" }
+        onKeepAliveError(EtcdRecipeRuntimeException("KeepAlive renewal stopped for lease ${lease.id}"))
+      }
+      .build(),
   )
 
 fun Client.leaseGrant(ttl: Duration): LeaseGrantResponse =

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
@@ -32,6 +32,7 @@ import io.etcd.recipes.common.doesExist
 import io.etcd.recipes.common.doesNotExist
 import io.etcd.recipes.common.keepAlive
 import io.etcd.recipes.common.leaseGrant
+import io.etcd.recipes.common.leaseRevoke
 import io.etcd.recipes.common.putOption
 import io.etcd.recipes.common.setTo
 import io.etcd.recipes.common.transaction
@@ -80,8 +81,6 @@ constructor(
     val instancePath = getNamesPath(service)
     val context = ServiceInstanceContext(service, client, instancePath)
 
-    serviceContextMap[service.id] = context
-
     context.lease = client.leaseGrant(leaseTtlSecs.seconds)
 
     val txn =
@@ -90,10 +89,18 @@ constructor(
         Then(instancePath.setTo(service.toJson(), putOption { withLeaseId(context.lease.id) }))
       }
 
-    if (txn.isSucceeded)
-      context.keepAlive = client.keepAlive(context.lease)
-    else
+    if (!txn.isSucceeded) {
+      // CAS lost (key already present). Revoke the lease we just granted so it does
+      // not linger until its TTL, and leave serviceContextMap untouched so a
+      // half-built context (with an unset keepAlive) is never published — doClose()
+      // would otherwise crash reading the unset delegate and abort the whole close.
+      client.leaseRevoke(context.lease)
       throw EtcdRecipeException("Service registration failed for $instancePath")
+    }
+
+    // Only publish a fully-built context (lease + keepAlive set) into the map.
+    context.keepAlive = client.keepAlive(context.lease) { e -> exceptionList.value += e }
+    serviceContextMap[service.id] = context
   }
 
   @Synchronized

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -306,7 +306,7 @@ constructor(
     }
 
     // Run keep-alive until closed
-    client.keepAliveWith(lease) { terminateKeepAlive.waitUntilTrue() }
+    client.keepAliveWith(lease, { e -> exceptionList.value += e }) { terminateKeepAlive.waitUntilTrue() }
   }
 
   // This will not return until election failure or leader surrenders leadership after being elected
@@ -342,7 +342,7 @@ constructor(
 
     // Selected as leader. This will exit when leadership is relinquished
     try {
-      client.keepAliveWith(lease) {
+      client.keepAliveWith(lease, { e -> exceptionList.value += e }) {
         electedLeader.store(true)
         listener.takeLeadership(this)
       }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
@@ -21,7 +21,8 @@ package io.etcd.recipes.keyvalue
 import io.etcd.jetcd.Client
 import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
-import io.etcd.recipes.common.putValueWithKeepAlive
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.putValuesWithKeepAlive
 import io.etcd.recipes.keyvalue.TransientKeyValue.Companion.defaultClientId
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CountDownLatch
@@ -84,7 +85,13 @@ constructor(
       try {
         val leaseTtl = leaseTtlSecs.seconds
         logger.debug { "$leaseTtl keep-alive started for $clientId $keyPath" }
-        client.putValueWithKeepAlive(keyPath, keyValue, leaseTtl) {
+        client.putValuesWithKeepAlive(
+          listOf(keyPath to keyValue.asByteSequence),
+          leaseTtl,
+          // Record a keep-alive death so a caller polling exceptions/hasExceptions
+          // sees the key is no longer being renewed, instead of it silently expiring.
+          onKeepAliveError = { e -> exceptionList.value += e },
+        ) {
           keepAliveStartedLatch.countDown()
           keepAliveWaitLatch.await()
           logger.debug { "$leaseTtl keep-alive terminated for $clientId $keyPath" }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedPriorityQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedPriorityQueue.kt
@@ -31,6 +31,7 @@ import io.etcd.recipes.common.getLastChild
 import io.etcd.recipes.common.lessThan
 import io.etcd.recipes.common.setTo
 import io.etcd.recipes.common.transaction
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.TimeSource
@@ -103,27 +104,50 @@ class DistributedPriorityQueue(
         sleep(minimumWaitTime - elapsed)
       }
 
-      val resp = client.getLastChild(prefix, SortTarget.KEY)
-      val kvs = resp.kvs
+      // Optimistic-concurrency retry loop. The CAS below is guarded on the base
+      // key's mod revision, so two producers enqueuing at the same priority from
+      // different instances can compute the same sequence number and one loses the
+      // CAS. That is ordinary contention, not an error: re-read getLastChild for a
+      // fresh sequence number and a fresh header revision, then retry — mirroring
+      // dequeue()'s retry-on-CAS-conflict loop. synchronized(this) only serializes
+      // writers within this JVM; cross-instance correctness comes from this retry.
+      repeat(MAX_ENQUEUE_ATTEMPTS) { attempt ->
+        val resp = client.getLastChild(prefix, SortTarget.KEY)
+        val kvs = resp.kvs
 
-      var newSeqNum = 0
-      if (kvs.isNotEmpty()) {
-        val fields = kvs.first().key.asString.split("/")
-        newSeqNum = fields[(fields.size) - 1].toInt() + 1
-      }
-
-      val txn =
-        client.transaction {
-          val newKey = "%s/%016d".format(prefix, newSeqNum)
-          val baseKey = "__$prefix"
-          If(lessThan(baseKey, CmpTarget.modRevision(resp.header.revision + 1)))
-          Then(baseKey setTo "", newKey setTo value)
+        var newSeqNum = 0
+        if (kvs.isNotEmpty()) {
+          val fields = kvs.first().key.asString.split("/")
+          newSeqNum = fields[(fields.size) - 1].toInt() + 1
         }
 
-      if (txn.isSucceeded)
-        lastWriteTime = TimeSource.Monotonic.markNow()
-      else
-        throw EtcdRecipeRuntimeException("Failed to set key")
+        val txn =
+          client.transaction {
+            val newKey = "%s/%016d".format(prefix, newSeqNum)
+            val baseKey = "__$prefix"
+            If(lessThan(baseKey, CmpTarget.modRevision(resp.header.revision + 1)))
+            Then(baseKey setTo "", newKey setTo value)
+          }
+
+        if (txn.isSucceeded) {
+          lastWriteTime = TimeSource.Monotonic.markNow()
+          return
+        }
+
+        logger.debug { "Lost enqueue CAS for $prefix on attempt ${attempt + 1}, retrying" }
+      }
+
+      throw EtcdRecipeRuntimeException("Failed to enqueue to $queuePath after $MAX_ENQUEUE_ATTEMPTS attempts")
     }
+  }
+
+  companion object {
+    private val logger = KotlinLogging.logger {}
+
+    // Upper bound on optimistic-CAS retries before surfacing failure. Each round
+    // guarantees forward progress (one same-priority producer always wins), so this
+    // only trips under pathological sustained contention; bounded rather than
+    // unbounded so a stuck enqueue cannot hold the instance monitor against close().
+    private const val MAX_ENQUEUE_ATTEMPTS = 50
   }
 }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/LeaseExtensionsTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/LeaseExtensionsTests.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.Lease
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
+import io.etcd.jetcd.support.CloseableClient
+import io.grpc.stub.StreamObserver
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.CapturingSlot
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+
+class LeaseExtensionsTests : StringSpec() {
+    // A Client whose leaseClient.keepAlive captures the StreamObserver jetcd would
+    // normally drive, so a test can fire onError/onCompleted by hand and assert that
+    // keepAlive's onKeepAliveError callback is invoked.
+    private fun capturingClient(
+      leaseId: Long,
+      observerSlot: CapturingSlot<StreamObserver<LeaseKeepAliveResponse>>,
+    ): Client {
+        val leaseMock = mockk<Lease>()
+        every {
+            leaseMock.keepAlive(eq(leaseId), capture(observerSlot))
+        } returns mockk<CloseableClient>(relaxed = true)
+        return mockk { every { leaseClient } returns leaseMock }
+    }
+
+    private fun leaseOf(leaseId: Long): LeaseGrantResponse = mockk { every { id } returns leaseId }
+
+    init {
+        "keepAlive surfaces a stream error through onKeepAliveError" {
+            val observerSlot = slot<StreamObserver<LeaseKeepAliveResponse>>()
+            val client = capturingClient(leaseId = 5L, observerSlot = observerSlot)
+
+            val recorded = mutableListOf<Throwable>()
+            client.keepAlive(leaseOf(5L)) { recorded += it }
+
+            val boom = RuntimeException("stream broke")
+            observerSlot.captured.onError(boom)
+
+            recorded shouldContainExactly listOf(boom)
+        }
+
+        // onCompleted carries no throwable, so keepAlive synthesizes an
+        // EtcdRecipeRuntimeException — an unexpected completion means renewal
+        // stopped (it never fires on our own CloseableClient.close()).
+        "keepAlive surfaces an unexpected completion through onKeepAliveError" {
+            val observerSlot = slot<StreamObserver<LeaseKeepAliveResponse>>()
+            val client = capturingClient(leaseId = 6L, observerSlot = observerSlot)
+
+            val recorded = mutableListOf<Throwable>()
+            client.keepAlive(leaseOf(6L)) { recorded += it }
+
+            observerSlot.captured.onCompleted()
+
+            recorded.size shouldBe 1
+            recorded.first().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
+        }
+
+        // The default no-op callback must not blow up — guards backward compat for
+        // existing callers that pass no callback.
+        "keepAlive with the default callback ignores stream errors" {
+            val observerSlot = slot<StreamObserver<LeaseKeepAliveResponse>>()
+            val client = capturingClient(leaseId = 7L, observerSlot = observerSlot)
+
+            client.keepAlive(leaseOf(7L))
+
+            observerSlot.captured.onError(RuntimeException("ignored"))
+            observerSlot.captured.onCompleted()
+        }
+    }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceRegistryLeaseTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceRegistryLeaseTests.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.discovery
+
+import io.etcd.recipes.common.EtcdRecipeException
+import io.etcd.recipes.common.FailingLeaseMocks
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.verify
+
+class ServiceRegistryLeaseTests : StringSpec() {
+    init {
+        // Regression test: when the CAS that publishes the instance key fails,
+        // registerService() must revoke the lease it just granted instead of
+        // letting it linger in etcd until its TTL expires.
+        "revokes the granted lease when the registration CAS fails" {
+            val mocks = FailingLeaseMocks(leaseId = 77L)
+            val registry = ServiceRegistry(mocks.client, "/discovery")
+            val service = serviceInstance("test-service", "payload")
+
+            shouldThrow<EtcdRecipeException> { registry.registerService(service) }
+
+            verify(exactly = 1) { mocks.lease.revoke(mocks.leaseId) }
+        }
+
+        // Regression test: a failed registration must not leave a half-built context
+        // (lease set, keepAlive unset) in serviceContextMap. Before the fix close()
+        // iterated it and threw IllegalStateException reading the unset keepAlive
+        // delegate, aborting cleanup of the whole registry.
+        "leaves the context map clean so close() is safe after a failed registration" {
+            val mocks = FailingLeaseMocks(leaseId = 77L)
+            val registry = ServiceRegistry(mocks.client, "/discovery")
+            val service = serviceInstance("test-service", "payload")
+
+            shouldThrow<EtcdRecipeException> { registry.registerService(service) }
+
+            shouldNotThrowAny { registry.close() }
+        }
+    }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueKeepAliveErrorTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueKeepAliveErrorTests.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.keyvalue
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.Lease
+import io.etcd.jetcd.kv.PutResponse
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
+import io.etcd.jetcd.lease.LeaseRevokeResponse
+import io.etcd.jetcd.support.CloseableClient
+import io.grpc.stub.StreamObserver
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import java.util.concurrent.CompletableFuture
+
+class TransientKeyValueKeepAliveErrorTests : StringSpec() {
+    init {
+        // Regression test: once the key is established, a keep-alive stream death
+        // must land on the recipe's exceptions list so a caller can see the key is
+        // no longer being renewed, instead of it silently expiring while the worker
+        // still blocks on its wait latch.
+        "records a keep-alive stream failure to exceptions" {
+            val leaseId = 11L
+            val observerSlot = slot<StreamObserver<LeaseKeepAliveResponse>>()
+
+            val leaseMock = mockk<Lease>()
+            every { leaseMock.grant(any()) } returns
+                CompletableFuture.completedFuture(mockk<LeaseGrantResponse> { every { id } returns leaseId })
+            every {
+                leaseMock.keepAlive(eq(leaseId), capture(observerSlot))
+            } returns mockk<CloseableClient>(relaxed = true)
+            every { leaseMock.revoke(any()) } returns CompletableFuture.completedFuture(mockk<LeaseRevokeResponse>())
+
+            val kvMock = mockk<KV>()
+            every { kvMock.put(any(), any(), any()) } returns CompletableFuture.completedFuture(mockk<PutResponse>())
+
+            val client = mockk<Client>()
+            every { client.leaseClient } returns leaseMock
+            every { client.kvClient } returns kvMock
+
+            // autoStart=true: the constructor starts the worker, which establishes
+            // the key and then blocks on the wait latch. start() returns once the
+            // keep-alive observer is wired, so observerSlot is captured by here.
+            val tkv = TransientKeyValue(client, "/transient/key", "value", leaseTtlSecs = 5L)
+
+            val boom = RuntimeException("keep-alive stream died")
+            observerSlot.captured.onError(boom)
+
+            tkv.hasExceptions shouldBe true
+            tkv.exceptions shouldContain boom
+
+            tkv.close()
+        }
+    }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueueEnqueueRetryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueueEnqueueRetryTests.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.queue
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.Response
+import io.etcd.jetcd.Txn
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.kv.TxnResponse
+import io.etcd.jetcd.options.GetOption
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.milliseconds
+
+class DistributedPriorityQueueEnqueueRetryTests : StringSpec() {
+    // Builds a Client whose getLastChild always reports an empty prefix and whose
+    // CAS (txn.commit) result is scripted by [casOutcomes]; returnsMany repeats the
+    // last element, so a single `false` makes every attempt lose. Returns the Txn
+    // mock too so a test can verify how many enqueue attempts were made.
+    private fun scriptedClient(casOutcomes: List<Boolean>): Pair<Client, Txn> {
+        val header = mockk<Response.Header>()
+        every { header.revision } returns 0L
+
+        val getResp = mockk<GetResponse>()
+        every { getResp.kvs } returns emptyList()
+        every { getResp.isMore } returns false
+        every { getResp.header } returns header
+
+        val txn = mockk<Txn>()
+        every { txn.If(*anyVararg()) } returns txn
+        every { txn.Then(*anyVararg()) } returns txn
+        every { txn.commit() } returnsMany
+            casOutcomes.map { succeeded ->
+                CompletableFuture.completedFuture(mockk<TxnResponse> { every { isSucceeded } returns succeeded })
+            }
+
+        val kv = mockk<KV>()
+        every { kv.get(any<ByteSequence>(), any<GetOption>()) } returns CompletableFuture.completedFuture(getResp)
+        every { kv.txn() } returns txn
+
+        val client = mockk<Client>()
+        every { client.kvClient } returns kv
+
+        return client to txn
+    }
+
+    init {
+        // Regression test: a same-priority enqueue that loses the optimistic CAS to
+        // another (cross-instance) producer must retry with a fresh sequence number,
+        // not surface the conflict as an exception to the caller.
+        "retries the enqueue CAS and succeeds once an attempt wins" {
+            val (client, txn) = scriptedClient(listOf(false, false, true))
+            val queue = DistributedPriorityQueue(client, "/pqueue", minimumWaitTime = 0.milliseconds)
+
+            shouldNotThrowAny { queue.enqueue("payload", priority = 5) }
+
+            verify(exactly = 3) { txn.commit() }
+        }
+
+        // The retry loop must be bounded so a persistently-losing enqueue surfaces a
+        // failure instead of spinning forever while holding the instance monitor.
+        "throws after a bounded number of attempts when the CAS never wins" {
+            val (client, txn) = scriptedClient(listOf(false))
+            val queue = DistributedPriorityQueue(client, "/pqueue", minimumWaitTime = 0.milliseconds)
+
+            shouldThrow<EtcdRecipeRuntimeException> { queue.enqueue("payload", priority = 5) }
+
+            // Proves it retried (not a single-shot failure) and that the loop terminates.
+            verify(atLeast = 2) { txn.commit() }
+        }
+    }
+}


### PR DESCRIPTION
Addresses three findings from the recipe code review (reported earlier in this branch's review pass).

## Fixes

**1. discovery — lease leak + close() crash on failed `registerService` CAS** (high)
`registerService` granted the lease and inserted the context into `serviceContextMap` *before* the CAS, then on CAS failure threw without revoking — leaking the lease, and leaving a half-built context whose unset `keepAlive` delegate crashed `doClose()` (`IllegalStateException`), aborting cleanup of the entire registry. Now the lease is revoked on failure and only a fully-built context (lease + keepAlive) is published to the map.

**2. queue — `DistributedPriorityQueue.enqueue` throws on a normal cross-instance CAS conflict** (high)
The optimistic CAS is guarded on the base key's mod revision, so two producers enqueuing at the same priority from different instances could both target the same sequence number and one would lose — surfacing `"Failed to set key"` to the caller with no retry (`dequeue()` already retried; enqueue did not). Now wrapped in a bounded retry loop (`MAX_ENQUEUE_ATTEMPTS`) mirroring `dequeue()`; `synchronized(this)` is retained for in-JVM serialization/pacing, and the bound prevents a stuck enqueue from holding the instance monitor against `close()`.

**3. common/keep-alive — stream death was silently swallowed** (library-wide)
jetcd's `Observers.observer { }` left `onError`/`onCompleted` as no-ops, so a keep-alive stream that errored or stopped after startup was invisible — the lease (and its keys) expired while the recipe still looked healthy. Now:
- The observer logs `onError`/`onCompleted` and invokes a new optional `onKeepAliveError: (Throwable) -> Unit` callback (default no-op, backward compatible; `@JvmOverloads` keeps the Java `keepAlive(client, lease)` form). Neither callback fires on our own `CloseableClient.close()`, so they reliably mean "renewal stopped"; `onCompleted` synthesizes a throwable for the callback.
- The callback is threaded through `keepAlive`, `keepAliveWith`, and `putValuesWithKeepAlive`.
- Every lease-holding recipe (`TransientKeyValue`, `DistributedBarrier`, `DistributedBarrierWithCount`, `ServiceRegistry`, `LeaderSelector`) records a keep-alive death on its `exceptions` list, so a dropped renewal is observable via `hasExceptions`/`exceptions` instead of only in logs. Recording is record-only (no auto-teardown), so jetcd's transient connection errors that it auto-recovers from won't tear anything down.

## Tests
- `ServiceRegistryLeaseTests` — revokes the lease on failed CAS; `close()` is safe afterward (both fail on the pre-fix code).
- `DistributedPriorityQueueEnqueueRetryTests` — retries-then-succeeds across CAS conflicts; throws bounded when the CAS never wins.
- `LeaseExtensionsTests` — `onKeepAliveError` fires on `onError` and on `onCompleted` (synthesized exception); default no-op is safe.
- `TransientKeyValueKeepAliveErrorTests` — a keep-alive stream failure lands on `exceptions`.

All new tests are MockK-based and need no etcd. The touched recipe packages (keyvalue, barrier, election, discovery, keep-alive) were additionally run green against a Testcontainers etcd, and lint + detekt pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)