### PR TITLE
Fix LeaderSelector close()/takeLeadership deadlock and revoke leases on normal close

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
@@ -69,6 +69,10 @@ constructor(
 
     override fun close() {
       keepAlive.close()
+      // Revoke the lease so it (and its bound key) is released promptly on
+      // unregister/close instead of lingering until TTL (#7). Revoking already
+      // deletes the lease-bound key; deleteKey is kept as belt-and-suspenders.
+      client.leaseRevoke(lease)
       client.deleteKey(instancePath)
     }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -135,6 +135,14 @@ constructor(
   private val attemptLeadership = BooleanMonitor(true)
   private val electedLeader = AtomicBoolean(false)
   private val startCallLock = Any()
+
+  // Serializes the leadership-claim section of attemptToBecomeLeader (CAS + guard
+  // resets) across the start() worker and the watch-dispatcher thread. Deliberately
+  // NOT the instance monitor: close() is @Synchronized on the instance, so holding
+  // the instance monitor across takeLeadership (the previous @Synchronized) made a
+  // close() during active leadership deadlock. This lock is released before the
+  // takeLeadership block runs, so close() can flip the termination monitors meanwhile.
+  private val electionLock = Any()
   private val startCallAllowed = AtomicBoolean(true)
   private val leaderPath = electionPath.withLeaderSuffix
 
@@ -256,6 +264,23 @@ constructor(
     return leadershipComplete.waitUntilTrue(timeout)
   }
 
+  // Blocking form of [isFinished]: waits until leadership completes (set by close()
+  // or by relinquishing). Unlike waitOnLeadershipComplete it acquires no instance
+  // monitor and does not wait on startThreadComplete, so it is safe to call from
+  // inside takeLeadership as a stop signal — a close() from another thread flips
+  // leadershipComplete and releases this wait.
+  @Throws(InterruptedException::class)
+  fun waitUntilFinished(): Boolean = waitUntilFinished(Long.MAX_VALUE.days)
+
+  @Throws(InterruptedException::class)
+  fun waitUntilFinished(
+    timeout: Long,
+    timeUnit: TimeUnit,
+  ): Boolean = waitUntilFinished(timeUnitToDuration(timeout, timeUnit))
+
+  @Throws(InterruptedException::class)
+  fun waitUntilFinished(timeout: Duration): Boolean = leadershipComplete.waitUntilTrue(timeout)
+
   private fun markLeadershipComplete() {
     terminateWatch.set(true)
     terminateKeepAlive.set(true)
@@ -305,45 +330,63 @@ constructor(
       throw EtcdRecipeException("Participation registration failed [$path]")
     }
 
-    // Run keep-alive until closed
-    client.keepAliveWith(lease, { e -> exceptionList.value += e }) { terminateKeepAlive.waitUntilTrue() }
+    // Run keep-alive until closed, then revoke the participation lease promptly
+    // (#7) so the participant key is evicted on relinquish instead of lingering
+    // until TTL (which is what forces the pre-CAS wait loop above).
+    try {
+      client.keepAliveWith(lease, { e -> exceptionList.value += e }) { terminateKeepAlive.waitUntilTrue() }
+    } finally {
+      client.leaseRevoke(lease)
+    }
   }
 
   // This will not return until election failure or leader surrenders leadership after being elected
-  @Synchronized
   @Suppress("ReturnCount", "TooGenericExceptionCaught")
   private fun attemptToBecomeLeader(client: Client): Boolean {
-    if (isLeader || !attemptLeadership.get()) {
-      return false
-    }
+    // Phase 1 — claim leadership under electionLock (NOT the instance monitor) so
+    // concurrent candidates (start() worker vs watch-dispatcher) are serialized
+    // without blocking close(). Returns the granted lease on a win, or returns
+    // false on every losing path after revoking its own lease.
+    val lease =
+      synchronized(electionLock) {
+        if (isLeader || !attemptLeadership.get()) {
+          return false
+        }
 
-    // Create unique token to avoid collision from clients with same id
-    val uniqueToken = "$clientId:${randomId(TOKEN_LENGTH)}"
+        // Create unique token to avoid collision from clients with same id
+        val uniqueToken = "$clientId:${randomId(TOKEN_LENGTH)}"
 
-    // Prime lease to give keepAliveWith a chance to get started; route through
-    // the common/ extension layer rather than reaching into jetcd directly.
-    val lease = client.leaseGrant(leaseTtlSecs.seconds)
+        // Prime lease to give keepAliveWith a chance to get started; route through
+        // the common/ extension layer rather than reaching into jetcd directly.
+        val granted = client.leaseGrant(leaseTtlSecs.seconds)
 
-    // Check the key name. If it is not found, then set it
-    val txn =
-      client.transaction {
-        If(leaderPath.doesNotExist)
-        Then(leaderPath.setTo(uniqueToken, putOption { withLeaseId(lease.id) }))
+        // Check the key name. If it is not found, then set it
+        val txn =
+          client.transaction {
+            If(leaderPath.doesNotExist)
+            Then(leaderPath.setTo(uniqueToken, putOption { withLeaseId(granted.id) }))
+          }
+
+        // Check to see if unique value was successfully set in the CAS step
+        if (!txn.isSucceeded || client.getValue(leaderPath)?.asString != uniqueToken) {
+          // Failed to become leader: revoke the lease we just created so it does
+          // not linger in etcd until TTL. Without this, every losing candidate in
+          // an election leaks a lease per turnover.
+          client.leaseRevoke(granted)
+          return false
+        }
+
+        // Mark elected inside the lock so a concurrent candidate sees isLeader and bails.
+        electedLeader.store(true)
+        granted
       }
 
-    // Check to see if unique value was successfully set in the CAS step
-    if (isLeader || !txn.isSucceeded || client.getValue(leaderPath)?.asString != uniqueToken) {
-      // Failed to become leader: revoke the lease we just created so it does
-      // not linger in etcd until TTL. Without this, every losing candidate in
-      // an election leaks a lease per turnover.
-      client.leaseRevoke(lease)
-      return false
-    }
-
-    // Selected as leader. This will exit when leadership is relinquished
+    // Phase 2 — hold leadership with NO lock held, so a close() on another thread
+    // can run doClose() -> markLeadershipComplete() and release a takeLeadership
+    // that is waiting on isFinished/waitUntilFinished. Exits when leadership is
+    // relinquished (takeLeadership returns).
     try {
       client.keepAliveWith(lease, { e -> exceptionList.value += e }) {
-        electedLeader.store(true)
         listener.takeLeadership(this)
       }
       // Leadership was relinquished
@@ -354,10 +397,16 @@ constructor(
       exceptionList.value += e
       return false
     } finally {
-      // Do this after leadership is complete so the thread does not terminate
-      attemptLeadership.set(false)
-      startCallAllowed.store(true)
-      electedLeader.store(false)
+      // Revoke the leadership lease promptly on relinquish (#7) instead of at TTL.
+      client.leaseRevoke(lease)
+      // Reset the election guards under the same lock Phase 1 reads them, so a
+      // concurrent candidate never observes a half-updated guard set.
+      synchronized(electionLock) {
+        attemptLeadership.set(false)
+        startCallAllowed.store(true)
+        electedLeader.store(false)
+      }
+      // Do this after leadership is complete so the thread does not terminate early
       markLeadershipComplete()
     }
   }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceRegistryRevokeTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceRegistryRevokeTests.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.discovery
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.Lease
+import io.etcd.jetcd.Txn
+import io.etcd.jetcd.kv.DeleteResponse
+import io.etcd.jetcd.kv.TxnResponse
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.lease.LeaseRevokeResponse
+import io.etcd.jetcd.support.CloseableClient
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.concurrent.CompletableFuture
+
+class ServiceRegistryRevokeTests : StringSpec() {
+    init {
+        // Regression test for #7: a successful registration revokes its lease exactly
+        // once — on normal unregister/close, not on the (successful) registration —
+        // so the lease and its bound key are released promptly instead of at TTL.
+        "revokes the lease exactly once on normal close" {
+            val leaseId = 21L
+            val lease = mockk<Lease>()
+            every { lease.grant(any()) } returns
+                CompletableFuture.completedFuture(mockk<LeaseGrantResponse> { every { id } returns leaseId })
+            every { lease.keepAlive(eq(leaseId), any()) } returns mockk<CloseableClient>(relaxed = true)
+            every { lease.revoke(leaseId) } returns CompletableFuture.completedFuture(mockk<LeaseRevokeResponse>())
+
+            val txn = mockk<Txn>()
+            every { txn.If(*anyVararg()) } returns txn
+            every { txn.Then(*anyVararg()) } returns txn
+            every { txn.commit() } returns
+                CompletableFuture.completedFuture(mockk<TxnResponse> { every { isSucceeded } returns true })
+
+            val kv = mockk<KV>()
+            every { kv.txn() } returns txn
+            every { kv.delete(any()) } returns CompletableFuture.completedFuture(mockk<DeleteResponse>())
+
+            val client = mockk<Client>()
+            every { client.kvClient } returns kv
+            every { client.leaseClient } returns lease
+
+            val registry = ServiceRegistry(client, "/discovery")
+            registry.registerService(serviceInstance("test-service", "payload"))
+
+            // Registration succeeded, so nothing was revoked yet.
+            verify(exactly = 0) { lease.revoke(leaseId) }
+
+            registry.close()
+
+            verify(exactly = 1) { lease.revoke(leaseId) }
+        }
+    }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorCloseDeadlockTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorCloseDeadlockTests.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.election
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+class LeaderSelectorCloseDeadlockTests : StringSpec() {
+    private val path = "/election/${javaClass.simpleName}"
+
+    private fun blockingLeaderSelector(
+      client: io.etcd.jetcd.Client,
+      latchRef: AtomicReference<CountDownLatch>,
+    ) = LeaderSelector(
+        client,
+        path,
+        takeLeadershipBlock = { selector ->
+            latchRef.get().countDown()
+            // Block until close() signals completion. Pre-fix attemptToBecomeLeader
+            // held the instance monitor across this call, so close() (also
+            // @Synchronized on the instance) could never run doClose() to flip the
+            // finished signal — a permanent deadlock.
+            selector.waitUntilFinished()
+        },
+        leaseTtlSecs = 2L,
+    )
+
+    init {
+        // The bounded join + isAlive assertion turn a regression into a clean FAIL
+        // (closer thread still alive after the timeout) rather than a hung suite.
+        "close() releases a takeLeadership blocked on waitUntilFinished()".config(timeout = 60.seconds) {
+            connectToEtcd(urls) { client ->
+                val latchRef = AtomicReference(CountDownLatch(1))
+                val selector = blockingLeaderSelector(client, latchRef)
+
+                selector.start()
+                latchRef.get().await(20, TimeUnit.SECONDS) shouldBe true
+
+                val closer = thread { selector.close() }
+                closer.join(20_000)
+
+                closer.isAlive shouldBe false
+                selector.isFinished shouldBe true
+                selector.hasExceptions shouldBe false
+            }
+        }
+
+        // Exercises the deadlock fix across start()/close() reuse, which also drives
+        // the electionLock-guarded reset path on every cycle.
+        "close() releases a blocked leader across start()/close() reuse".config(timeout = 90.seconds) {
+            connectToEtcd(urls) { client ->
+                val latchRef = AtomicReference(CountDownLatch(1))
+                val selector = blockingLeaderSelector(client, latchRef)
+
+                repeat(3) {
+                    latchRef.set(CountDownLatch(1))
+                    selector.start()
+                    latchRef.get().await(20, TimeUnit.SECONDS) shouldBe true
+
+                    val closer = thread { selector.close() }
+                    closer.join(20_000)
+
+                    closer.isAlive shouldBe false
+                    selector.isFinished shouldBe true
+                }
+
+                selector.hasExceptions shouldBe false
+            }
+        }
+    }
+}


### PR DESCRIPTION
Two more findings from the recipe code review.

## Fixes

**#4 — `LeaderSelector` `close()`/`takeLeadership` deadlock** (concurrency)
`attemptToBecomeLeader` was `@Synchronized` on the instance and held that monitor for the entire duration of `listener.takeLeadership(this)`. `EtcdConnector.close()` is `final @Synchronized` on the same monitor, so a `close()` issued while a leader was mid-`takeLeadership` blocked acquiring the monitor, never ran `doClose() → markLeadershipComplete()`, and therefore never flipped the termination flags — a permanent deadlock for any `takeLeadership` that waits to be told to relinquish (e.g. `while (!isFinished) …`). The shipped tests dodged it by always sequencing `waitOnLeadershipComplete()` before `close()` and using a self-returning `takeLeadership`.

Fix (a hybrid arrived at via independent design analysis + an adversarial deadlock review):
- Replace `@Synchronized` with a private `electionLock` that guards only the leadership-claim (lease grant + CAS + verify) section, **released before** the `takeLeadership` block runs. `close()` is then uncontended during leadership and can flip the termination monitors.
- Reset the election guards (`attemptLeadership` / `startCallAllowed` / `electedLeader`) back **under `electionLock`**, so a concurrent candidate (the watch-dispatcher thread) never observes a half-updated guard set. (This closes a race a naïve "just use a private lock" version would introduce.)
- Add public **`waitUntilFinished(...)`** — a monitor-free blocking form of `isFinished` that, unlike `waitOnLeadershipComplete`, does not wait on `startThreadComplete`, so it is safe to call from inside `takeLeadership` as a stop signal.
- No `EtcdConnector` change; no `requestRelinquish()` — once the monitor is released, `close()` alone is sufficient.
- Also removed the dead `isLeader ||` term from the post-CAS recheck.

Documented unsupported edge (pre-existing, not introduced here): calling `close()` *from inside* your own `takeLeadership` on the same thread self-deadlocks.

**#7 — revoke leases on normal cleanup** (resource leak)
On normal relinquish/close these revoked nothing, so the lease lingered until TTL:
- `ServiceRegistry.ServiceInstanceContext.close()` now `leaseRevoke`s the service lease.
- `advertiseParticipation()` wraps its participation keep-alive in `try/finally { leaseRevoke }` (this is also what lets the participant key be evicted promptly instead of forcing the pre-CAS wait loop to ride out the TTL).
- The leadership path revokes its lease first in the Phase-2 `finally`.
- The failed-CAS paths still revoke-and-return *before* these `finally` blocks, so revocation is **exactly-once** (`LeaderSelectorLeaseTests`' `verify(exactly = 1)` still holds).

## Tests
- `LeaderSelectorCloseDeadlockTests` (real etcd) — `close()` releases a `takeLeadership` blocked on `waitUntilFinished()`, plus a `start()`/`close()` reuse variant. Both use a bounded `join` + `isAlive` assertion, so a regression FAILs cleanly instead of hanging the suite.
- `ServiceRegistryRevokeTests` (MockK) — the service lease is revoked exactly once on normal close, zero times on a successful registration.

Verified the full **election + discovery** suites against a Testcontainers etcd (`LeaderSelectorReuseTests`, `ParticipantTests`, `LeaderSelectorLeaseTests`, threaded/serial election, etc.), plus lint + detekt.

Net public API addition: `waitUntilFinished(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)