### PR TITLE
Typed exception for ServiceProvider.getInstance() and a defensive exceptions snapshot

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
@@ -37,7 +37,17 @@ open class EtcdConnector(
     if (closeCalled.load()) throw EtcdRecipeRuntimeException("close() already called")
   }
 
-  val exceptions: List<Throwable> get() = if (exceptionList.isInitialized()) exceptionList.value else emptyList()
+  // Return a defensive snapshot taken under the synchronizedList's own monitor.
+  // The list is appended to from background recipe threads (keep-alive onError
+  // callbacks, watcher threads); synchronizedList only guards individual ops, so a
+  // caller iterating the live list while a worker adds would hit a
+  // ConcurrentModificationException. A bare toList() still iterates, hence the lock.
+  val exceptions: List<Throwable>
+    get() =
+      if (exceptionList.isInitialized())
+        synchronized(exceptionList.value) { exceptionList.value.toList() }
+      else
+        emptyList()
 
   val hasExceptions get() = exceptionList.isInitialized() && exceptionList.value.isNotEmpty()
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceProvider.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceProvider.kt
@@ -19,6 +19,7 @@
 package io.etcd.recipes.discovery
 
 import io.etcd.jetcd.Client
+import io.etcd.recipes.common.EtcdRecipeException
 import io.etcd.recipes.common.appendToPath
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.getChildrenValues
@@ -35,7 +36,13 @@ class ServiceProvider(
   // by the parent ServiceDiscovery.
   private val instancesPath: String = namesPath.appendToPath(serviceName)
 
-  fun getInstance(): ServiceInstance = getAllInstances().random()
+  // "No instances available" is an ordinary discovery condition, not a programming
+  // error, so surface the library's typed exception (matching ServiceDiscovery's
+  // absent-instance contract) instead of letting List.random() throw a bare,
+  // context-free NoSuchElementException.
+  @Throws(EtcdRecipeException::class)
+  fun getInstance(): ServiceInstance =
+    getAllInstances().randomOrNull() ?: throw EtcdRecipeException("No instances available for service $serviceName")
 
   fun getAllInstances(): List<ServiceInstance> =
     client.getChildrenValues(instancesPath).map { it.asString }.map { ServiceInstance.toObject(it) }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdConnectorExceptionsTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdConnectorExceptionsTests.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.Client
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+class EtcdConnectorExceptionsTests : StringSpec() {
+    private class TestConnector(
+      client: Client,
+    ) : EtcdConnector(client) {
+        fun record(t: Throwable) {
+            exceptionList.value += t
+        }
+    }
+
+    init {
+        // Regression test for #12: exceptions must hand back a defensive copy, not the
+        // live synchronizedList. If it returned the live list, a caller iterating it
+        // while a background thread appends would hit a ConcurrentModificationException.
+        "exceptions returns a defensive snapshot, not the live backing list" {
+            val connector = TestConnector(mockk())
+            connector.record(RuntimeException("a"))
+            connector.record(RuntimeException("b"))
+
+            val snapshot = connector.exceptions
+            snapshot.size shouldBe 2
+
+            // A later append must not mutate an already-returned snapshot.
+            connector.record(RuntimeException("c"))
+            snapshot.size shouldBe 2
+            connector.exceptions.size shouldBe 3
+        }
+
+        "exceptions is empty before anything is recorded" {
+            TestConnector(mockk()).exceptions.shouldBeEmpty()
+        }
+    }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceProviderTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceProviderTests.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.discovery
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.KeyValue
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.recipes.common.EtcdRecipeException
+import io.etcd.recipes.common.asByteSequence
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+
+class ServiceProviderTests : StringSpec() {
+    private fun clientReturning(kvs: List<KeyValue>): Client {
+        val getResp = mockk<GetResponse>()
+        every { getResp.kvs } returns kvs
+        every { getResp.isMore } returns false
+        val kv = mockk<KV>()
+        every { kv.get(any(), any()) } returns CompletableFuture.completedFuture(getResp)
+        return mockk { every { kvClient } returns kv }
+    }
+
+    init {
+        // Regression test for #10: an empty result is an ordinary discovery condition,
+        // so getInstance() must throw the library's typed exception (naming the
+        // service) instead of a bare, context-free NoSuchElementException from random().
+        "getInstance throws a typed EtcdRecipeException naming the service when none are registered" {
+            val provider = ServiceProvider(clientReturning(emptyList()), "/services/names", "my-service")
+
+            val ex = shouldThrow<EtcdRecipeException> { provider.getInstance() }
+            ex.message shouldContain "my-service"
+        }
+
+        "getInstance returns a registered instance when one is present" {
+            val instance = serviceInstance("my-service", "payload")
+            val kv =
+                mockk<KeyValue> {
+                    every { key } returns "/services/names/my-service/abc".asByteSequence
+                    every { value } returns instance.toJson().asByteSequence
+                }
+            val provider = ServiceProvider(clientReturning(listOf(kv)), "/services/names", "my-service")
+
+            provider.getInstance().name shouldBe "my-service"
+        }
+    }
+}


### PR DESCRIPTION
Two low-risk review findings, batched.

## #10 — `ServiceProvider.getInstance()` leaked a bare JDK exception (error-handling)
`getInstance() = getAllInstances().random()` threw a context-free `NoSuchElementException` when no instances were registered — an ordinary, expected discovery condition, and inconsistent with `ServiceDiscovery.queryForInstance`, which throws the library's `EtcdRecipeException` for the absent case.

**Fix:** `randomOrNull() ?: throw EtcdRecipeException("No instances available for service $serviceName")`, annotated `@Throws(EtcdRecipeException::class)`. The non-null `ServiceInstance` return contract is preserved, and it now matches the module's convention. (Verified there are no callers relying on the old exception.)

## #12 — `EtcdConnector.exceptions` returned the live synchronized list (concurrency)
The getter handed back the live `Collections.synchronizedList` that background recipe threads append to (the keep-alive `onError` callbacks added in #38/#39, plus watcher threads). `synchronizedList` only guards individual operations, so a caller iterating the returned list while a worker appends could hit a `ConcurrentModificationException`.

**Fix:** return a defensive snapshot taken under the list's own monitor:
```kotlin
get() = if (exceptionList.isInitialized())
          synchronized(exceptionList.value) { exceptionList.value.toList() }
        else emptyList()
```
The `synchronized` is required (a bare `toList()` still iterates). It locks the *same* monitor the single-arg `synchronizedList` factory uses internally for `add()` (`mutex = this`), so the snapshot is consistent. `hasExceptions` (`isNotEmpty()`) and `clearExceptions` (`clear()`) are single atomic ops that don't iterate, so they're left unguarded.

## Tests (MockK, no etcd)
- `ServiceProviderTests` — `getInstance()` throws a typed, service-named `EtcdRecipeException` when empty, and returns the instance when present.
- `EtcdConnectorExceptionsTests` — `exceptions` returns a defensive copy that a later append does not mutate (would reflect the append if it were the live list).

Verified the existing `.exceptions` consumer (`TransientKeyValueKeepAliveErrorTests`) still passes, plus lint + detekt. An adversarial review of the diff confirmed the monitor correctness, the completeness of the #12 guard, and the #10 contract preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)