### PR TITLE
Fix DistributedBarrierWithCount keep-alive client leak/double-close race

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -122,7 +122,7 @@ constructor(
   @Suppress("CyclomaticComplexMethod", "LongMethod")
   @Throws(InterruptedException::class, EtcdRecipeException::class)
   fun waitOnBarrier(timeout: Duration): Boolean {
-    var keepAliveLease: CloseableClient? = null
+    val keepAliveLease = AtomicReference<CloseableClient?>(null)
     val keepAliveClosed = BooleanMonitor(false)
     val cancelled = BooleanMonitor(false)
     val uniqueToken = "$clientId:${randomId(TOKEN_LENGTH)}"
@@ -132,12 +132,17 @@ constructor(
     checkCloseNotCalled()
 
     fun closeKeepAlive() {
-      if (!keepAliveClosed.get()) {
-        keepAliveLease?.close()
-        keepAliveLease = null
+      // Atomically claim the keep-alive client so it is closed exactly once across the
+      // waiter / watch-dispatcher / close() threads: whoever exchanges the non-null ref
+      // is the unique closer. Driving idempotency off the exchange (rather than a
+      // check-then-act on keepAliveClosed) also closes the leak where a close() that
+      // arrived before the client was assigned would flip keepAliveClosed and strand
+      // the just-created client. keepAliveClosed stays purely the wait/signal flag.
+      keepAliveLease.exchange(null)?.let { kac ->
+        kac.close()
         runCatching { client.deleteKey(myWaitingPath) }
-        keepAliveClosed.set(true)
       }
+      keepAliveClosed.set(true)
     }
 
     fun checkWaiterCount() {
@@ -191,7 +196,13 @@ constructor(
         // waiting-path key (the re-read only guarded a commit-to-read race window).
         else -> {
           // Keep key alive
-          keepAliveLease = client.keepAlive(lease) { e -> exceptionList.value += e }
+          keepAliveLease.store(client.keepAlive(lease) { e -> exceptionList.value += e })
+
+          // Reconcile with a close() that may have fired before the store above: its
+          // closeKeepAlive() would have found a null ref and closed nothing, stranding
+          // the just-created client. onCancel sets `cancelled` before calling
+          // closeKeepAlive(), so observing it here means we own closing our client.
+          if (cancelled.get()) closeKeepAlive()
 
           checkWaiterCount()
 


### PR DESCRIPTION
The final open code-review finding (#5, concurrency/medium).

## The race
In `DistributedBarrierWithCount.waitOnBarrier()`, `keepAliveLease` was a plain local `var CloseableClient?` written by the waiter (after the CAS) and read/nulled by `closeKeepAlive()` from up to three threads — the waiter (`checkWaiterCount`), the watch dispatcher, and `close()` → `onCancel` — with no happens-before edge. `closeKeepAlive()` guarded its close+delete with a check-then-act on the `keepAliveClosed` monitor.

A `close()` arriving in the window between the cancel-hook registration (`activeWaiter.store`) and the `keepAliveLease` assignment ran `closeKeepAlive()` while the ref was still null: it closed nothing, flipped `keepAliveClosed`, and the waiter's just-created `CloseableClient` was then **never closed** — a leaked keep-alive stream that keeps renewing the lease. The check-then-act also allowed double-close/double-delete.

## The fix
- `keepAliveLease` → `kotlin.concurrent.atomics.AtomicReference<CloseableClient?>`.
- `closeKeepAlive()` claims the client with a single atomic `exchange(null)`: whoever retrieves the non-null ref is the **unique closer** (`close()` + best-effort `deleteKey`). Idempotency is driven off the exchange result, not the monitor. `keepAliveClosed.set(true)` is now unconditional — purely the wait/signal flag (strictly stronger than before).
- After storing the client the waiter reconciles with an early `close()`: `if (cancelled.get()) closeKeepAlive()`. `onCancel` sets `cancelled` **before** calling `closeKeepAlive()`, and the cancel hook is registered **before** the store, so observing `cancelled` after the store provably catches the stranded-client window in every interleaving.

This establishes happens-before across the three threads and makes cleanup ordered and exactly-once.

## Verification
The leak is a nanosecond window between hook-registration and assignment that can't be reproduced deterministically, so:
- Full `check koverXmlReport -PuseTestcontainers` is green — including `DesignFixesTests "fix #2"` (close unblocks an in-flight `waitOnBarrier`), `"fix #10"` (the **`DistributedBarrier`** field stays a plain var — this change is to `DistributedBarrierWithCount`'s method-local, so no conflict), the barrier/watcher suites, and `ContainerBarrierTest`.
- An adversarial interleaving review confirmed: exactly-once close, no leak in any store-vs-onCancel ordering, no double-close/double-delete, and preserved cancellation signalling.

With this, **all 25 findings from the code review are resolved.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)