### PR TITLE
Enable Testcontainers Ryuk reaper to silence prune-conflict warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -160,11 +160,15 @@ subprojects {
                     "TESTCONTAINERS_DOCKER_CLIENT_STRATEGY",
                     "org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy",
                 )
-                // Disable Ryuk: on Docker Desktop the reaper container
-                // tries to bind-mount the docker socket, which the engine
-                // refuses with "operation not supported". We register an
-                // explicit JVM shutdown hook in EtcdTestContainer instead.
-                environment("TESTCONTAINERS_RYUK_DISABLED", "true")
+                // Enable Ryuk (the single sidecar reaper) and explicitly override
+                // any ryuk.disabled=true left in ~/.testcontainers.properties — the
+                // env var takes precedence. With Ryuk off, Testcontainers falls back
+                // to JVMHookResourceReaper, whose per-JVM `docker prune` at shutdown
+                // races across parallel forks and floods stderr with 409 "a prune
+                // operation is already running". Ryuk avoids that; the explicit
+                // stop()/close() shutdown hooks in the fixtures remain as
+                // belt-and-suspenders cleanup.
+                environment("TESTCONTAINERS_RYUK_DISABLED", "false")
             }
 
             // The container-based tests (etcd-recipes/src/test/.../container) need

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdTestContainer.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdTestContainer.kt
@@ -29,10 +29,9 @@ internal object EtcdTestContainer {
 
   // Lazy: the container is only started when a test in this JVM actually
   // asks for the endpoint. With forkEvery=1 each test class is its own JVM,
-  // so this gives one container per test class. We register a shutdown
-  // hook because Ryuk is disabled in this setup (Docker Desktop refuses
-  // the bind-mount Ryuk needs); the hook ensures the container is stopped
-  // when the test JVM exits.
+  // so this gives one container per test class. Testcontainers' Ryuk reaper
+  // handles cleanup; the explicit shutdown hook is belt-and-suspenders that
+  // stops the container promptly when the test JVM exits.
   private val container: GenericContainer<*> by lazy {
     val c = GenericContainer(DockerImageName.parse(ETCD_IMAGE))
       .withExposedPorts(CLIENT_PORT, PEER_PORT)


### PR DESCRIPTION
## Problem

`make tests-container` (and `make tests-tc`) flood stderr with:

```
Exception in thread "Thread-6" com.github.dockerjava.api.exception.ConflictException:
Status 409: {"message":"a prune operation is already running"}
    ...
    at org.testcontainers.utility.JVMHookResourceReaper.prune(JVMHookResourceReaper.java:58)
```

## Root cause

The stack trace is Testcontainers' **own** internal reaper, not the fixtures' `stop()`/`close()` hooks. Because Ryuk was disabled, Testcontainers falls back to `JVMHookResourceReaper`, which issues a Docker `prune` from **each forked test JVM's** shutdown hook. Docker permits only one prune at a time, so the concurrent forks (`maxParallelForks = cores/2`) collide and the losers dump a 409.

The warnings were benign — tests passed and the fixtures' explicit shutdown hooks still cleaned up — but noisy on every container run.

## Fix

Re-enable Ryuk (`TESTCONTAINERS_RYUK_DISABLED=false`), which overrides `ryuk.disabled=true` in the user's `~/.testcontainers.properties`. Ryuk is a single sidecar reaper that never runs the per-JVM prune, so the conflict cannot occur. The Docker Desktop bind-mount refusal that originally motivated disabling Ryuk no longer reproduces. The explicit `stop()`/`close()` shutdown hooks in the fixtures are kept as belt-and-suspenders cleanup; the stale "Ryuk is disabled" comment in `EtcdTestContainer` is updated.

## Verification

Three `make tests-container` runs:

| Check | Result |
|---|---|
| BUILD | SUCCESSFUL (all 3) |
| Container tests | 5/5 PASSED |
| `409 prune` warnings | 0 (was many) |
| `Exception in thread` lines | 0 |
| Ryuk running | live `testcontainers/ryuk:0.14.0` container observed during a run |
| Leftover containers | none — Ryuk reaped everything |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
