### PR TITLE
Fail fast when local etcd is unreachable instead of hanging the test suite

### DIFF
--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/TestExtensions.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/TestExtensions.kt
@@ -21,16 +21,50 @@ package io.etcd.recipes.common
 import com.pambrose.common.concurrent.thread
 import com.pambrose.common.util.isNotNull
 import org.junit.jupiter.api.Assertions.fail
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
 import java.util.concurrent.CountDownLatch
 import kotlin.concurrent.thread
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+private const val LOCAL_ETCD_HOST = "localhost"
+private const val LOCAL_ETCD_PORT = 2379
 
 val urls: List<String> by lazy {
-  if (System.getProperty("etcd.recipes.testcontainers") == "true")
+  if (System.getProperty("etcd.recipes.testcontainers") == "true") {
     listOf(EtcdTestContainer.endpoint())
-  else
-    listOf("http://localhost:2379")
+  } else {
+    assertLocalEtcdReachable(LOCAL_ETCD_HOST, LOCAL_ETCD_PORT)
+    listOf("http://$LOCAL_ETCD_HOST:$LOCAL_ETCD_PORT")
+  }
+}
+
+/**
+ * Fail fast if nothing is accepting TCP connections at [host]:[port]. Runs only on the
+ * local-etcd path; the Testcontainers path waits for readiness before handing back an
+ * endpoint. Without this, jetcd blocks indefinitely on the initial connection when the
+ * local etcd was never started, so the whole suite hangs instead of failing with a
+ * clear message.
+ */
+private fun assertLocalEtcdReachable(
+  host: String,
+  port: Int,
+  timeout: Duration = 2.seconds,
+) {
+  try {
+    Socket().use { it.connect(InetSocketAddress(host, port), timeout.inWholeMilliseconds.toInt()) }
+  } catch (e: IOException) {
+    error(
+      """
+      No etcd reachable at $host:$port (${e.message}).
+      Start a local etcd with ./etcd.sh, or run the suite under Testcontainers:
+        make tests-tc      (./gradlew check -PuseTestcontainers)
+      """.trimIndent(),
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Every etcd-dependent test gets its endpoint from the shared `urls` helper in `TestExtensions.kt`. On the local-etcd path (`make tests`), if nothing is listening at `localhost:2379`, jetcd blocks **indefinitely** on the initial gRPC connection — its blocking `.get()` calls have no timeout — so the whole suite hangs rather than reporting the problem. Observed in practice as a run stuck at 91% for 19+ minutes: the static `DesignFixesTests` passed (they never touch etcd), while every barrier/cache/keep-alive class sat "EXECUTING" forever.

## Fix

Add a short (2s) TCP preflight, `assertLocalEtcdReachable`, on the **local-etcd branch of `urls`**. If nothing accepts a connection, it throws `IllegalStateException` with an actionable message:

```
No etcd reachable at localhost:2379 (Connection refused).
Start a local etcd with ./etcd.sh, or run the suite under Testcontainers:
  make tests-tc      (./gradlew check -PuseTestcontainers)
```

- **Testcontainers path untouched** — it already blocks on `Wait.forLogMessage` before returning an endpoint, so etcd is guaranteed up there.
- **Static tests unaffected** — `DesignFixesTests` and friends never reference `urls`.
- No per-test-class changes; the single shared chokepoint covers the whole suite.

## Verification

| Scenario | Result |
|---|---|
| etcd **down** → `DistributedBarrierTests` | Task **FAILED in ~5s** with the clear message (vs. the previous 19+ min hang) |
| etcd **up** → `DistributedBarrierTests` | 3 tests **PASSED**, `BUILD SUCCESSFUL` |
| `lintKotlinTest` | **BUILD SUCCESSFUL** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)