### PR TITLE
Fix PathChildrenCache key-stripping for a trailing-slash cachePath

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -63,6 +63,13 @@ class PathChildrenCache(
   val cachePath: String,
   private val userExecutor: Executor? = null,
 ) : EtcdConnector(client) {
+  // Canonical prefix for the watched key range. Every child key is stripped
+  // relative to this, never cachePath.length + 1: when cachePath already ends in
+  // '/', that offset over-strips by one char and corrupts every child name, so the
+  // snapshot/rebuild paths would disagree with the live watcher (which already
+  // strips by trailingPath.length). One field keeps all three sites in lockstep.
+  private val trailingPath = cachePath.ensureSuffix("/")
+
   // Plain var: all reads/writes are inside @Synchronized methods on this instance.
   private var watcher: Watch.Watcher? = null
   private val cacheMap: ConcurrentMap<String, ByteSequence> = newConcurrentMap()
@@ -158,7 +165,6 @@ class PathChildrenCache(
   @Suppress("TooGenericExceptionCaught")
   private fun loadDataAndStartWatcher() {
     try {
-      val trailingPath = cachePath.ensureSuffix("/")
       val getOption = getOption {
         isPrefix(true)
         withSortField(GetOption.SortTarget.KEY)
@@ -168,7 +174,7 @@ class PathChildrenCache(
 
       for (kv in resp.kvs) {
         val k = kv.key.asString
-        val s = k.substring(cachePath.length + 1)
+        val s = k.substring(trailingPath.length)
         cacheMap[s] = kv.value
       }
 
@@ -181,7 +187,6 @@ class PathChildrenCache(
 
   @Suppress("TooGenericExceptionCaught")
   private fun setupWatcher(startRevision: Long) {
-    val trailingPath = cachePath.ensureSuffix("/")
     logger.debug { "Setting up watch for $trailingPath at rev $startRevision" }
     val watchOption = watchOption {
       isPrefix(true).also { if (startRevision > 0L) it.withRevision(startRevision) }
@@ -253,13 +258,12 @@ class PathChildrenCache(
 
   fun rebuild() {
     clear()
-    val trailingPath = cachePath.ensureSuffix("/")
     val getOption = getOption {
       isPrefix(true)
       withSortField(GetOption.SortTarget.KEY)
     }
     for ((k, v) in client.getKeyValuePairs(trailingPath, getOption)) {
-      val s = k.substring(cachePath.length + 1)
+      val s = k.substring(trailingPath.length)
       cacheMap[s] = v
     }
   }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheTrailingSlashTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheTrailingSlashTests.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.cache
+
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+class PathChildrenCacheTrailingSlashTests : StringSpec() {
+    private val base = "/caches/${javaClass.simpleName}"
+
+    init {
+        // Regression test: a cachePath that ends in '/' must strip child names the
+        // same way the live watcher does (by the trailing-prefix length), not by
+        // cachePath.length + 1, which over-strips the first char of every child
+        // ("bar" -> "ar") and corrupts the snapshot/rebuild views of the cache.
+        "a trailing-slash cachePath strips child names consistently" {
+            connectToEtcd(urls) { client ->
+                client.deleteChildren(base)
+                client.putValue("$base/bar", "v1")
+
+                // Note the trailing slash on the cachePath.
+                PathChildrenCache(client, "$base/").use { cache ->
+                    cache.start(buildInitial = true)
+
+                    // Snapshot path (loadDataAndStartWatcher): full name, not "ar".
+                    cache.currentDataAsMap.keys shouldContainExactlyInAnyOrder listOf("bar")
+                    cache.getCurrentData("bar")?.asString shouldBe "v1"
+
+                    // Live watcher PUT lands in the same key space — no duplicate/stale key.
+                    client.putValue("$base/baz", "v2")
+                    pollUntil(5.seconds) { cache.getCurrentData("baz") != null } shouldBe true
+                    cache.getCurrentData("baz")?.asString shouldBe "v2"
+                    cache.currentDataAsMap.keys shouldContainExactlyInAnyOrder listOf("bar", "baz")
+
+                    // rebuild() re-reads via the same prefix and must agree.
+                    cache.rebuild()
+                    cache.currentDataAsMap.keys shouldContainExactlyInAnyOrder listOf("bar", "baz")
+                    cache.getCurrentData("bar")?.asString shouldBe "v1"
+                }
+
+                client.deleteChildren(base)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addresses review finding #6 (correctness, medium).

## The bug
`PathChildrenCache` strips child names three ways, and two of them disagree with the watcher:
- `setupWatcher` (the live watch): `k.substring(trailingPath.length)` where `trailingPath = cachePath.ensureSuffix("/")`.
- `loadDataAndStartWatcher` (snapshot) and `rebuild`: `k.substring(cachePath.length + 1)`.

These offsets are equal **only** when `cachePath` has no trailing slash. For a `cachePath` that ends in `/` (e.g. `"/foo/"`), `cachePath.length + 1` over-strips the first character of every child name — `"/foo/bar"` becomes `"ar"` in the snapshot but `"bar"` in the live watch. The result is duplicate/stale keys, `isAdd` detection always firing, and `getCurrentData()` / `currentData` / `currentDataAsMap` returning the wrong keys. It's a silent corruption trap, latent only because every existing test and example happens to pass a non-slash path.

## The fix
Introduce a single canonical `private val trailingPath = cachePath.ensureSuffix("/")` field and route all three sites through it, so every strip is relative to the same prefix (`trailingPath.length`) and the inconsistency cannot be reintroduced. This also dedupes the three identical `cachePath.ensureSuffix("/")` recomputations. The public `cachePath` is left untouched (no surprising mutation of what callers passed).

## Test
`PathChildrenCacheTrailingSlashTests` (real etcd) builds a cache on a **trailing-slash** `cachePath` and asserts the child names are stripped consistently across the snapshot (`BUILD_INITIAL_CACHE`), a live watch PUT, and `rebuild()`. It fails pre-fix (key `"ar"` instead of `"bar"`).

Verified the full existing cache suite still passes (no regression for the common no-slash paths), plus lint + detekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)