### PR TITLE
Apply low-priority review cleanups (#13-#25)

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -38,7 +38,6 @@ import io.etcd.recipes.common.setTo
 import io.etcd.recipes.common.transaction
 import io.etcd.recipes.common.watchOption
 import io.etcd.recipes.common.withWatcher
-import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.atomics.AtomicBoolean
@@ -87,7 +86,7 @@ constructor(
       // Create unique token to avoid collision from clients with same id
       val uniqueToken = "$clientId:${randomId(TOKEN_LENGTH)}"
 
-      // Prime lease with 2 seconds to give keepAlive a chance to get started
+      // Grant the barrier lease with the configurable TTL; keepAlive renews it until the barrier is removed
       val lease = client.leaseGrant(leaseTtlSecs.seconds)
 
       // Do a CAS on the key name. If it is not found, then set it
@@ -175,8 +174,6 @@ constructor(
   }
 
   companion object {
-    private val logger = KotlinLogging.logger {}
-
     internal fun defaultClientId() = EtcdConnector.defaultClientId(DistributedBarrier::class.simpleName!!)
   }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -280,7 +280,13 @@ class PathChildrenCache(
   val currentData: List<ChildData> get() = cacheMap.map { (k, v) -> ChildData(k, v) }.sortedBy { it.key }
 
   // For consistency with Curator
-  fun getCurrentData(path: String): ByteSequence? = cacheMap[path]
+
+  /**
+   * Returns the cached value for [childName], the child name relative to `cachePath` (the same keys
+   * exposed by [currentDataAsMap]) — NOT a full path. Passing a full path such as `cachePath/k1`
+   * returns `null`.
+   */
+  fun getCurrentData(childName: String): ByteSequence? = cacheMap[childName]
 
   val currentDataAsMap: Map<String, ByteSequence> get() = cacheMap.toMap()
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCacheEvent.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCacheEvent.kt
@@ -43,5 +43,5 @@ class PathChildrenCacheEvent(
    */
   val initialData: List<ChildData> get() = initialDataVal
 
-  override fun toString() = "PathChildrenCacheEvent{type=$type, data=$data}"
+  override fun toString() = "PathChildrenCacheEvent{type=$type, childName=$childName, data=$data}"
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ChildrenExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ChildrenExtensions.kt
@@ -23,6 +23,7 @@ import com.pambrose.common.util.ensureSuffix
 import io.etcd.jetcd.ByteSequence
 import io.etcd.jetcd.Client
 import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.options.DeleteOption
 import io.etcd.jetcd.options.GetOption
 import io.etcd.jetcd.options.GetOption.SortOrder
 
@@ -87,7 +88,15 @@ fun Client.getChildrenValues(
 ): List<ByteSequence> = getChildren(keyName, target, order).values
 
 // Delete children keys
-fun Client.deleteChildren(keyName: String): List<String> = getChildrenKeys(keyName).onEach { deleteKey(it) }
+fun Client.deleteChildren(keyName: String): List<String> {
+  val trailingKey = keyName.ensureSuffix("/")
+  val deleteOption =
+    deleteOption {
+      isPrefix(true)
+      withPrevKV(true)
+    }
+  return kvClient.delete(trailingKey.asByteSequence, deleteOption).get().prevKvs.map { it.key.asString }
+}
 
 // Count children keys
 fun Client.getChildCount(keyName: String): Long {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/KVExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/KVExtensions.kt
@@ -27,6 +27,8 @@ import io.etcd.jetcd.kv.PutResponse
 import io.etcd.jetcd.options.GetOption
 import io.etcd.jetcd.options.PutOption
 
+private const val MAX_GET_ATTEMPTS = 10
+
 @JvmOverloads
 fun Client.putValue(
   keyName: String,
@@ -68,8 +70,10 @@ internal fun Client.getResponse(
 ): GetResponse {
   val response = kvClient.get(keyName, option).get()
   return if (response.kvs.isEmpty() && response.isMore) {
-    if (iteration == 10)
-      throw EtcdRecipeRuntimeException("Unable to fulfill call to getResponse after multiple attempts")
+    if (iteration >= MAX_GET_ATTEMPTS)
+      throw EtcdRecipeRuntimeException(
+        "Unable to fulfill call to getResponse for key ${keyName.asString} after $iteration attempts",
+      )
     getResponse(keyName, option, iteration + 1)
   } else {
     response

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
@@ -25,10 +25,13 @@ import io.etcd.jetcd.options.WatchOption
 import io.etcd.jetcd.watch.WatchEvent
 import io.etcd.jetcd.watch.WatchEvent.EventType
 import io.etcd.jetcd.watch.WatchResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+
+private val logger = KotlinLogging.logger {}
 
 val WatchEvent.keyAsString get() = keyValue.key.asString
 val WatchEvent.keyAsInt get() = keyValue.key.asInt
@@ -73,7 +76,17 @@ private class DispatchingWatcher(
     // returned — touching state the caller assumes is no longer in use. A
     // short bounded wait makes the close-then-touch contract real without
     // turning into a blocker on a misbehaving callback.
-    dispatcher.awaitTermination(5, TimeUnit.SECONDS)
+    try {
+      if (!dispatcher.awaitTermination(5, TimeUnit.SECONDS)) {
+        // The callback outran the bounded wait, so the close-then-touch contract
+        // cannot be honored — surface it rather than pretending the dispatcher drained.
+        logger.warn { "Watch dispatcher did not terminate within 5 seconds; a callback may still be running" }
+      }
+    } catch (e: InterruptedException) {
+      // awaitTermination clears the interrupt flag on InterruptedException; restore it
+      // so callers up the stack can still observe the interruption.
+      Thread.currentThread().interrupt()
+    }
   }
 }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceDiscovery.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceDiscovery.kt
@@ -110,8 +110,8 @@ constructor(
   fun queryForInstances(name: String): List<ServiceInstance> {
     checkCloseNotCalled()
     return client.getChildrenValues(namesPath.appendToPath(name)).map {
-      it.asString
-    }.map { ServiceInstance.toObject(it) }
+      ServiceInstance.toObject(it.asString)
+    }
   }
 
   @Synchronized

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceProvider.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceProvider.kt
@@ -38,7 +38,7 @@ class ServiceProvider(
   fun getInstance(): ServiceInstance = getAllInstances().random()
 
   fun getAllInstances(): List<ServiceInstance> =
-    client.getChildrenValues(instancesPath).map { it.asString }.map { ServiceInstance.toObject(it) }
+    client.getChildrenValues(instancesPath).map { ServiceInstance.toObject(it.asString) }
 
   override fun close() {
     // No owned resources: provider does not hold a watcher, lease, or executor.

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderListener.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderListener.kt
@@ -22,4 +22,12 @@ interface LeaderListener {
   fun takeLeadership(leaderName: String)
 
   fun relinquishLeadership()
+
+  /**
+   * Invoked when a [takeLeadership] or [relinquishLeadership] callback throws while being
+   * dispatched from the leader watch loop. The default is a no-op, so existing Kotlin and Java
+   * implementors remain source- and binary-compatible; override it to surface the failure
+   * programmatically. The watch loop continues running after this is called.
+   */
+  fun onError(e: Throwable) {}
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -308,11 +308,14 @@ constructor(
         break
       }
 
+      // Only sleep when another attempt will follow; on the last iteration just log
+      // the exhaustion and let the loop end (the CAS below then fails and throws as
+      // before). This also avoids a redundant final ~1s sleep past the intended bound.
       if (i == attemptCount - 1) {
         logger.error { "Exhausted wait for deletion of participation key $path" }
+      } else {
+        sleep(1.seconds)
       }
-
-      sleep(1.seconds)
     }
 
     // Prime lease with leaseTtlSecs seconds to give keepAlive a chance to get started
@@ -462,6 +465,7 @@ constructor(
                   }
                 } catch (e: Throwable) {
                   logger.error(e) { "Exception in reportLeader()" }
+                  listener.onError(e)
                 }
               }
             },

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -101,11 +101,19 @@ abstract class AbstractQueue(
       // watchLatch's monitor, so holding it while a gRPC response is pending
       // deadlocks the event loop and never delivers the response.
       //
-      // The poll result is authoritative for ordering — it returns the
-      // queue's actual first item by mod revision, which may pre-date any
-      // PUT the watcher saw if PUTs slipped in between watcher.use { } and
-      // the watch actually being live in jetcd. Override keyFound so we
-      // always dequeue the oldest item.
+      // When the receiver poll wins the race (watchLatch is still latched),
+      // it is authoritative for ordering — it returns the queue's actual
+      // first item by mod revision, which may pre-date any PUT the watcher
+      // saw if PUTs slipped in between watcher.use { } and the watch actually
+      // being live in jetcd, so we override keyFound and dequeue the
+      // highest-priority/oldest item. But this override only runs while the
+      // latch is still up: under a producer/watcher race where the watch
+      // callback fires first, keyFound already holds whatever PUT the watcher
+      // observed and dequeue returns that available item rather than the
+      // strict highest-priority/oldest one. Delivery is still safe regardless
+      // of which side wins — no loss or duplication — because the
+      // deleteRevKey CAS rejects a stale candidate and the outer retry loop
+      // re-reads the queue.
       if (watchLatch.count > 0) {
         val waitingChildList = client.getFirstChild(queuePath, target).kvs
         if (waitingChildList.isNotEmpty()) {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/util/LeaderReporter.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/util/LeaderReporter.kt
@@ -37,21 +37,20 @@ fun main() {
       urls,
       electionPath,
       object : LeaderListener {
-        val electedClock = Monotonic
-        val unelectedClock = Monotonic
-        var electedTime = electedClock.markNow()
-        var unelectedTime = unelectedClock.markNow()
+        val clock = Monotonic
+        var electedTime = clock.markNow()
+        var unelectedTime = clock.markNow()
         var currentLeader = ""
 
         override fun takeLeadership(leaderName: String) {
           logger.info {"$leaderName is now the leader [Break time: ${unelectedTime.elapsedNow()}]"}
           currentLeader = leaderName
-          electedTime = electedClock.markNow()
+          electedTime = clock.markNow()
         }
 
         override fun relinquishLeadership() {
           logger.info {"$currentLeader is no longer the leader, after being leader for: ${electedTime.elapsedNow()}"}
-          unelectedTime = unelectedClock.markNow()
+          unelectedTime = clock.markNow()
         }
       },
       executor,

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/util/ShowKeys.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/util/ShowKeys.kt
@@ -21,7 +21,6 @@ package io.etcd.recipes.util
 import com.pambrose.common.util.sleep
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.connectToEtcd
-import io.etcd.recipes.common.getChildCount
 import io.etcd.recipes.common.getChildren
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.Duration.Companion.seconds
@@ -33,8 +32,9 @@ fun main() {
 
   connectToEtcd(urls) { client ->
     repeat(600) {
-      logger.info { client.getChildren(path).asString }
-      logger.info { client.getChildCount(path) }
+      val children = client.getChildren(path)
+      logger.info { children.asString }
+      logger.info { children.size }
       sleep(1.seconds)
     }
   }


### PR DESCRIPTION
A batch of 13 small, low-risk cleanups from the code review (the low-priority tail). Behavior-preserving except the intended minor changes in #13/#15/#16/#17.

| # | File | Change |
|---|------|--------|
| 13 | `common/ChildrenExtensions` | `deleteChildren` does one atomic ranged prefix delete (`isPrefix`+`withPrevKV`) instead of a GET + N per-key deletes; returns the deleted keys (`List<String>` contract preserved) |
| 14 | `common/KVExtensions` | `getResponse` retry uses a named `MAX_GET_ATTEMPTS` const with a `>=` guard (no unbounded recursion for a non-zero start) and a key/attempt-count message |
| 15 | `common/WatchExtensions` | `DispatchingWatcher.close()` checks the `awaitTermination` result (warns on timeout) and restores the interrupt flag on `InterruptedException` |
| 16 | `election/LeaderListener`, `LeaderSelector` | add a no-op default `LeaderListener.onError(Throwable)` and route `reportLeader`'s caught callback failures to it (still logged; watch loop unaffected) |
| 17 | `election/LeaderSelector` | drop the redundant final `sleep` in `advertiseParticipation`'s wait loop (sleep only when a retry follows) |
| 18 | `cache/PathChildrenCache` | rename `getCurrentData` param to `childName` + KDoc clarifying it's the stripped child name, not a full path |
| 19 | `queue/AbstractQueue` | correct the dequeue ordering comment (returns an available item under a producer/watcher race; delivery still guaranteed by the CAS retry) |
| 20 | `cache/PathChildrenCacheEvent` | include `childName` in `toString()` |
| 21 | `barrier/DistributedBarrier` | remove the dead `logger` and its unused import |
| 22 | `barrier/DistributedBarrier` | reword the stale "2-second prime lease" comment to reflect the configurable `leaseTtlSecs` grant |
| 23 | `discovery/ServiceDiscovery`, `ServiceProvider` | collapse the double `.map { asString }.map { toObject }` into one map |
| 24 | `util/ShowKeys` | reuse one `getChildren` read for both log lines (drop the redundant `getChildCount` round-trip) |
| 25 | `util/LeaderReporter` | collapse the two identical `Monotonic` clock fields to one |

## Verification
- compile + ktlint + detekt clean.
- Full **non-container Testcontainers suite** green across common/cache/queue/discovery/election/barrier/keyvalue/counter — this exercises `deleteChildren` in every test's teardown and the watcher-close path.
- Adversarial review of the combined diff returned **ship**: all 13 findings confirmed applied; `deleteChildren`'s prefix-delete confirmed contract-preserving and equivalent-or-better for the (return-ignoring) callers; no silent behavior changes; and the two concurrent edits to `LeaderSelector.kt` both landed intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)