### PR TITLE
Validate priority-queue Int priorities and drop redundant post-CAS GETs

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -25,10 +25,8 @@ import io.etcd.jetcd.support.CloseableClient
 import io.etcd.jetcd.watch.WatchEvent.EventType.DELETE
 import io.etcd.recipes.barrier.DistributedBarrier.Companion.defaultClientId
 import io.etcd.recipes.common.EtcdConnector
-import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.deleteKey
 import io.etcd.recipes.common.doesNotExist
-import io.etcd.recipes.common.getValue
 import io.etcd.recipes.common.isKeyPresent
 import io.etcd.recipes.common.keepAlive
 import io.etcd.recipes.common.leaseGrant
@@ -96,8 +94,10 @@ constructor(
           Then(barrierPath.setTo(uniqueToken, putOption { withLeaseId(lease.id) }))
         }
 
-      // Check to see if unique value was successfully set in the CAS step
-      if (txn.isSucceeded && client.getValue(barrierPath)?.asString == uniqueToken) {
+      // The CAS is authoritative: txn.isSucceeded means this client created the
+      // barrier key. (The previous getValue re-read only guarded the tiny window
+      // where a concurrent removeBarrier ran between commit and read.)
+      if (txn.isSucceeded) {
         keepAliveLease = client.keepAlive(lease) { e -> exceptionList.value += e }
         true
       } else {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -36,7 +36,6 @@ import io.etcd.recipes.common.deleteOp
 import io.etcd.recipes.common.doesExist
 import io.etcd.recipes.common.doesNotExist
 import io.etcd.recipes.common.getChildCount
-import io.etcd.recipes.common.getValue
 import io.etcd.recipes.common.isKeyPresent
 import io.etcd.recipes.common.keepAlive
 import io.etcd.recipes.common.leaseGrant
@@ -188,11 +187,8 @@ constructor(
           throw EtcdRecipeException("Failed to set waitingPath")
         }
 
-        client.getValue(myWaitingPath)?.asString != uniqueToken -> {
-          client.leaseRevoke(lease)
-          throw EtcdRecipeException("Failed to assign waitingPath unique value")
-        }
-
+        // No getValue re-read: txn.isSucceeded already proves this client set the
+        // waiting-path key (the re-read only guarded a commit-to-read race window).
         else -> {
           // Keep key alive
           keepAliveLease = client.keepAlive(lease) { e -> exceptionList.value += e }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/counter/DistributedAtomicLong.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/counter/DistributedAtomicLong.kt
@@ -121,16 +121,15 @@ constructor(
     }
   }
 
+  // The If(doesNotExist) predicate is itself the atomic "is it absent?" check, so the
+  // prior getResponse(counterPath).kvs.isEmpty() GET was a redundant extra round-trip.
+  // Returns true if this call created the counter, false if it already existed.
   private fun createCounterIfNotPresent(): Boolean =
-    if (client.getResponse(counterPath).kvs.isEmpty()) {
-      client
-        .transaction {
-          If(counterPath.doesNotExist)
-          Then(counterPath setTo default)
-        }.isSucceeded
-    } else {
-      false
-    }
+    client
+      .transaction {
+        If(counterPath.doesNotExist)
+        Then(counterPath setTo default)
+      }.isSucceeded
 
   private fun applyCounterTransaction(amount: Long): Pair<TxnResponse, Long> {
     val kvList: List<KeyValue> = client.getResponse(counterPath).kvs

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -370,8 +370,10 @@ constructor(
             Then(leaderPath.setTo(uniqueToken, putOption { withLeaseId(granted.id) }))
           }
 
-        // Check to see if unique value was successfully set in the CAS step
-        if (!txn.isSucceeded || client.getValue(leaderPath)?.asString != uniqueToken) {
+        // The CAS is authoritative: txn.isSucceeded means this client created the
+        // leader key with uniqueToken. (The previous getValue re-read only guarded
+        // the tiny window where another client overwrote it between commit and read.)
+        if (!txn.isSucceeded) {
           // Failed to become leader: revoke the lease we just created so it does
           // not linger in etcd until TTL. Without this, every losing candidate in
           // an election leaks a lease per turnover.

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedPriorityQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedPriorityQueue.kt
@@ -53,22 +53,22 @@ class DistributedPriorityQueue(
   fun enqueue(
     value: String,
     priority: Int,
-  ) = enqueue(value.asByteSequence, priority.toUShort())
+  ) = enqueue(value.asByteSequence, priority.toCheckedPriority())
 
   fun enqueue(
     value: Int,
     priority: Int,
-  ) = enqueue(value.asByteSequence, priority.toUShort())
+  ) = enqueue(value.asByteSequence, priority.toCheckedPriority())
 
   fun enqueue(
     value: Long,
     priority: Int,
-  ) = enqueue(value.asByteSequence, priority.toUShort())
+  ) = enqueue(value.asByteSequence, priority.toCheckedPriority())
 
   fun enqueue(
     value: ByteSequence,
     priority: Int,
-  ) = enqueue(value, priority.toUShort())
+  ) = enqueue(value, priority.toCheckedPriority())
 
   fun enqueue(
     value: String,
@@ -92,6 +92,14 @@ class DistributedPriorityQueue(
     checkCloseNotCalled()
     val prefix = "%s/%05d".format(queuePath, priority.toInt())
     newSequentialKV(prefix, value)
+  }
+
+  // Validate Int priorities rather than silently truncating them. priority.toUShort()
+  // wraps mod 65536 (e.g. 70000 -> 4464, -1 -> 65535), which would file the entry in
+  // the wrong sort bucket with no diagnostic.
+  private fun Int.toCheckedPriority(): UShort {
+    require(this in 0..UShort.MAX_VALUE.toInt()) { "priority must be in 0..${UShort.MAX_VALUE.toInt()}, was $this" }
+    return toUShort()
   }
 
   private fun newSequentialKV(

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueuePriorityTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueuePriorityTests.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.queue
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.asByteSequence
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.mockk.mockk
+import kotlin.time.Duration.Companion.milliseconds
+
+class DistributedPriorityQueuePriorityTests : StringSpec() {
+    // The priority check runs as the enqueue argument is evaluated, before any etcd
+    // call, so a never-stubbed mock client suffices (and confirms no I/O happens).
+    private fun queue() = DistributedPriorityQueue(mockk<Client>(), "/pqueue", minimumWaitTime = 0.milliseconds)
+
+    init {
+        // Regression test for #9: out-of-range Int priorities must be rejected, not
+        // silently truncated mod 65536 (70000 -> 4464, -1 -> 65535), which would file
+        // the entry in the wrong sort bucket with no diagnostic. Exercises all four
+        // Int-priority overloads (String/Int/Long/ByteSequence value), each of which
+        // routes through toCheckedPriority() before any etcd call.
+        "enqueue rejects an above-range Int priority on every typed overload" {
+            val q = queue()
+            shouldThrow<IllegalArgumentException> { q.enqueue("v", 70000) }
+            shouldThrow<IllegalArgumentException> { q.enqueue(42, 70000) }
+            shouldThrow<IllegalArgumentException> { q.enqueue(42L, 70000) }
+            shouldThrow<IllegalArgumentException> { q.enqueue("v".asByteSequence, 70000) }
+        }
+
+        "enqueue rejects a negative Int priority on every typed overload" {
+            val q = queue()
+            shouldThrow<IllegalArgumentException> { q.enqueue("v", -1) }
+            shouldThrow<IllegalArgumentException> { q.enqueue(42, -1) }
+            shouldThrow<IllegalArgumentException> { q.enqueue(42L, -1) }
+            shouldThrow<IllegalArgumentException> { q.enqueue("v".asByteSequence, -1) }
+        }
+    }
+}


### PR DESCRIPTION
The last two open code-review findings (#9, #11).

## #9 — Int priority silently truncated to UShort (api, medium)
`DistributedPriorityQueue`'s four `Int`-priority `enqueue` overloads called `priority.toUShort()`, which wraps mod 65536 with no diagnostic — `enqueue(v, 70000)` landed at 4464, `enqueue(v, -1)` at 65535, filing the entry in the wrong sort bucket.

**Fix:** route the four `Int` overloads through a private `Int.toCheckedPriority()` that `require()`s `0..65535`. The `UShort` overloads are unchanged.

## #11 — Redundant GET after an authoritative CAS (efficiency, low)
Four sites re-read the key with `getValue` after a CAS that `txn.isSucceeded` already proves succeeded:
- `DistributedBarrier.setBarrier` — gate on `txn.isSucceeded`
- `DistributedBarrierWithCount.waitOnBarrier` — removed the redundant `when` branch
- `LeaderSelector.attemptToBecomeLeader` — gate on `txn.isSucceeded`
- `DistributedAtomicLong.createCounterIfNotPresent` — drop the `getResponse().kvs.isEmpty()` GET before its idempotent `If(doesNotExist)` txn

Each site keeps a comment naming the tiny commit-to-read race the re-read used to guard (the review judged it pure overhead). Removed the now-unused `getValue`/`asString` imports in the barrier files (kept where still used elsewhere).

## Tests
`DistributedPriorityQueuePriorityTests` (no etcd) asserts out-of-range `Int` priorities throw `IllegalArgumentException` before any client call. #11 is behavior-preserving and covered by the existing barrier/election/counter suites.

Verified with the **full `check koverXmlReport -PuseTestcontainers`** (including the `design` package — `DesignFixesTests` static/reflection guards on these exact files — and the `container` package), plus lint + detekt. The change deliberately preserves the guards `DesignFixesTests` enforces (`DistributedBarrier.keepAliveLease` stays a plain var; `LeaderSelector` keeps `client.leaseGrant(`; `DistributedAtomicLong` constructor still does no I/O).

🤖 Generated with [Claude Code](https://claude.com/claude-code)