### PR TITLE
Make PathChildrenCache.rebuild() reconcile in place instead of clear-then-refill

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -256,16 +256,24 @@ class PathChildrenCache(
     return startThreadComplete.waitUntilTrue(timeout)
   }
 
+  // Re-sync the cache to etcd's current children. Build the fresh view first, then
+  // reconcile the live map in place (drop keys no longer present, upsert the rest)
+  // rather than clear()-then-refill, which left an empty/partial window where
+  // currentData reported no children. @Synchronized restores the class invariant by
+  // serializing against start()/doClose(). This is a coarse, manual re-sync: a live
+  // watch event on the same key can race the snapshot (last-writer-wins); rely on the
+  // watcher, not rebuild(), for strict event ordering.
+  @Synchronized
   fun rebuild() {
-    clear()
     val getOption = getOption {
       isPrefix(true)
       withSortField(GetOption.SortTarget.KEY)
     }
-    for ((k, v) in client.getKeyValuePairs(trailingPath, getOption)) {
-      val s = k.substring(trailingPath.length)
-      cacheMap[s] = v
-    }
+    val fresh =
+      client.getKeyValuePairs(trailingPath, getOption)
+        .associate { (k, v) -> k.substring(trailingPath.length) to v }
+    cacheMap.keys.retainAll(fresh.keys)
+    cacheMap.putAll(fresh)
   }
 
   // For consistency with Curator
@@ -276,6 +284,7 @@ class PathChildrenCache(
 
   val currentDataAsMap: Map<String, ByteSequence> get() = cacheMap.toMap()
 
+  @Synchronized
   fun clear() = cacheMap.clear()
 
   @Synchronized

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheRebuildTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheRebuildTests.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.cache
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+class PathChildrenCacheRebuildTests : StringSpec() {
+    private val base = "/caches/${javaClass.simpleName}"
+    private val childCount = 20
+
+    init {
+        // Regression test for #8: rebuild() must reconcile the live map in place, so a
+        // reader never observes the empty/partial window that the old clear()-then-refill
+        // produced. A concurrent reader sampling currentDataAsMap across many rebuilds
+        // would catch size 0 with overwhelming probability pre-fix; post-fix the map is
+        // never emptied while the children still exist.
+        "rebuild() never exposes an empty window while children exist".config(timeout = 60.seconds) {
+            connectToEtcd(urls) { client ->
+                client.deleteChildren(base)
+                repeat(childCount) { client.putValue("$base/k$it", "v$it") }
+
+                PathChildrenCache(client, base).use { cache ->
+                    cache.start(buildInitial = true)
+                    cache.currentDataAsMap.size shouldBe childCount
+
+                    val sawEmpty = AtomicBoolean(false)
+                    val stop = AtomicBoolean(false)
+                    val reader =
+                        thread {
+                            while (!stop.get()) {
+                                if (cache.currentDataAsMap.isEmpty()) sawEmpty.set(true)
+                            }
+                        }
+
+                    repeat(100) { cache.rebuild() }
+
+                    stop.set(true)
+                    reader.join(5_000)
+
+                    sawEmpty.get() shouldBe false
+                    cache.currentDataAsMap.size shouldBe childCount
+                }
+
+                client.deleteChildren(base)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Addresses review finding #8 (concurrency, medium).

## The bug
`PathChildrenCache.rebuild()` called `clear()` and then re-read the prefix and refilled `cacheMap` key-by-key. It was not `@Synchronized` and did a non-revision-anchored read, while the watch-dispatcher thread concurrently mutates the same map (PUT/DELETE handlers in `setupWatcher`). `cacheMap` is a `ConcurrentMap` so there is no structural corruption, but the *sequence* races:
- A real window after `clear()` where `currentData` / `currentDataAsMap` report **no children** (it spans the entire snapshot GET).
- A watch `DELETE` during the window can be resurrected by the stale refill; a watch `PUT` can be clobbered by an older snapshot value — transient lost events and views that disagree with etcd.

It's a manual/maintenance path (`rebuild()` is called explicitly, for Curator parity), hence medium.

## The fix
- Build the fresh view first, then **reconcile the live map in place**: `cacheMap.keys.retainAll(fresh.keys)` to drop keys no longer present, `cacheMap.putAll(fresh)` to upsert the rest. The map is never emptied, so `currentData` never observes the empty/partial window.
- Add `@Synchronized` to `rebuild()` and `clear()` to restore the class's documented "all reads/writes inside `@Synchronized` methods" invariant and serialize against `start()`/`doClose()`.
- A live watch event on the same key still races the manual snapshot (**last-writer-wins**) — documented in the method; callers should rely on the watcher, not `rebuild()`, for strict event ordering. (Full revision-anchoring of a manual re-sync against a live watcher would be disproportionate here.)

## Test
`PathChildrenCacheRebuildTests` (real etcd): a reader thread samples `currentDataAsMap` across 100 concurrent `rebuild()` calls and asserts it is **never observed empty** while the children still exist. This fails on the old `clear()`-then-refill (the reader catches size 0 with overwhelming probability) and passes on the in-place reconcile.

Verified the full existing cache suite still passes, plus lint + detekt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)