### PR TITLE
Restore strict priority/FIFO ordering on the empty-queue dequeue wait

### DIFF
--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -95,25 +95,12 @@ abstract class AbstractQueue(
         }
       },
     ) {
-      // Query again in case a value arrived just before watch was created.
-      // The gRPC call must run *outside* the synchronized block: the watcher
-      // callback executes on the jetcd Vert.x event loop and also takes
-      // watchLatch's monitor, so holding it while a gRPC response is pending
-      // deadlocks the event loop and never delivers the response.
-      //
-      // When the receiver poll wins the race (watchLatch is still latched),
-      // it is authoritative for ordering — it returns the queue's actual
-      // first item by mod revision, which may pre-date any PUT the watcher
-      // saw if PUTs slipped in between watcher.use { } and the watch actually
-      // being live in jetcd, so we override keyFound and dequeue the
-      // highest-priority/oldest item. But this override only runs while the
-      // latch is still up: under a producer/watcher race where the watch
-      // callback fires first, keyFound already holds whatever PUT the watcher
-      // observed and dequeue returns that available item rather than the
-      // strict highest-priority/oldest one. Delivery is still safe regardless
-      // of which side wins — no loss or duplication — because the
-      // deleteRevKey CAS rejects a stale candidate and the outer retry loop
-      // re-reads the queue.
+      // Poll once to UNBLOCK: a value may have arrived between watcher.use { } and the
+      // watch going live in jetcd, and the watcher never delivers such a pre-live PUT,
+      // so a poll is needed to count the latch down. The gRPC call must run *outside*
+      // the synchronized block — the watcher callback runs on the jetcd Vert.x event
+      // loop and also takes watchLatch's monitor, so holding it while a gRPC response
+      // is pending would deadlock the event loop and never deliver the response.
       if (watchLatch.count > 0) {
         val waitingChildList = client.getFirstChild(queuePath, target).kvs
         if (waitingChildList.isNotEmpty()) {
@@ -124,7 +111,16 @@ abstract class AbstractQueue(
         }
       }
       watchLatch.await()
-      keyFound.get()
+
+      // STRICT ORDERING: whichever PUT the watcher observed first (in keyFound) is not
+      // necessarily the head by sort order — a lower-priority key can be committed just
+      // before a higher-priority one. So after waking, re-query the actual first child
+      // by `target` and prefer it; this routes the wake-up path through the SAME
+      // head-selection as the non-empty fast path above, guaranteeing the
+      // highest-priority (KEY) / oldest (MOD) item. Fall back to the watcher's event only if the re-query is
+      // empty (a concurrent consumer already took the head) — the deleteRevKey CAS and
+      // the outer retry loop then still guarantee no loss or duplication.
+      client.getFirstChild(queuePath, target).kvs.firstOrNull() ?: keyFound.get()
     }
   }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueueTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueueTest.kt
@@ -19,6 +19,7 @@
 package io.etcd.recipes.queue
 
 import com.pambrose.common.concurrent.thread
+import com.pambrose.common.util.sleep
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.deleteChildren
@@ -192,6 +193,52 @@ class DistributedPriorityQueueTest : StringSpec() {
             dequeuedData.size shouldBe testData.size
             repeat(dequeuedData.size) { i -> dequeuedData[i] shouldBe testData[i] }
             dequeuedData shouldBe testData
+        }
+
+        // #19: a consumer parked on an empty queue must deliver every item of a
+        // mixed-priority burst exactly once via the re-query-on-wake path. Strict
+        // ordering of the woken item comes from the same getFirstChild head-selection
+        // that serialTestNoWaitWithPriorities verifies; the burst-arrival race itself
+        // is not deterministically orderable, so this guards delivery, not order.
+        "emptyWaitDeliversEveryMixedPriorityItemExactlyOnce" {
+            val queuePath = "$basePath/emptyWaitMixedPriority"
+            val count = 25
+            val values = List(count) { "mp%03d".format(it) }
+            val dequeued = synchronizedList(mutableListOf<String>())
+            val dequeueLatch = CountDownLatch(1)
+            val enqueueLatch = CountDownLatch(1)
+            val consumerReady = CountDownLatch(1)
+
+            connectToEtcd(urls) { client ->
+                client.deleteChildren(queuePath)
+                client.getChildCount(queuePath) shouldBe 0
+            }
+
+            thread(dequeueLatch) {
+                connectToEtcd(urls) { client ->
+                    withDistributedPriorityQueue(client, queuePath) {
+                        consumerReady.countDown()
+                        repeat(count) { dequeued += dequeue().asString }
+                    }
+                }
+            }
+
+            thread(enqueueLatch) {
+                connectToEtcd(urls) { client ->
+                    consumerReady.await()
+                    // Let the consumer reach the empty-queue wait, then burst-enqueue
+                    // distinct priorities in descending order (the head is enqueued last).
+                    sleep(2.seconds)
+                    withDistributedPriorityQueue(client, queuePath) {
+                        values.forEachIndexed { i, v -> enqueue(v, count - i) }
+                    }
+                }
+            }
+
+            dequeueLatch.await()
+            enqueueLatch.await()
+
+            dequeued shouldContainExactlyInAnyOrder values
         }
 
         "threadedTestNoWait1" {


### PR DESCRIPTION
Turns review finding #19 from a documented limitation into a real fix.

## The bug
`AbstractQueue.waitForFirstChild()` (the empty-queue wait path of `dequeue()`) returned `keyFound.get()` — whichever PUT the **watcher happened to observe first**, set via `compareAndSet(null, …)` in the callback. That is not necessarily the head by sort order: under a producer/watcher race, a lower-priority key committed just before a higher-priority one could be returned, so `DistributedPriorityQueue` could dequeue out of priority order. (Delivery was always safe; only ordering was weak.)

## The fix
After `watchLatch.await()`, re-query `getFirstChild(queuePath, target)` and prefer its first element, falling back to the watcher's event only if the re-query is empty:

```kotlin
client.getFirstChild(queuePath, target).kvs.firstOrNull() ?: keyFound.get()
```

This routes the wake-up path through the **same head-selection** as `dequeue()`'s non-empty fast path, so the highest-priority (`SortTarget.KEY`) / oldest (`SortTarget.MOD`) item is always returned. The pre-`await` poll (which counts the latch down to unblock a pre-live arrival) is unchanged. Exactly-once delivery is still guaranteed by the `deleteRevKey` CAS + the outer retry loop (a stale fallback candidate just loses the CAS and retries). Cost: one extra GET on the slow wait path only — never the fast path.

## Tests
- New `emptyWaitDeliversEveryMixedPriorityItemExactlyOnce` — a consumer parked on an empty queue delivers every item of a mixed-priority burst exactly once via the re-query path.
- Strict ordering itself is covered by the existing `serialTestNoWaitWithPriorities` (same `getFirstChild` selector) — the burst-arrival race is inherently non-deterministic to order, so that's verified by an adversarial interleaving review (**ship**: strict ordering, no loss/dup, no deadlock, no regression to uniform-priority/FIFO paths).

Verified with the full `check koverXmlReport -PuseTestcontainers` — `BUILD SUCCESSFUL`, including the `design` package (`DesignFixesTests`, e.g. the `dequeue()`-count guard) and all five `Container*Test` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)