### PR TITLE
Extract Dokka/versions build config into functions and add all-tests target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default help clean clean-all stop build tests tests-tc tests-container coverage kdocs \
+.PHONY: default help clean clean-all stop build tests tests-tc tests-container all-tests coverage kdocs \
         lint detekt detekt-baseline refresh versions publish-local publish-local-snapshot \
         publish-snapshot publish-maven-central upgrade-wrapper \
         _check-gpg-env _require-version _require-gradle-version
@@ -53,6 +53,8 @@ tests-tc: ## Run the full test suite under Testcontainers (no local etcd require
 
 tests-container: ## Run only the multi-container tests (each participant in its own container)
 	DOCKER_HOST="$(DOCKER_HOST)" ./gradlew :etcd-recipes:cleanTest :etcd-recipes:test --tests "io.etcd.recipes.container.*" --no-build-cache -PuseTestcontainers
+
+all-tests: tests tests-tc tests-container ## Run all tests (local etcd, Testcontainers, and multi-container)
 
 coverage: ## Generate Kover HTML + XML coverage reports and print the summary
 	./gradlew koverHtmlReport koverXmlReport koverLog

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,9 @@
+import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.SourcesJar
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -60,12 +62,8 @@ dependencies {
     kover(project(libraryModule))
 }
 
-dokka {
-    pluginsConfiguration.html {
-        homepageLink.set(repoUrl)
-        footerMessage.set(libraryName)
-    }
-}
+configureDokka()
+configureVersions()
 
 subprojects {
     description = name
@@ -246,3 +244,32 @@ fun Project.configurePublishing() {
     }
 }
 
+fun Project.configureDokka() {
+    dokka {
+        pluginsConfiguration.html {
+            homepageLink.set(repoUrl)
+            footerMessage.set(libraryName)
+        }
+    }
+}
+
+fun Project.configureVersions() {
+    // A pre-release qualifier is a `.` or `-` delimiter followed by a known unstable
+    // keyword. `m\d` matches milestones (`-M1`/`.M2`) without catching stable classifiers
+    // like `-macos`/`-MR1`, and the `[.-]` delimiter catches both dash-style (`-alpha`)
+    // and dot-style (Netty's `.Beta1`) qualifiers while leaving `-jre`/`.Final` stable.
+    val preReleaseQualifier =
+        Regex("""[.-](rc|beta|alpha|m\d|cr|snapshot|eap|dev|milestone|pre)""", RegexOption.IGNORE_CASE)
+
+    fun isNonStable(version: String): Boolean = preReleaseQualifier.containsMatchIn(version)
+
+    tasks.withType<DependencyUpdatesTask>().configureEach {
+        notCompatibleWithConfigurationCache("the dependency updates plugin is not compatible with the configuration cache")
+        // Reject a pre-release candidate only when the current version is stable. For
+        // dependencies we intentionally track on a pre-release line (e.g. a detekt
+        // alpha), newer pre-releases are still surfaced as available updates.
+        rejectVersionIf {
+            isNonStable(candidate.version) && !isNonStable(currentVersion)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Small build-tooling cleanup — no behavior change to the library.

**`build.gradle.kts`**
- Move the inline `dokka {}` block into a `Project.configureDokka()` function.
- Add `Project.configureVersions()` to configure the ben-manes `dependencyUpdates` task (used by `make versions`):
  - Mark it configuration-cache-incompatible (the plugin doesn't support the config cache).
  - Reject pre-release candidates **only when the current version is stable**, so dependencies intentionally tracked on a pre-release line (e.g. a detekt alpha) still surface newer pre-releases. The qualifier regex matches `-M1`/`.Beta1`/`-alpha`-style markers while leaving stable classifiers like `-jre`/`.Final`/`-macos` alone.

**`Makefile`**
- Add an `all-tests` target that runs `tests`, `tests-tc`, and `tests-container` in sequence.

## Notes
- Orthogonal to the recently merged #49 (test infra); touches only `build.gradle.kts` and `Makefile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)