### PR TITLE
Add connection resilience, part 1: self-recovering watchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Connection-resilience release, part 1: watchers survive fatal stream deaths.
+
+### Added
+
+- `RetryPolicy` (exponential backoff / bounded / forever / never) pacing all watch
+  recovery, and `WatchResilience` / `ResilienceConfig` to tune or disable it
+  (`ResilienceConfig.DISABLED` restores pre-0.12 behavior). Every recipe constructor
+  takes an optional trailing `resilience` parameter.
+- Resilient watchers: `Client.watcher` now subscribes with jetcd's listener API,
+  tracks the last observed revision, auto-resubscribes after fatal stream deaths
+  (halt errors, "no leader"), and re-anchors after compaction via a resync hook.
+  Recovery is observable through `WatchRecoveryListener` events
+  (`Suspended` / `Resubscribed` / `Resynced` / `Failed`); `addRecoveryListener` on
+  `PathChildrenCache` and `ServiceCache`.
+- `Client.compact(revision, option)` KV extension.
+- Fault-injection test harness (container pause/unpause/restart with a
+  restart-stable client port) and fault tests under `io.etcd.recipes.fault`,
+  gated behind `-PuseTestcontainers`.
+
+### Changed
+
+- **Behavior:** watch-backed recipes no longer go silently stale after a fatal
+  watch death. `PathChildrenCache` and `ServiceCache` reconcile their maps during a
+  compaction resync; `LeaderSelector` re-probes the leader key after recovery (a
+  node can no longer permanently drop out of re-election); barrier waiters and
+  queue `dequeue()` re-check their condition after recovery and throw
+  `EtcdRecipeRuntimeException` if recovery is abandoned instead of parking forever.
+- Watchers request etcd progress notifications by default (`WatchResilience`),
+  so watch blocks may observe `WatchResponse`s with an empty event list.
+- `EtcdRecipeRuntimeException` gained an optional `cause` constructor parameter.
+
 ## [0.11.0] - 2026-06-03
 
 Hardening release. Most of the work closes lease leaks, `close()`/wait deadlocks,

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ DOCKER_HOST ?= unix://$(HOME)/.docker/run/docker.sock
 endif
 
 tests-tc: ## Run the full test suite under Testcontainers (no local etcd required)
+	# Fault-injection tests (io.etcd.recipes.fault.*) only run here: they pause/restart/
+	# compact their per-class etcd container and skip cleanly against a shared local etcd.
 	DOCKER_HOST="$(DOCKER_HOST)" ./gradlew check --rerun-tasks --no-build-cache -PuseTestcontainers
 
 tests-container: ## Run only the multi-container tests (each participant in its own container)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,48 @@ See the `etcd-recipes-examples/` module for runnable
 and [Kotlin](https://github.com/pambrose/etcd-recipes/tree/master/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples)
 demos of every recipe.
 
+## Connection resilience
+
+Watchers created through this library survive fatal watch-stream deaths — **on by
+default** as of 0.12.0. The division of labor:
+
+| Failure | Handled by | How |
+|---|---|---|
+| Connection blip, etcd restart | jetcd | Internal stream resume with revision continuity (~500&nbsp;ms retry) |
+| Compaction of the watched revision | etcd-recipes | Re-read state (recipe resync), re-anchor the watch at the fresh revision |
+| Halt-error statuses, "no leader" | etcd-recipes | Re-subscribe from the last observed revision with configurable backoff |
+
+Recipes that maintain derived state (`PathChildrenCache`, `ServiceCache`) reconcile
+their maps during a compaction resync instead of going silently stale; parked waiters
+(barriers, queue `dequeue()`, `LeaderSelector` re-election) re-probe their condition
+after every recovery, and an abandoned recovery unparks them with an error rather
+than hanging forever.
+
+Recovery pacing is a [`RetryPolicy`](etcd-recipes/src/main/kotlin/io/etcd/recipes/common/RetryPolicy.kt)
+(default: exponential backoff, 250&nbsp;ms → 15&nbsp;s, unbounded). Every recipe takes an
+optional trailing `ResilienceConfig`:
+
+```kotlin
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.RetryPolicy
+import io.etcd.recipes.common.WatchResilience
+
+// Tune the backoff (or pass ResilienceConfig.DISABLED for pre-0.12 behavior):
+val resilience = ResilienceConfig(watch = WatchResilience(RetryPolicy.exponentialBackoff(maxAttempts = 20)))
+val cache = PathChildrenCache(client, cachePath, resilience = resilience)
+
+// Observe recovery from application code:
+cache.addRecoveryListener { event -> println("cache watch recovery: $event") }
+```
+
+Recovery events (`Suspended`, `Resubscribed`, `Resynced`, `Failed`) are exposed via
+`addRecoveryListener` on the caches and via the low-level
+`client.watcher(key, option, resilience, recoveryListener, resyncWith) { ... }`
+extension. `Failed` (retry policy exhausted) is also recorded in the connector's
+`exceptions` list. Watchers request etcd progress notifications by default so the
+resume revision stays fresh on quiet keys; watch blocks see them as
+`WatchResponse`s with an empty event list.
+
 ## Compatibility
 
 - Built on [jetcd](https://github.com/etcd-io/jetcd) and targets etcd v3.

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/cache/ResilientPathChildrenCacheExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/cache/ResilientPathChildrenCacheExample.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.cache
+
+import com.pambrose.common.util.sleep
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.putValue
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Demonstrates watch recovery: run this, then kill and restart the local etcd
+ * (`./etcd.sh`) while it is running. The cache keeps converging — puts made after
+ * the restart show up, and every recovery event is printed.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val cachePath = "/cache/resilient-example"
+
+  connectToEtcd(urls) { client ->
+    PathChildrenCache(client, cachePath).use { cache ->
+      cache.addRecoveryListener { event -> logger.info { "Recovery: $event" } }
+      cache.addListener { event -> logger.info { "Event: ${event.type} ${event.childName}" } }
+      cache.start(true)
+
+      repeat(120) { i ->
+        client.putValue("$cachePath/tick", "value-$i")
+        sleep(2.seconds)
+        logger.info { "Cache now: ${cache.currentDataAsMap.mapValues { it.value.asString }}" }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -25,6 +25,10 @@ import io.etcd.jetcd.support.CloseableClient
 import io.etcd.jetcd.watch.WatchEvent.EventType.DELETE
 import io.etcd.recipes.barrier.DistributedBarrier.Companion.defaultClientId
 import io.etcd.recipes.common.EtcdConnector
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
 import io.etcd.recipes.common.deleteKey
 import io.etcd.recipes.common.doesNotExist
 import io.etcd.recipes.common.isKeyPresent
@@ -38,6 +42,7 @@ import io.etcd.recipes.common.watchOption
 import io.etcd.recipes.common.withWatcher
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
@@ -61,7 +66,8 @@ constructor(
   val leaseTtlSecs: Long = DEFAULT_TTL_SECS,
   private val waitOnMissingBarriers: Boolean = true,
   val clientId: String = defaultClientId(),
-) : EtcdConnector(client) {
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+) : EtcdConnector(client, resilience) {
   // Plain var: all reads/writes are inside @Synchronized methods on this instance.
   private var keepAliveLease: CloseableClient? = null
   private val barrierRemoved = AtomicBoolean(false)
@@ -144,12 +150,21 @@ constructor(
     return if (!waitOnMissingBarriers && !isBarrierSet()) {
       true
     } else {
+      // Presence at wait start bounds the recovery recheck below: with
+      // waitOnMissingBarriers=true a waiter on a never-set barrier must keep
+      // waiting across recoveries, not release spuriously.
+      val barrierPresentAtStart = isBarrierSet()
       val waitLatch = CountDownLatch(1)
       val watchOption = watchOption { withNoPut(true) }
+      val watchFailure = AtomicReference<Throwable?>()
+      val recoveryListener = waiterRecoveryListener(barrierPresentAtStart, waitLatch, watchFailure)
 
       client.withWatcher(
         barrierPath,
         watchOption,
+        resilience.watch,
+        recoveryListener,
+        resyncWith = null,
         { watchResponse ->
           for (event in watchResponse.events) {
             if (event.eventType == DELETE) {
@@ -162,10 +177,45 @@ constructor(
         if (!waitOnMissingBarriers && !isBarrierSet())
           waitLatch.countDown()
 
-        waitLatch.await(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        val released = waitLatch.await(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        watchFailure.get()?.let { cause ->
+          throw EtcdRecipeRuntimeException("Barrier watch on $barrierPath failed while waiting", cause)
+        }
+        released
       }
     }
   }
+
+  // The DELETE can be lost while the watch stream is fatally dead (compaction
+  // resync, or a death before any event was ever observed). After each recovery,
+  // re-probe the barrier and release the waiter if it is gone. An abandoned
+  // recovery unparks the waiter with the failure recorded so the caller errors
+  // out instead of parking until timeout.
+  private fun waiterRecoveryListener(
+    barrierPresentAtStart: Boolean,
+    waitLatch: CountDownLatch,
+    watchFailure: AtomicReference<Throwable?>,
+  ): WatchRecoveryListener =
+    WatchRecoveryListener { event ->
+      when (event) {
+        is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+          if (!isBarrierSet() && (barrierPresentAtStart || !waitOnMissingBarriers))
+            waitLatch.countDown()
+        }
+
+        is WatchRecoveryEvent.Failed -> {
+          val cause = event.cause
+            ?: EtcdRecipeRuntimeException("Watch on $barrierPath abandoned while waiting on barrier")
+          watchFailure.set(cause)
+          exceptionList.value += cause
+          waitLatch.countDown()
+        }
+
+        is WatchRecoveryEvent.Suspended -> {
+          // jetcd (transient) or the recovery loop (fatal) is already on it
+        }
+      }
+    }
 
   @Synchronized
   override fun doClose() {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -29,6 +29,10 @@ import io.etcd.jetcd.watch.WatchEvent.EventType.PUT
 import io.etcd.recipes.barrier.DistributedBarrierWithCount.Companion.defaultClientId
 import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdRecipeException
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
 import io.etcd.recipes.common.appendToPath
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.deleteKey
@@ -77,7 +81,8 @@ constructor(
   val memberCount: Int,
   val leaseTtlSecs: Long = DEFAULT_TTL_SECS,
   val clientId: String = defaultClientId(),
-) : EtcdConnector(client) {
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+) : EtcdConnector(client, resilience) {
   private val readyPath = barrierPath.appendToPath("ready")
   private val waitingPath = barrierPath.appendToPath("waiting")
 
@@ -215,9 +220,40 @@ constructor(
             // Watch for DELETE of /ready and PUTS on /waiters/*
             val trailingKey = barrierPath.ensureSuffix("/")
             val watchOption = watchOption { isPrefix(true) }
+            val watchFailure = java.util.concurrent.atomic.AtomicReference<Throwable?>()
+
+            // A ready-key DELETE or waiter PUT can be lost while the watch stream is
+            // fatally dead. After each recovery, checkWaiterCount() re-probes both
+            // conditions (ready gone / member count reached) exactly like the
+            // pre-park recheck below. An abandoned recovery unparks the waiter with
+            // the failure recorded so the caller errors out instead of parking.
+            val recoveryListener =
+              WatchRecoveryListener { event ->
+                when (event) {
+                  is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+                    checkWaiterCount()
+                  }
+
+                  is WatchRecoveryEvent.Failed -> {
+                    val cause = event.cause
+                      ?: EtcdRecipeRuntimeException("Watch on $barrierPath abandoned while waiting on barrier")
+                    watchFailure.set(cause)
+                    exceptionList.value += cause
+                    closeKeepAlive()
+                  }
+
+                  is WatchRecoveryEvent.Suspended -> {
+                    // jetcd (transient) or the recovery loop (fatal) is already on it
+                  }
+                }
+              }
+
             client.withWatcher(
               trailingKey,
               watchOption,
+              resilience.watch,
+              recoveryListener,
+              resyncWith = null,
               { watchResponse ->
                 watchResponse.events
                   .forEach { watchEvent ->
@@ -237,6 +273,10 @@ constructor(
               if (!signalled) {
                 closeKeepAlive()
                 client.deleteKey(myWaitingPath)  // This is redundant but waiting for keep-alive to stop is slower
+              }
+
+              watchFailure.get()?.let { cause ->
+                throw EtcdRecipeRuntimeException("Barrier watch on $barrierPath failed while waiting", cause)
               }
 
               // Distinguish natural completion from cancellation.

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -33,9 +33,11 @@ import io.etcd.recipes.cache.PathChildrenCacheEvent.Type.CHILD_REMOVED
 import io.etcd.recipes.cache.PathChildrenCacheEvent.Type.CHILD_UPDATED
 import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
 import io.etcd.recipes.common.asPair
 import io.etcd.recipes.common.asString
-import io.etcd.recipes.common.getKeyValuePairs
 import io.etcd.recipes.common.getOption
 import io.etcd.recipes.common.getResponse
 import io.etcd.recipes.common.watchOption
@@ -58,11 +60,14 @@ fun <T> withPathChildrenCache(
   receiver: PathChildrenCache.() -> T,
 ): T = PathChildrenCache(client, cachePath, userExecutor).use { it.receiver() }
 
-class PathChildrenCache(
-  client: Client,
-  val cachePath: String,
-  private val userExecutor: Executor? = null,
-) : EtcdConnector(client) {
+class PathChildrenCache
+  @JvmOverloads
+  constructor(
+    client: Client,
+    val cachePath: String,
+    private val userExecutor: Executor? = null,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : EtcdConnector(client, resilience) {
   // Canonical prefix for the watched key range. Every child key is stripped
   // relative to this, never cachePath.length + 1: when cachePath already ends in
   // '/', that offset over-strips by one char and corrupts every child name, so the
@@ -74,6 +79,7 @@ class PathChildrenCache(
   private var watcher: Watch.Watcher? = null
   private val cacheMap: ConcurrentMap<String, ByteSequence> = newConcurrentMap()
   private val listeners: MutableList<PathChildrenCacheListener> = CopyOnWriteArrayList()
+  private val recoveryListeners: MutableList<WatchRecoveryListener> = CopyOnWriteArrayList()
 
   // Use a single-threaded executor to maintain order
   private val executor = userExecutor ?: Executors.newSingleThreadExecutor()
@@ -160,6 +166,14 @@ class PathChildrenCache(
     listeners += listener
   }
 
+  /**
+   * Registers a listener for watch-recovery events (resubscribes after fatal stream
+   * deaths, compaction resyncs, abandoned recovery).
+   */
+  fun addRecoveryListener(listener: WatchRecoveryListener) {
+    recoveryListeners += listener
+  }
+
   fun clearListeners() = listeners.clear()
 
   @Suppress("TooGenericExceptionCaught")
@@ -191,7 +205,13 @@ class PathChildrenCache(
     val watchOption = watchOption {
       isPrefix(true).also { if (startRevision > 0L) it.withRevision(startRevision) }
     }
-    watcher = client.watcher(trailingPath, watchOption) { watchResponse ->
+    watcher = client.watcher(
+      trailingPath,
+      watchOption,
+      resilience.watch,
+      recoveryListener = { event -> onRecoveryEvent(event) },
+      resyncWith = { reconcile() },
+    ) { watchResponse ->
       watchResponse.events
         .forEach { event ->
           val (k, v) = event.keyValue.asPair
@@ -265,15 +285,41 @@ class PathChildrenCache(
   // watcher, not rebuild(), for strict event ordering.
   @Synchronized
   fun rebuild() {
+    reconcile()
+  }
+
+  // Snapshot etcd's current children, reconcile the live map in place, and return
+  // the next watch anchor (snapshot revision + 1). Deliberately NOT synchronized:
+  // the compaction-resync path invokes this on the watch dispatcher thread, where
+  // taking the cache monitor could stall against a concurrent close(); map
+  // reconciliation is safe on the ConcurrentMap, and watch events are serialized on
+  // the same dispatcher thread anyway.
+  private fun reconcile(): Long {
     val getOption = getOption {
       isPrefix(true)
       withSortField(GetOption.SortTarget.KEY)
     }
-    val fresh =
-      client.getKeyValuePairs(trailingPath, getOption)
-        .associate { (k, v) -> k.substring(trailingPath.length) to v }
+    val resp = client.getResponse(trailingPath, getOption)
+    val fresh = resp.kvs.associate { kv -> kv.key.asString.substring(trailingPath.length) to kv.value }
     cacheMap.keys.retainAll(fresh.keys)
     cacheMap.putAll(fresh)
+    return resp.header.revision + 1
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun onRecoveryEvent(event: WatchRecoveryEvent) {
+    if (event is WatchRecoveryEvent.Failed) {
+      exceptionList.value += event.cause
+        ?: EtcdRecipeRuntimeException("Watch on $cachePath abandoned; cache is no longer updating")
+    }
+    recoveryListeners.forEach { listener ->
+      try {
+        listener.onRecoveryEvent(event)
+      } catch (e: Throwable) {
+        logger.error(e) { "Exception in recovery listener" }
+        exceptionList.value += e
+      }
+    }
   }
 
   // For consistency with Curator

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
@@ -27,6 +27,7 @@ import kotlin.concurrent.atomics.AtomicBoolean
 
 open class EtcdConnector(
   protected val client: Client,
+  protected val resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
 ) : Closeable {
   protected val startCalled = AtomicBoolean(false)
   protected val startThreadComplete = BooleanMonitor(false)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/KVExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/KVExtensions.kt
@@ -21,9 +21,11 @@ package io.etcd.recipes.common
 
 import io.etcd.jetcd.ByteSequence
 import io.etcd.jetcd.Client
+import io.etcd.jetcd.kv.CompactResponse
 import io.etcd.jetcd.kv.DeleteResponse
 import io.etcd.jetcd.kv.GetResponse
 import io.etcd.jetcd.kv.PutResponse
+import io.etcd.jetcd.options.CompactOption
 import io.etcd.jetcd.options.GetOption
 import io.etcd.jetcd.options.PutOption
 
@@ -118,6 +120,13 @@ fun Client.getValue(
   keyName: String,
   default: Long,
 ): Long = getValue(keyName)?.asLong ?: default
+
+// Compaction
+@JvmOverloads
+fun Client.compact(
+  revision: Long,
+  option: CompactOption = CompactOption.DEFAULT,
+): CompactResponse = kvClient.compact(revision, option).get()
 
 // Key checking
 fun Client.isKeyPresent(keyName: String) = transaction { If(keyName.doesExist) }.isSucceeded

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ResilienceConfig.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ResilienceConfig.kt
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
-@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
-
 package io.etcd.recipes.common
 
-class EtcdRecipeRuntimeException
-  @JvmOverloads
-  constructor(
-    msg: String,
-    cause: Throwable? = null,
-  ) : RuntimeException(msg, cause)
+/**
+ * Bundles the resilience configuration a recipe applies to its etcd interactions.
+ * Resilience is ON by default; pass [DISABLED] to restore the pre-0.12 behavior
+ * (fatally dead watchers stay dead, silently).
+ */
+data class ResilienceConfig(
+  val watch: WatchResilience = WatchResilience.DEFAULT,
+) {
+  companion object {
+    @JvmField
+    val DEFAULT = ResilienceConfig()
+
+    @JvmField
+    val DISABLED = ResilienceConfig(watch = WatchResilience.DISABLED)
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/RetryPolicy.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/RetryPolicy.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.common
+
+import kotlin.math.pow
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Decides whether — and after what delay — a failed operation should be retried.
+ *
+ * Used by the resilience layer (watch recovery, lease healing) to pace re-establishment
+ * attempts. Implementations must be thread-safe; [nextDelay] may be called from
+ * background recovery threads.
+ */
+fun interface RetryPolicy {
+  /**
+   * Returns the delay to wait before retry [attempt] (1-based), given the total
+   * [elapsed] time since the first failure, or `null` to give up.
+   */
+  fun nextDelay(
+    attempt: Int,
+    elapsed: Duration,
+  ): Duration?
+
+  companion object {
+    /**
+     * Exponential backoff: `initialDelay * factor^(attempt-1)` capped at [maxDelay],
+     * with ±[jitterRatio] randomization. Gives up after [maxAttempts] attempts or once
+     * [maxElapsed] time has passed since the first failure.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun exponentialBackoff(
+      initialDelay: Duration = 250.milliseconds,
+      maxDelay: Duration = 15.seconds,
+      factor: Double = 2.0,
+      jitterRatio: Double = 0.25,
+      maxAttempts: Int = Int.MAX_VALUE,
+      maxElapsed: Duration = Duration.INFINITE,
+    ): RetryPolicy {
+      require(initialDelay > Duration.ZERO) { "initialDelay must be positive: $initialDelay" }
+      require(maxDelay >= initialDelay) { "maxDelay ($maxDelay) must be >= initialDelay ($initialDelay)" }
+      require(factor >= 1.0) { "factor must be >= 1.0: $factor" }
+      require(jitterRatio in 0.0..1.0) { "jitterRatio must be in [0.0, 1.0]: $jitterRatio" }
+      require(maxAttempts >= 1) { "maxAttempts must be >= 1: $maxAttempts" }
+      return RetryPolicy { attempt, elapsed ->
+        require(attempt >= 1) { "attempt must be >= 1: $attempt" }
+        if (attempt > maxAttempts || elapsed >= maxElapsed) {
+          null
+        } else {
+          // factor^(attempt-1) overflows to Infinity for large attempts; the cap applies either way
+          val scale = factor.pow(attempt - 1)
+          val base = if (scale.isFinite()) (initialDelay * scale).coerceAtMost(maxDelay) else maxDelay
+          if (jitterRatio == 0.0) {
+            base
+          } else {
+            (base * (1.0 + Random.nextDouble(-jitterRatio, jitterRatio))).coerceAtMost(maxDelay)
+          }
+        }
+      }
+    }
+
+    /** Fixed [delay] between attempts, giving up after [maxAttempts]. */
+    @JvmStatic
+    @JvmOverloads
+    fun bounded(
+      maxAttempts: Int,
+      delay: Duration = 500.milliseconds,
+    ): RetryPolicy {
+      require(maxAttempts >= 1) { "maxAttempts must be >= 1: $maxAttempts" }
+      require(delay >= Duration.ZERO) { "delay must be >= 0: $delay" }
+      return RetryPolicy { attempt, _ ->
+        require(attempt >= 1) { "attempt must be >= 1: $attempt" }
+        if (attempt <= maxAttempts) delay else null
+      }
+    }
+
+    /** Unbounded [exponentialBackoff] with the default pacing — never gives up. */
+    @JvmField
+    val forever: RetryPolicy = exponentialBackoff()
+
+    /** Always gives up — disables the recovery loop entirely. */
+    @JvmField
+    val never: RetryPolicy = RetryPolicy { _, _ -> null }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
@@ -21,15 +21,22 @@ package io.etcd.recipes.common
 
 import io.etcd.jetcd.Client
 import io.etcd.jetcd.Watch
+import io.etcd.jetcd.common.exception.CompactedException
 import io.etcd.jetcd.options.WatchOption
 import io.etcd.jetcd.watch.WatchEvent
 import io.etcd.jetcd.watch.WatchEvent.EventType
 import io.etcd.jetcd.watch.WatchResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.math.max
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 private val logger = KotlinLogging.logger {}
 
@@ -41,34 +48,113 @@ val WatchEvent.valueAsString get() = keyValue.value.asString
 val WatchEvent.valueAsInt get() = keyValue.value.asInt
 val WatchEvent.valueAsLong get() = keyValue.value.asLong
 
-// fun WatchOption.Builder.withPrefix(prefix: String): WatchOption.Builder = withPrefix(prefix.asByteSequence)
-
 @JvmOverloads
 fun Client.watcher(
   keyName: String,
   option: WatchOption = WatchOption.DEFAULT,
   block: (WatchResponse) -> Unit,
-): Watch.Watcher {
-  // jetcd 0.7+ delivers watch events on its Vert.x gRPC event loop. Anything
-  // the callback does that needs another gRPC response — or contends with a
-  // lock the caller is holding while waiting on a gRPC response — would
-  // deadlock the event loop. Hop the callback onto a dedicated single-thread
-  // executor so blocking calls inside it stay off the gRPC threads.
-  val dispatcher = Executors.newSingleThreadExecutor { runnable ->
-    Thread(runnable, "etcd-watch-dispatcher").apply { isDaemon = true }
-  }
-  val delegate = watchClient.watch(keyName.asByteSequence, option) { response ->
-    dispatcher.execute { block(response) }
-  }
-  return DispatchingWatcher(delegate, dispatcher)
-}
+): Watch.Watcher = watcher(keyName, option, WatchResilience.DEFAULT, null, null, block)
 
-private class DispatchingWatcher(
-  private val delegate: Watch.Watcher,
-  private val dispatcher: ExecutorService,
-) : Watch.Watcher by delegate {
+/**
+ * Creates a watcher that survives fatal watch-stream deaths.
+ *
+ * jetcd transparently retries *transient* stream errors itself; what it abandons — and
+ * this watcher recovers per [resilience] — are *fatal* deaths (compaction of the watched
+ * revision, halt-error statuses, "etcdserver: no leader"). Recovery re-subscribes from
+ * the revision just past the last observed event, so no events are lost or duplicated
+ * across a recovery, except after compaction: there [resyncWith] is invoked so the
+ * caller can re-read its world (GET + rebuild derived state) and return the new anchor
+ * revision (typically the GET's `header.revision + 1`). Without [resyncWith] the watch
+ * resumes just past the compacted revision and the gap is reported via
+ * [WatchRecoveryEvent.Resynced] — callers with derived state should supply [resyncWith].
+ */
+fun Client.watcher(
+  keyName: String,
+  option: WatchOption,
+  resilience: WatchResilience,
+  recoveryListener: WatchRecoveryListener? = null,
+  resyncWith: (() -> Long)? = null,
+  block: (WatchResponse) -> Unit,
+): Watch.Watcher =
+  ResilientWatcher(this, keyName, option, resilience, recoveryListener, resyncWith, block)
+    .also { it.subscribeInitial() }
+
+/**
+ * A [Watch.Watcher] wrapping ephemeral jetcd watchers, re-subscribing across fatal
+ * stream deaths.
+ *
+ * Threading: jetcd 0.7+ delivers watch callbacks on its Vert.x gRPC event loop.
+ * Anything a callback does that needs another gRPC response — or contends with a lock
+ * the caller is holding while waiting on a gRPC response — would deadlock the event
+ * loop. Every callback therefore hops onto a dedicated single-thread scheduled
+ * executor; the recovery loop (including the blocking resync GET) runs on that same
+ * executor, and backoff delays are scheduled rather than slept so close() can cancel
+ * a pending attempt immediately.
+ */
+private class ResilientWatcher(
+  private val client: Client,
+  private val keyName: String,
+  private val baseOption: WatchOption,
+  private val resilience: WatchResilience,
+  private val recoveryListener: WatchRecoveryListener?,
+  private val resyncWith: (() -> Long)?,
+  private val block: (WatchResponse) -> Unit,
+) : Watch.Watcher {
+  private val dispatcher: ScheduledExecutorService =
+    Executors.newSingleThreadScheduledExecutor { runnable ->
+      Thread(runnable, "etcd-watch-dispatcher").apply { isDaemon = true }
+    }
+  private val closed = AtomicBoolean(false)
+  private val lock = Any() // guards delegate + pendingAttempt against close() racing recovery
+  private var delegate: Watch.Watcher? = null
+  private var pendingAttempt: ScheduledFuture<*>? = null
+
+  // Dispatcher-thread-confined after construction:
+  private var resumeRevision = baseOption.revision // 0 = "current revision"
+  private var lastCause: Throwable? = null
+  private var suspendedReported = false
+  private var attempt = 0
+  private var recoveryStart: TimeMark? = null
+
+  private val listener =
+    object : Watch.Listener {
+      override fun onNext(response: WatchResponse) {
+        dispatch {
+          advanceRevision(response)
+          suspendedReported = false
+          runCatching { block(response) }
+            .onFailure { e -> logger.error(e) { "Watch block for $keyName threw" } }
+        }
+      }
+
+      override fun onError(throwable: Throwable) {
+        dispatch {
+          lastCause = throwable
+          if (!suspendedReported) {
+            suspendedReported = true
+            emit(WatchRecoveryEvent.Suspended(keyName, throwable))
+          }
+        }
+      }
+
+      override fun onCompleted() {
+        // jetcd fires this when it abandons the watch as fatally dead — and also as a
+        // side effect of our own close(); the closed flag inside dispatch() filters that.
+        dispatch { startRecovery() }
+      }
+    }
+
+  fun subscribeInitial() {
+    val watcher = client.watchClient.watch(keyName.asByteSequence, buildOption(), listener)
+    synchronized(lock) { delegate = watcher }
+  }
+
   override fun close() {
-    delegate.close()
+    if (!closed.compareAndSet(false, true)) return
+    synchronized(lock) {
+      pendingAttempt?.cancel(false)
+      delegate?.close()
+    }
     dispatcher.shutdown()
     // shutdown() refuses new tasks but does not wait for the currently-running
     // callback task. Without awaiting, the user's `block` could still be
@@ -88,6 +174,123 @@ private class DispatchingWatcher(
       Thread.currentThread().interrupt()
     }
   }
+
+  override fun isClosed(): Boolean = closed.load()
+
+  override fun requestProgress() {
+    synchronized(lock) { delegate }?.requestProgress()
+  }
+
+  private fun dispatch(task: () -> Unit) {
+    if (closed.load()) return
+    try {
+      dispatcher.execute {
+        if (closed.load()) return@execute
+        runCatching(task).onFailure { e -> logger.error(e) { "Watch dispatch for $keyName threw" } }
+      }
+    } catch (_: RejectedExecutionException) {
+      // closed concurrently; nothing left to deliver to
+    }
+  }
+
+  private fun advanceRevision(response: WatchResponse) {
+    val events = response.events
+    resumeRevision =
+      if (events.isNotEmpty()) {
+        max(resumeRevision, events.maxOf { it.keyValue.modRevision } + 1)
+      } else {
+        // progress notification: synced through header.revision
+        max(resumeRevision, response.header.revision + 1)
+      }
+  }
+
+  private fun buildOption(): WatchOption =
+    watchOption {
+      if (resumeRevision > 0L) withRevision(resumeRevision)
+      if (baseOption.isPrefix) isPrefix(true)
+      baseOption.endKey.ifPresent { withRange(it) }
+      withPrevKV(baseOption.isPrevKV)
+      withProgressNotify(baseOption.isProgressNotify || resilience.progressNotify)
+      withCreateNotify(baseOption.isCreatedNotify)
+      withNoPut(baseOption.isNoPut)
+      withNoDelete(baseOption.isNoDelete)
+      withRequireLeader(baseOption.withRequireLeader())
+    }
+
+  private fun startRecovery() {
+    if (!suspendedReported) {
+      suspendedReported = true
+      emit(
+        WatchRecoveryEvent.Suspended(
+          keyName,
+          lastCause ?: EtcdRecipeRuntimeException("Watch stream for $keyName completed unexpectedly"),
+        ),
+      )
+    }
+    attempt = 0
+    recoveryStart = TimeSource.Monotonic.markNow()
+    scheduleNextAttempt()
+  }
+
+  private fun scheduleNextAttempt() {
+    attempt += 1
+    val elapsed = recoveryStart?.elapsedNow() ?: kotlin.time.Duration.ZERO
+    val delay = resilience.retryPolicy.nextDelay(attempt, elapsed)
+    if (delay == null) {
+      logger.error(lastCause) { "Abandoning watch on $keyName: retry policy exhausted after ${attempt - 1} attempts" }
+      emit(WatchRecoveryEvent.Failed(keyName, lastCause))
+      return
+    }
+    synchronized(lock) {
+      if (closed.load()) return
+      pendingAttempt = dispatcher.schedule(::runAttempt, delay.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun runAttempt() {
+    if (closed.load()) return
+    try {
+      val compactRevision = compactedRevisionOf(lastCause)
+      if (compactRevision != null) {
+        // Events between compactRevision and the new anchor are unrecoverable; the
+        // resync hook re-reads the world so derived state converges despite the gap.
+        resumeRevision = resyncWith?.invoke() ?: (compactRevision + 1)
+      }
+      val watcher = client.watchClient.watch(keyName.asByteSequence, buildOption(), listener)
+      synchronized(lock) {
+        if (closed.load()) {
+          watcher.close()
+          return
+        }
+        delegate = watcher
+      }
+      lastCause = null
+      suspendedReported = false
+      emit(
+        if (compactRevision != null) {
+          WatchRecoveryEvent.Resynced(keyName, compactRevision, resumeRevision)
+        } else {
+          WatchRecoveryEvent.Resubscribed(keyName, resumeRevision)
+        },
+      )
+      logger.info { "Watch on $keyName re-established (attempt $attempt, resume revision $resumeRevision)" }
+    } catch (e: Throwable) {
+      lastCause = e
+      scheduleNextAttempt()
+    }
+  }
+
+  private fun compactedRevisionOf(cause: Throwable?): Long? =
+    generateSequence(cause) { it.cause.takeIf { c -> c !== it } }
+      .filterIsInstance<CompactedException>()
+      .firstOrNull()
+      ?.compactedRevision
+
+  private fun emit(event: WatchRecoveryEvent) {
+    runCatching { recoveryListener?.onRecoveryEvent(event) }
+      .onFailure { e -> logger.error(e) { "Watch recovery listener for $keyName threw on $event" } }
+  }
 }
 
 @JvmOverloads
@@ -96,8 +299,18 @@ fun <T> Client.withWatcher(
   option: WatchOption = WatchOption.DEFAULT,
   block: (WatchResponse) -> Unit,
   receiver: Watch.Watcher.() -> T,
+): T = withWatcher(keyName, option, WatchResilience.DEFAULT, null, null, block, receiver)
+
+fun <T> Client.withWatcher(
+  keyName: String,
+  option: WatchOption,
+  resilience: WatchResilience,
+  recoveryListener: WatchRecoveryListener? = null,
+  resyncWith: (() -> Long)? = null,
+  block: (WatchResponse) -> Unit,
+  receiver: Watch.Watcher.() -> T,
 ): T =
-  watcher(keyName, option, block)
+  watcher(keyName, option, resilience, recoveryListener, resyncWith, block)
     .use { watcher ->
       watcher.receiver()
     }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchResilience.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchResilience.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.common
+
+/**
+ * Configures how a watcher created by [io.etcd.jetcd.Client.watcher] recovers from a
+ * fatally dead watch stream.
+ *
+ * jetcd itself transparently retries *transient* stream errors (connection loss, etcd
+ * restart) with revision continuity. What jetcd abandons — and this layer recovers —
+ * are *fatal* deaths: compaction of the watched revision, halt-error statuses, and
+ * "etcdserver: no leader". [RetryPolicy.never] disables recovery, restoring the
+ * pre-0.12 behavior where a fatally dead watch was silently dropped.
+ */
+class WatchResilience
+  @JvmOverloads
+  constructor(
+    val retryPolicy: RetryPolicy = RetryPolicy.exponentialBackoff(),
+    /**
+     * Ask etcd for periodic progress notifications so the resume revision stays fresh
+     * on quiet keys. Progress notifications are delivered to the watch block as
+     * [io.etcd.jetcd.watch.WatchResponse]s with an empty event list.
+     */
+    val progressNotify: Boolean = true,
+  ) {
+    companion object {
+      @JvmField
+      val DEFAULT = WatchResilience()
+
+      @JvmField
+      val DISABLED = WatchResilience(RetryPolicy.never, progressNotify = false)
+    }
+  }
+
+/**
+ * Events describing the lifecycle of a resilient watcher's recovery machinery,
+ * delivered to a [WatchRecoveryListener].
+ */
+sealed interface WatchRecoveryEvent {
+  val watchedKey: String
+
+  /** The underlying watch stream reported an error; recovery may follow. */
+  data class Suspended(
+    override val watchedKey: String,
+    val cause: Throwable,
+  ) : WatchRecoveryEvent
+
+  /**
+   * A replacement watch was established, resuming at [resumeRevision]
+   * (0 means "current revision" — nothing had been observed yet).
+   */
+  data class Resubscribed(
+    override val watchedKey: String,
+    val resumeRevision: Long,
+  ) : WatchRecoveryEvent
+
+  /**
+   * The watched revision was compacted away ([compactRevision]); the watch was
+   * re-anchored at [anchorRevision]. Events between the two were lost — a caller
+   * maintaining derived state must have reconciled it in the resync hook.
+   */
+  data class Resynced(
+    override val watchedKey: String,
+    val compactRevision: Long,
+    val anchorRevision: Long,
+  ) : WatchRecoveryEvent
+
+  /** Recovery was abandoned (retry policy exhausted); the watcher is dead. */
+  data class Failed(
+    override val watchedKey: String,
+    val cause: Throwable?,
+  ) : WatchRecoveryEvent
+}
+
+fun interface WatchRecoveryListener {
+  fun onRecoveryEvent(event: WatchRecoveryEvent)
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
@@ -26,6 +26,9 @@ import io.etcd.jetcd.options.GetOption
 import io.etcd.jetcd.watch.WatchEvent
 import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
 import io.etcd.recipes.common.appendToPath
 import io.etcd.recipes.common.asPair
 import io.etcd.recipes.common.asString
@@ -37,16 +40,20 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.CopyOnWriteArrayList
 
-class ServiceCache(
-  client: Client,
-  val namesPath: String,
-  val serviceName: String,
-) : EtcdConnector(client) {
+class ServiceCache
+  @JvmOverloads
+  constructor(
+    client: Client,
+    val namesPath: String,
+    val serviceName: String,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : EtcdConnector(client, resilience) {
   // Plain var: all reads/writes are inside @Synchronized methods on this instance.
   private var watcher: Watch.Watcher? = null
   private val servicePath = namesPath.appendToPath(serviceName)
   private val serviceMap: ConcurrentMap<String, String> = newConcurrentMap()
   private val listeners: MutableList<ServiceCacheListener> = CopyOnWriteArrayList()
+  private val recoveryListeners: MutableList<WatchRecoveryListener> = CopyOnWriteArrayList()
 
   init {
     require(serviceName.isNotEmpty()) { "ServiceCache service name cannot be empty" }
@@ -66,24 +73,20 @@ class ServiceCache(
     // produced. Then start the watch anchored at revision+1 so the watch
     // stream has zero overlap and zero gap relative to the snapshot — this
     // is the standard etcd pattern for consistent cache initialization.
-    val getOption = getOption {
-      isPrefix(true)
-      withSortField(GetOption.SortTarget.KEY)
-    }
-    val resp = client.getResponse(trailingServicePath, getOption)
-    for (kv in resp.kvs) {
-      val k = kv.key.asString
-      val stripped = k.substring(trailingNamesPath.length)
-      serviceMap[stripped] = kv.value.asString
-    }
-    val anchorRevision = resp.header.revision + 1
+    val anchorRevision = reconcile()
 
     val watchOption = watchOption {
       isPrefix(true)
       withRevision(anchorRevision)
     }
 
-    watcher = client.watcher(trailingServicePath, watchOption) { watchResponse ->
+    watcher = client.watcher(
+      trailingServicePath,
+      watchOption,
+      resilience.watch,
+      recoveryListener = { event -> onRecoveryEvent(event) },
+      resyncWith = { reconcile() },
+    ) { watchResponse ->
       watchResponse.events
         .forEach { event ->
           val (k, v) = event.keyValue.asPair.asString
@@ -131,6 +134,41 @@ class ServiceCache(
     return this
   }
 
+  // Snapshot etcd's current instances, reconcile the live map in place (drop keys no
+  // longer present, upsert the rest), and return the next watch anchor (snapshot
+  // revision + 1). Runs during start() and, on the watch dispatcher thread, during
+  // compaction resync — deliberately not synchronized (see PathChildrenCache.reconcile).
+  private fun reconcile(): Long {
+    val trailingServicePath = servicePath.ensureSuffix("/")
+    val trailingNamesPath = namesPath.ensureSuffix("/")
+    val getOption = getOption {
+      isPrefix(true)
+      withSortField(GetOption.SortTarget.KEY)
+    }
+    val resp = client.getResponse(trailingServicePath, getOption)
+    val fresh =
+      resp.kvs.associate { kv -> kv.key.asString.substring(trailingNamesPath.length) to kv.value.asString }
+    serviceMap.keys.retainAll(fresh.keys)
+    serviceMap.putAll(fresh)
+    return resp.header.revision + 1
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun onRecoveryEvent(event: WatchRecoveryEvent) {
+    if (event is WatchRecoveryEvent.Failed) {
+      exceptionList.value += event.cause
+        ?: EtcdRecipeRuntimeException("Watch on $servicePath abandoned; service cache is no longer updating")
+    }
+    recoveryListeners.forEach { listener ->
+      try {
+        listener.onRecoveryEvent(event)
+      } catch (e: Throwable) {
+        logger.error(e) { "Exception in recovery listener" }
+        exceptionList.value += e
+      }
+    }
+  }
+
   val instances: List<ServiceInstance>
     get() {
       checkCloseNotCalled()
@@ -140,6 +178,15 @@ class ServiceCache(
   fun addListenerForChanges(listener: ServiceCacheListener) {
     checkCloseNotCalled()
     listeners += listener
+  }
+
+  /**
+   * Registers a listener for watch-recovery events (resubscribes after fatal stream
+   * deaths, compaction resyncs, abandoned recovery).
+   */
+  fun addRecoveryListener(listener: WatchRecoveryListener) {
+    checkCloseNotCalled()
+    recoveryListeners += listener
   }
 
   @Synchronized

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -23,6 +23,7 @@ import com.pambrose.common.time.timeUnitToDuration
 import com.pambrose.common.util.randomId
 import com.pambrose.common.util.sleep
 import io.etcd.jetcd.Client
+import io.etcd.jetcd.options.WatchOption
 import io.etcd.jetcd.watch.WatchEvent.EventType.DELETE
 import io.etcd.jetcd.watch.WatchEvent.EventType.PUT
 import io.etcd.jetcd.watch.WatchEvent.EventType.UNRECOGNIZED
@@ -30,12 +31,17 @@ import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdConnector.Companion.DEFAULT_TTL_SECS
 import io.etcd.recipes.common.EtcdRecipeException
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
+import io.etcd.recipes.common.WatchResilience
 import io.etcd.recipes.common.appendToPath
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.doesNotExist
 import io.etcd.recipes.common.getChildrenValues
 import io.etcd.recipes.common.getValue
+import io.etcd.recipes.common.isKeyNotPresent
 import io.etcd.recipes.common.isKeyPresent
 import io.etcd.recipes.common.keepAliveWith
 import io.etcd.recipes.common.leaseGrant
@@ -99,7 +105,8 @@ constructor(
   val leaseTtlSecs: Long = DEFAULT_TTL_SECS,
   private val userExecutor: Executor? = null,
   val clientId: String = defaultClientId(),
-) : EtcdConnector(client) {
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+) : EtcdConnector(client, resilience) {
   // For Kotlin clients
   @JvmOverloads
   constructor(
@@ -188,9 +195,39 @@ constructor(
         executor.execute {
           try {
             val watchOption = watchOption { withNoPut(true) }
+
+            // The leader-key DELETE is this node's only re-election trigger. If it
+            // is lost while the watch stream is fatally dead (compaction resync, or
+            // a death before any event), the node would never run for leader again —
+            // so after each recovery, re-probe the leader key and run if it is gone.
+            // attemptToBecomeLeader CAS-guards against a concurrent winner.
+            val recoveryListener =
+              WatchRecoveryListener { event ->
+                when (event) {
+                  is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+                    if (client.isKeyNotPresent(leaderPath))
+                      attemptToBecomeLeader(client)
+                  }
+
+                  is WatchRecoveryEvent.Failed -> {
+                    val cause = event.cause
+                      ?: EtcdRecipeRuntimeException("Watch on $leaderPath abandoned; no further re-election attempts")
+                    logger.error(cause) { "Leader watch on $leaderPath abandoned" }
+                    exceptionList.value += cause
+                  }
+
+                  is WatchRecoveryEvent.Suspended -> {
+                    // jetcd (transient) or the recovery loop (fatal) is already on it
+                  }
+                }
+              }
+
             client.withWatcher(
               leaderPath,
               watchOption,
+              resilience.watch,
+              recoveryListener,
+              resyncWith = null,
               { watchResponse ->
                 for (event in watchResponse.events) {
                   if (event.eventType == DELETE) {
@@ -440,6 +477,46 @@ constructor(
       return participants
     }
 
+    // A leader PUT/DELETE can be lost while the watch stream is fatally dead:
+    // always for a compaction resync, and for a plain resubscribe only when nothing
+    // had ever been observed (resumeRevision 0 — no revision to replay from). In
+    // those cases re-read the leader key and replay the current state to the
+    // listener.
+    @Suppress("TooGenericExceptionCaught")
+    private fun reportLeaderRecoveryListener(
+      client: Client,
+      electionPath: String,
+      listener: LeaderListener,
+    ): WatchRecoveryListener =
+      WatchRecoveryListener { event ->
+        try {
+          when (event) {
+            is WatchRecoveryEvent.Resynced,
+            is WatchRecoveryEvent.Resubscribed,
+            -> {
+              val gapPossible = event !is WatchRecoveryEvent.Resubscribed || event.resumeRevision == 0L
+              if (gapPossible) {
+                val leader = client.getValue(electionPath.withLeaderSuffix)?.asString?.stripUniqueSuffix
+                if (leader != null) listener.takeLeadership(leader) else listener.relinquishLeadership()
+              }
+            }
+
+            is WatchRecoveryEvent.Failed -> {
+              listener.onError(
+                event.cause ?: EtcdRecipeRuntimeException("Leader watch on $electionPath abandoned"),
+              )
+            }
+
+            is WatchRecoveryEvent.Suspended -> {
+              // jetcd (transient) or the recovery loop (fatal) is already on it
+            }
+          }
+        } catch (e: Throwable) {
+          logger.error(e) { "Exception in reportLeader() recovery" }
+          listener.onError(e)
+        }
+      }
+
     @Suppress("TooGenericExceptionCaught")
     @JvmStatic
     fun reportLeader(
@@ -454,8 +531,14 @@ constructor(
       val terminateListener = CountDownLatch(1)
       executor.execute {
         connectToEtcd(urls) { client ->
+          val recoveryListener = reportLeaderRecoveryListener(client, electionPath, listener)
+
           client.withWatcher(
             electionPath.withLeaderSuffix,
+            WatchOption.DEFAULT,
+            WatchResilience.DEFAULT,
+            recoveryListener,
+            resyncWith = null,
             block = { watchResponse ->
               for (event in watchResponse.events) {
                 try {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -25,6 +25,10 @@ import io.etcd.jetcd.op.CmpTarget
 import io.etcd.jetcd.options.GetOption.SortTarget
 import io.etcd.jetcd.watch.WatchEvent
 import io.etcd.recipes.common.EtcdConnector
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
 import io.etcd.recipes.common.deleteOp
 import io.etcd.recipes.common.equalTo
 import io.etcd.recipes.common.getFirstChild
@@ -39,7 +43,8 @@ abstract class AbstractQueue(
   client: Client,
   val queuePath: String,
   val target: SortTarget,
-) : EtcdConnector(client) {
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+) : EtcdConnector(client, resilience) {
   init {
     require(queuePath.isNotEmpty()) { "Queue path cannot be empty" }
   }
@@ -79,10 +84,15 @@ abstract class AbstractQueue(
         withNoDelete(true)
       }
     val keyFound = AtomicReference<KeyValue?>()
+    val watchFailure = AtomicReference<Throwable?>()
+    val recoveryListener = waiterRecoveryListener(watchLatch, keyFound, watchFailure)
 
     return client.withWatcher(
       queuePath,
       watchOption,
+      resilience.watch,
+      recoveryListener,
+      resyncWith = null,
       { watchResponse ->
         synchronized(watchLatch) {
           for (watchEvent in watchResponse.events) {
@@ -120,9 +130,53 @@ abstract class AbstractQueue(
       // highest-priority (KEY) / oldest (MOD) item. Fall back to the watcher's event only if the re-query is
       // empty (a concurrent consumer already took the head) — the deleteRevKey CAS and
       // the outer retry loop then still guarantee no loss or duplication.
-      client.getFirstChild(queuePath, target).kvs.firstOrNull() ?: keyFound.get()
+      val head = client.getFirstChild(queuePath, target).kvs.firstOrNull() ?: keyFound.get()
+      if (head == null) {
+        watchFailure.get()?.let { cause ->
+          throw EtcdRecipeRuntimeException("Queue watch on $queuePath failed while waiting for an item", cause)
+        }
+      }
+      head
     }
   }
+
+  // A PUT can land while the watch stream is fatally dead and never be delivered.
+  // After each recovery, poll the head the same way the pre-live gap poll in
+  // waitForFirstChild does (gRPC outside the latch monitor, on the watch dispatcher
+  // thread). An abandoned recovery unparks the waiter with the failure recorded so
+  // the caller errors out instead of parking forever.
+  private fun waiterRecoveryListener(
+    watchLatch: CountDownLatch,
+    keyFound: AtomicReference<KeyValue?>,
+    watchFailure: AtomicReference<Throwable?>,
+  ): WatchRecoveryListener =
+    WatchRecoveryListener { event ->
+      when (event) {
+        is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+          val children = client.getFirstChild(queuePath, target).kvs
+          if (children.isNotEmpty()) {
+            synchronized(watchLatch) {
+              keyFound.compareAndSet(null, children.first())
+              if (watchLatch.count > 0) watchLatch.countDown()
+            }
+          }
+        }
+
+        is WatchRecoveryEvent.Failed -> {
+          val cause = event.cause
+            ?: EtcdRecipeRuntimeException("Watch on $queuePath abandoned while waiting for an item")
+          watchFailure.set(cause)
+          exceptionList.value += cause
+          synchronized(watchLatch) {
+            if (watchLatch.count > 0) watchLatch.countDown()
+          }
+        }
+
+        is WatchRecoveryEvent.Suspended -> {
+          // jetcd (transient) or the recovery loop (fatal) is already on it
+        }
+      }
+    }
 
   private fun deleteRevKey(kv: KeyValue): Boolean =
     client.transaction {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedPriorityQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedPriorityQueue.kt
@@ -25,6 +25,7 @@ import io.etcd.jetcd.op.CmpTarget
 import io.etcd.jetcd.options.GetOption.SortTarget
 import io.etcd.recipes.common.EtcdRecipeException
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
 import io.etcd.recipes.common.asByteSequence
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.getLastChild
@@ -43,11 +44,14 @@ fun <T> withDistributedPriorityQueue(
   receiver: DistributedPriorityQueue.() -> T,
 ): T = DistributedPriorityQueue(client, queuePath, minimumWaitTime).use { it.receiver() }
 
-class DistributedPriorityQueue(
-  client: Client,
-  queuePath: String,
-  val minimumWaitTime: Duration,
-) : AbstractQueue(client, queuePath, SortTarget.KEY) {
+class DistributedPriorityQueue
+  @JvmOverloads
+  constructor(
+    client: Client,
+    queuePath: String,
+    val minimumWaitTime: Duration,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : AbstractQueue(client, queuePath, SortTarget.KEY, resilience) {
   private var lastWriteTime = TimeSource.Monotonic.markNow()
 
   fun enqueue(

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedQueue.kt
@@ -23,6 +23,7 @@ import com.pambrose.common.util.randomId
 import io.etcd.jetcd.ByteSequence
 import io.etcd.jetcd.Client
 import io.etcd.jetcd.options.GetOption.SortTarget
+import io.etcd.recipes.common.ResilienceConfig
 import io.etcd.recipes.common.asByteSequence
 import io.etcd.recipes.common.putValue
 
@@ -32,10 +33,13 @@ fun <T> withDistributedQueue(
   receiver: DistributedQueue.() -> T,
 ): T = DistributedQueue(client, queuePath).use { it.receiver() }
 
-class DistributedQueue(
-  client: Client,
-  queuePath: String,
-) : AbstractQueue(client, queuePath, SortTarget.MOD) {
+class DistributedQueue
+  @JvmOverloads
+  constructor(
+    client: Client,
+    queuePath: String,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : AbstractQueue(client, queuePath, SortTarget.MOD, resilience) {
   fun enqueue(value: String) = enqueue(value.asByteSequence)
 
   fun enqueue(value: Int) = enqueue(value.asByteSequence)

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWatchRecoveryTests.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.barrier
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.Txn
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.kv.TxnResponse
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.pollUntil
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives a parked [DistributedBarrier.waitOnBarrier] through a fatal watch death with
+ * a mocked jetcd [Client]. A barrier DELETE that happened while the watch stream was
+ * dead must release the waiter after recovery; an abandoned recovery must fail the
+ * wait instead of parking it until timeout.
+ */
+class BarrierWatchRecoveryTests : StringSpec() {
+  /**
+   * The barrier's presence is probed via CAS transactions (isKeyPresent). The first
+   * [presentProbes] probes report the barrier present; later ones report it absent.
+   */
+  private class BarrierMocks(
+    private val presentProbes: Int,
+  ) {
+    val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    private val probeCount = AtomicInteger(0)
+
+    val client: Client =
+      mockk {
+        every { kvClient } returns
+          mockk<KV> {
+            every { txn() } answers {
+              val present = probeCount.incrementAndGet() <= presentProbes
+              mockk<Txn> {
+                every { If(*anyVararg()) } returns this
+                every { Then(*anyVararg()) } returns this
+                every { commit() } returns
+                  CompletableFuture.completedFuture(mockk<TxnResponse> { every { isSucceeded } returns present })
+              }
+            }
+          }
+        every { watchClient } returns
+          mockk<Watch> {
+            every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+              listeners += thirdArg<Watch.Listener>()
+              mockk<Watch.Watcher>(relaxed = true)
+            }
+          }
+      }
+  }
+
+  private fun Watch.Listener.die() {
+    onError(RuntimeException("fatal watch error"))
+    onCompleted()
+  }
+
+  init {
+    "waiter releases after recovery when the barrier DELETE happened during the outage" {
+      // Probe #1 (presence at wait start): present. Later probes (recovery recheck): absent.
+      val mocks = BarrierMocks(presentProbes = 1)
+      val released = AtomicReference<Boolean?>()
+      val error = AtomicReference<Throwable?>()
+
+      DistributedBarrier(mocks.client, "/barrier/recovery").use { barrier ->
+        val waiter =
+          thread(name = "barrier-waiter") {
+            try {
+              released.set(barrier.waitOnBarrier(1.minutes))
+            } catch (e: Throwable) {
+              error.set(e)
+            }
+          }
+
+        pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
+        mocks.listeners.first().die()
+
+        pollUntil(10.seconds) { released.get() != null || error.get() != null } shouldBe true
+        error.get() shouldBe null
+        released.get() shouldBe true
+        waiter.join(5_000)
+      }
+    }
+
+    "waiter fails fast when watch recovery is abandoned" {
+      // Barrier stays present; recovery disabled: the wait must error, not park.
+      val mocks = BarrierMocks(presentProbes = Int.MAX_VALUE)
+      val released = AtomicReference<Boolean?>()
+      val error = AtomicReference<Throwable?>()
+
+      DistributedBarrier(
+        mocks.client,
+        "/barrier/recovery",
+        resilience = ResilienceConfig.DISABLED,
+      ).use { barrier ->
+        val waiter =
+          thread(name = "barrier-waiter") {
+            try {
+              released.set(barrier.waitOnBarrier(1.minutes))
+            } catch (e: Throwable) {
+              error.set(e)
+            }
+          }
+
+        pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
+        mocks.listeners.first().die()
+
+        pollUntil(10.seconds) { error.get() != null } shouldBe true
+        error.get().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
+        released.get() shouldBe null
+        waiter.join(5_000)
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWithCountWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWithCountWatchRecoveryTests.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.barrier
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.Lease
+import io.etcd.jetcd.Txn
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.kv.DeleteResponse
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.kv.TxnResponse
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.jetcd.support.CloseableClient
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.pollUntil
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives a parked [DistributedBarrierWithCount.waitOnBarrier] through a fatal watch
+ * death with a mocked jetcd [Client]. A ready-key DELETE that happened while the
+ * stream was dead must release the waiter after recovery (via the checkWaiterCount
+ * re-probe); an abandoned recovery must fail the wait instead of parking it.
+ */
+class BarrierWithCountWatchRecoveryTests : StringSpec() {
+  /**
+   * Transactions arrive in order: #1 ready-CAS (result unused), #2 waiting-path CAS
+   * (must win), then presence probes for the ready key. Probes up to
+   * [readyPresentProbes] report the ready key present; later ones report it absent.
+   */
+  private class CountBarrierMocks(
+    private val readyPresentProbes: Int,
+  ) {
+    val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    private val txnCount = AtomicInteger(0)
+
+    val client: Client =
+      mockk {
+        every { kvClient } returns
+          mockk<KV> {
+            every { txn() } answers {
+              val n = txnCount.incrementAndGet()
+              val succeeded = if (n <= 2) true else (n - 2) <= readyPresentProbes
+              mockk<Txn> {
+                every { If(*anyVararg()) } returns this
+                every { Then(*anyVararg()) } returns this
+                every { commit() } returns
+                  CompletableFuture.completedFuture(mockk<TxnResponse> { every { isSucceeded } returns succeeded })
+              }
+            }
+            every { get(any<ByteSequence>(), any()) } returns
+              CompletableFuture.completedFuture(
+                mockk<GetResponse> {
+                  every { count } returns 1L // waiter count stays below memberCount
+                  every { kvs } returns emptyList()
+                  every { isMore } returns false
+                },
+              )
+            every { delete(any<ByteSequence>()) } returns
+              CompletableFuture.completedFuture(mockk<DeleteResponse>())
+          }
+        every { leaseClient } returns
+          mockk<Lease> {
+            every { grant(any()) } returns
+              CompletableFuture.completedFuture(mockk<LeaseGrantResponse> { every { id } returns 7L })
+            every { keepAlive(7L, any()) } returns mockk<CloseableClient>(relaxed = true)
+            every { revoke(any()) } returns CompletableFuture.completedFuture(mockk())
+          }
+        every { watchClient } returns
+          mockk<Watch> {
+            every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+              listeners += thirdArg<Watch.Listener>()
+              mockk<Watch.Watcher>(relaxed = true)
+            }
+          }
+      }
+  }
+
+  private fun Watch.Listener.die() {
+    onError(RuntimeException("fatal watch error"))
+    onCompleted()
+  }
+
+  init {
+    "counted waiter releases after recovery when the ready DELETE happened during the outage" {
+      // Ready-key probes: 2 present (initial checkWaiterCount + pre-park recheck),
+      // then absent (deleted during the dead-stream window).
+      val mocks = CountBarrierMocks(readyPresentProbes = 2)
+      val released = AtomicReference<Boolean?>()
+      val error = AtomicReference<Throwable?>()
+
+      DistributedBarrierWithCount(mocks.client, "/barrier/count", memberCount = 2).use { barrier ->
+        val waiter =
+          thread(name = "count-barrier-waiter") {
+            try {
+              released.set(barrier.waitOnBarrier(1.minutes))
+            } catch (e: Throwable) {
+              error.set(e)
+            }
+          }
+
+        pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
+        mocks.listeners.first().die()
+
+        pollUntil(10.seconds) { released.get() != null || error.get() != null } shouldBe true
+        error.get() shouldBe null
+        released.get() shouldBe true
+        waiter.join(5_000)
+      }
+    }
+
+    "counted waiter fails fast when watch recovery is abandoned" {
+      // Ready key stays present; recovery disabled: the wait must error, not park.
+      val mocks = CountBarrierMocks(readyPresentProbes = Int.MAX_VALUE)
+      val released = AtomicReference<Boolean?>()
+      val error = AtomicReference<Throwable?>()
+
+      DistributedBarrierWithCount(
+        mocks.client,
+        "/barrier/count",
+        memberCount = 2,
+        resilience = ResilienceConfig.DISABLED,
+      ).use { barrier ->
+        val waiter =
+          thread(name = "count-barrier-waiter") {
+            try {
+              released.set(barrier.waitOnBarrier(1.minutes))
+            } catch (e: Throwable) {
+              error.set(e)
+            }
+          }
+
+        pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
+        mocks.listeners.first().die()
+
+        pollUntil(10.seconds) { error.get() != null } shouldBe true
+        error.get().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
+        released.get() shouldBe null
+        waiter.join(5_000)
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheRebuildTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheRebuildTests.kt
@@ -33,6 +33,11 @@ class PathChildrenCacheRebuildTests : StringSpec() {
     private val childCount = 20
 
     init {
+        // Boot the (possibly Testcontainers) etcd fixture outside the tight per-test
+        // invocation timeout below: the first `urls` access lazily starts the etcd +
+        // Ryuk containers, which can take over a minute on a busy Docker daemon.
+        beforeSpec { urls }
+
         // Regression test for #8: rebuild() must reconcile the live map in place, so a
         // reader never observes the empty/partial window that the old clear()-then-refill
         // produced. A concurrent reader sampling currentDataAsMap across many rebuilds

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheResyncTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheResyncTests.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.cache
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.KeyValue
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.common.exception.EtcdExceptionFactory
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.pollUntil
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives [PathChildrenCache] through a compaction-killed watch with a mocked jetcd
+ * [Client] (in the style of [io.etcd.recipes.common.FailingLeaseMocks]): the cache
+ * must reconcile its map from a fresh snapshot and re-anchor the replacement watch
+ * at the snapshot's revision, so `currentData` converges despite the lost history.
+ */
+class PathChildrenCacheResyncTests : StringSpec() {
+  private class CacheMocks(
+    val cachePath: String,
+  ) {
+    val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    val options = CopyOnWriteArrayList<WatchOption>()
+    private val getCount = AtomicInteger(0)
+
+    private fun kv(
+      name: String,
+      value: String,
+    ): KeyValue =
+      mockk {
+        every { key } returns "$cachePath/$name".asByteSequence
+        every { this@mockk.value } returns value.asByteSequence
+      }
+
+    // GET #1 (initial snapshot): {a=1} at revision 10. Every later GET (resync
+    // snapshot): {a=2, b=3} at revision 20.
+    private fun getResponse(): GetResponse {
+      val first = getCount.incrementAndGet() == 1
+      return mockk {
+        every { kvs } returns
+          if (first) listOf(kv("a", "1")) else listOf(kv("a", "2"), kv("b", "3"))
+        every { isMore } returns false
+        every { header } returns mockk { every { revision } returns if (first) 10L else 20L }
+      }
+    }
+
+    val client: Client =
+      mockk {
+        every { kvClient } returns
+          mockk<KV> {
+            every { get(any<ByteSequence>(), any()) } answers {
+              CompletableFuture.completedFuture(getResponse())
+            }
+          }
+        every { watchClient } returns
+          mockk<Watch> {
+            every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+              options += secondArg<WatchOption>()
+              listeners += thirdArg<Watch.Listener>()
+              mockk<Watch.Watcher>(relaxed = true)
+            }
+          }
+      }
+  }
+
+  init {
+    "compaction-killed cache watch reconciles the map and re-anchors past the snapshot" {
+      val mocks = CacheMocks("/cache/resync")
+      val recovery = CopyOnWriteArrayList<WatchRecoveryEvent>()
+
+      PathChildrenCache(mocks.client, mocks.cachePath).use { cache ->
+        cache.addRecoveryListener { recovery += it }
+        cache.start(true)
+
+        cache.currentDataAsMap.mapValues { it.value.asString } shouldBe mapOf("a" to "1")
+        mocks.options.first().revision shouldBe 11 // snapshot revision + 1
+
+        // etcd compacted away the watch anchor: jetcd reports a fatal death
+        mocks.listeners.first().onError(EtcdExceptionFactory.newCompactedException(15))
+        mocks.listeners.first().onCompleted()
+
+        pollUntil(10.seconds) { recovery.any { it is WatchRecoveryEvent.Resynced } } shouldBe true
+        val resync = recovery.filterIsInstance<WatchRecoveryEvent.Resynced>().first()
+        resync.compactRevision shouldBe 15
+        resync.anchorRevision shouldBe 21 // resync snapshot revision + 1
+
+        pollUntil(10.seconds) {
+          mocks.options.size == 2 && mocks.options[1].revision == 21L
+        } shouldBe true
+        cache.currentDataAsMap.mapValues { it.value.asString } shouldBe mapOf("a" to "2", "b" to "3")
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdTestContainer.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdTestContainer.kt
@@ -18,14 +18,32 @@
 
 package io.etcd.recipes.common
 
+import com.github.dockerjava.api.model.ExposedPort
+import com.github.dockerjava.api.model.PortBinding
+import com.github.dockerjava.api.model.Ports
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
+import java.net.ServerSocket
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
 internal object EtcdTestContainer {
   private const val ETCD_IMAGE = "gcr.io/etcd-development/etcd:v3.5.17"
   private const val CLIENT_PORT = 2379
-  private const val PEER_PORT = 2380
+
+  // The client port is bound to a FIXED host port chosen once per JVM: Docker does
+  // NOT preserve randomly-assigned host ports across `docker restart` (verified:
+  // the port changes), and the fault tests restart the container while jetcd
+  // clients keep dialing the original endpoint. A fixed binding lives in the
+  // container's HostConfig and survives restarts. Probing a free port and then
+  // binding it is racy in principle; with one container per forked test JVM the
+  // window is negligible.
+  private val fixedClientHostPort: Int by lazy {
+    ServerSocket(0).use { it.localPort }
+  }
 
   // Lazy: the container is only started when a test in this JVM actually
   // asks for the endpoint. With forkEvery=1 each test class is its own JVM,
@@ -33,8 +51,16 @@ internal object EtcdTestContainer {
   // handles cleanup; the explicit shutdown hook is belt-and-suspenders that
   // stops the container promptly when the test JVM exits.
   private val container: GenericContainer<*> by lazy {
+    // Only the client port is exposed: the peer port is unused on a single node, and
+    // the fixed-binding modifier below replaces ALL host-port bindings — an exposed
+    // port without a binding would stall Testcontainers' startup port check.
     val c = GenericContainer(DockerImageName.parse(ETCD_IMAGE))
-      .withExposedPorts(CLIENT_PORT, PEER_PORT)
+      .withExposedPorts(CLIENT_PORT)
+      .withCreateContainerCmdModifier { cmd ->
+        cmd.hostConfig?.withPortBindings(
+          PortBinding(Ports.Binding.bindPort(fixedClientHostPort), ExposedPort.tcp(CLIENT_PORT)),
+        )
+      }
       .withCommand(
         "etcd",
         "--listen-client-urls=http://0.0.0.0:$CLIENT_PORT",
@@ -46,5 +72,62 @@ internal object EtcdTestContainer {
     c
   }
 
-  fun endpoint(): String = "http://${container.host}:${container.getMappedPort(CLIENT_PORT)}"
+  fun endpoint(): String = "http://${container.host}:$fixedClientHostPort"
+
+  // ---- Fault-injection controls (used by io.etcd.recipes.fault tests) ----
+  // These mutate the private container; they are only meaningful under
+  // -PuseTestcontainers, where each forked test JVM owns its own etcd node.
+
+  /** Freezes the etcd process (simulates a network partition / unresponsive server). */
+  fun pause() {
+    container.dockerClient.pauseContainerCmd(container.containerId).exec()
+  }
+
+  /** Unfreezes a [pause]d etcd process. */
+  fun unpause() {
+    container.dockerClient.unpauseContainerCmd(container.containerId).exec()
+  }
+
+  /**
+   * Restarts the etcd process (simulates an etcd crash/restart). Docker preserves the
+   * container's published host-port binding across a restart, which keeps [endpoint]
+   * valid — asserted here so a Docker behavior change fails loudly instead of leaving
+   * clients dialing a dead port.
+   */
+  fun restart() {
+    val portBefore = container.getMappedPort(CLIENT_PORT)
+    container.dockerClient.restartContainerCmd(container.containerId).exec()
+    awaitReady()
+    val portAfter = currentMappedClientPort()
+    check(portBefore == portAfter) {
+      "etcd container's mapped client port changed across restart ($portBefore -> $portAfter); " +
+        "fault tests require a stable endpoint"
+    }
+  }
+
+  /** Blocks until etcd answers a real KV request at [endpoint], or fails after [timeout]. */
+  fun awaitReady(timeout: Duration = 30.seconds) {
+    val start = TimeSource.Monotonic.markNow()
+    var lastFailure: Exception? = null
+    while (start.elapsedNow() < timeout) {
+      try {
+        connectToEtcd(listOf(endpoint())) { client ->
+          client.kvClient.get("/fault/ready-probe".asByteSequence).get(2, TimeUnit.SECONDS)
+        }
+        return
+      } catch (e: Exception) {
+        lastFailure = e
+        Thread.sleep(250)
+      }
+    }
+    throw IllegalStateException("etcd container did not become ready within $timeout", lastFailure)
+  }
+
+  // Re-reads the port mapping from Docker rather than trusting any cached container info.
+  private fun currentMappedClientPort(): Int {
+    val info = container.dockerClient.inspectContainerCmd(container.containerId).exec()
+    val binding = info.networkSettings.ports.bindings[ExposedPort.tcp(CLIENT_PORT)]
+    return binding?.firstOrNull()?.hostPortSpec?.toInt()
+      ?: error("no host binding found for etcd client port $CLIENT_PORT")
+  }
 }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ResilientWatcherTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ResilientWatcherTests.kt
@@ -1,0 +1,267 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KeyValue
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.common.exception.EtcdExceptionFactory
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.jetcd.watch.WatchEvent
+import io.etcd.jetcd.watch.WatchResponse
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Unit tests for the resilient watcher recovery machinery. jetcd's [Watch] is mocked
+ * (in the style of [FailingLeaseMocks]) so tests can kill the stream deterministically:
+ * jetcd reports a fatal watch death by invoking `onError` followed by `onCompleted`
+ * on the registered [Watch.Listener], which is exactly what these tests drive.
+ * No etcd connection is required.
+ */
+class ResilientWatcherTests : StringSpec() {
+  /** Captures every subscribe call the watcher under test makes against jetcd. */
+  private class WatchMocks {
+    val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    val options = CopyOnWriteArrayList<WatchOption>()
+    val watchers = CopyOnWriteArrayList<Watch.Watcher>()
+    var failSubscribesAfter = Int.MAX_VALUE
+
+    val watch: Watch =
+      mockk {
+        every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+          if (listeners.size >= failSubscribesAfter) throw IllegalStateException("subscribe refused")
+          options += secondArg<WatchOption>()
+          listeners += thirdArg<Watch.Listener>()
+          mockk<Watch.Watcher>(relaxed = true).also { watchers += it }
+        }
+      }
+
+    val client: Client = mockk { every { watchClient } returns watch }
+  }
+
+  private fun eventResponse(vararg modRevisions: Long): WatchResponse =
+    mockk {
+      every { events } returns
+        modRevisions.map { rev ->
+          mockk<WatchEvent> {
+            every { keyValue } returns mockk<KeyValue> { every { modRevision } returns rev }
+          }
+        }
+      every { header } returns mockk { every { revision } returns (modRevisions.maxOrNull() ?: 0L) }
+    }
+
+  private fun progressResponse(headerRevision: Long): WatchResponse =
+    mockk {
+      every { events } returns emptyList()
+      every { header } returns mockk { every { revision } returns headerRevision }
+    }
+
+  private fun quickRetries() = WatchResilience(RetryPolicy.bounded(maxAttempts = 5, delay = 10.milliseconds))
+
+  /** Drives the fatal-death sequence jetcd produces when it abandons a watch. */
+  private fun Watch.Listener.die(cause: Throwable = RuntimeException("fatal watch error")) {
+    onError(cause)
+    onCompleted()
+  }
+
+  init {
+    "default watcher resubscribes after a fatal stream death" {
+      val mocks = WatchMocks()
+      mocks.client.watcher("/rw/default") { }.use {
+        mocks.listeners.first().die()
+        pollUntil(5.seconds) { mocks.listeners.size == 2 } shouldBe true
+      }
+    }
+
+    "resubscribe resumes at last-seen event revision + 1" {
+      val mocks = WatchMocks()
+      val events = CopyOnWriteArrayList<WatchRecoveryEvent>()
+      mocks.client.watcher("/rw/resume", WatchOption.DEFAULT, quickRetries(), { events += it }, null) { }
+        .use {
+          mocks.listeners.first().onNext(eventResponse(41, 42))
+          mocks.listeners.first().die()
+          pollUntil(5.seconds) { mocks.listeners.size == 2 } shouldBe true
+          mocks.options[1].revision shouldBe 43
+          pollUntil(5.seconds) { events.any { e -> e is WatchRecoveryEvent.Resubscribed } } shouldBe true
+          events.filterIsInstance<WatchRecoveryEvent.Resubscribed>().first().resumeRevision shouldBe 43
+        }
+    }
+
+    "progress-notify responses advance the resume revision" {
+      val mocks = WatchMocks()
+      mocks.client.watcher("/rw/notify", WatchOption.DEFAULT, quickRetries()) { }
+        .use {
+          mocks.listeners.first().onNext(progressResponse(500))
+          mocks.listeners.first().die()
+          pollUntil(5.seconds) { mocks.listeners.size == 2 } shouldBe true
+          mocks.options[1].revision shouldBe 501
+        }
+    }
+
+    "un-anchored watcher that saw no events resubscribes from current revision" {
+      val mocks = WatchMocks()
+      mocks.client.watcher("/rw/current", WatchOption.DEFAULT, quickRetries()) { }
+        .use {
+          mocks.listeners.first().die()
+          pollUntil(5.seconds) { mocks.listeners.size == 2 } shouldBe true
+          mocks.options[1].revision shouldBe 0
+        }
+    }
+
+    "caller-anchored watcher that saw no events resubscribes from its anchor" {
+      val mocks = WatchMocks()
+      val anchored = watchOption { withRevision(50) }
+      mocks.client.watcher("/rw/anchored", anchored, quickRetries()) { }
+        .use {
+          mocks.listeners.first().die()
+          pollUntil(5.seconds) { mocks.listeners.size == 2 } shouldBe true
+          mocks.options[1].revision shouldBe 50
+        }
+    }
+
+    "compaction death invokes resyncWith and anchors the new watch at its revision" {
+      val mocks = WatchMocks()
+      val events = CopyOnWriteArrayList<WatchRecoveryEvent>()
+      val compacted = EtcdExceptionFactory.newCompactedException(100)
+      mocks.client.watcher("/rw/resync", WatchOption.DEFAULT, quickRetries(), { events += it }, { 106L }) { }
+        .use {
+          mocks.listeners.first().die(compacted)
+          pollUntil(5.seconds) { mocks.listeners.size == 2 } shouldBe true
+          mocks.options[1].revision shouldBe 106
+          pollUntil(5.seconds) { events.any { e -> e is WatchRecoveryEvent.Resynced } } shouldBe true
+          val resync = events.filterIsInstance<WatchRecoveryEvent.Resynced>().first()
+          resync.compactRevision shouldBe 100
+          resync.anchorRevision shouldBe 106
+        }
+    }
+
+    "compaction death without resyncWith resumes just past the compacted revision" {
+      val mocks = WatchMocks()
+      val events = CopyOnWriteArrayList<WatchRecoveryEvent>()
+      val compacted = EtcdExceptionFactory.newCompactedException(200)
+      mocks.client.watcher("/rw/skip", WatchOption.DEFAULT, quickRetries(), { events += it }, null) { }
+        .use {
+          mocks.listeners.first().die(compacted)
+          pollUntil(5.seconds) { mocks.listeners.size == 2 } shouldBe true
+          mocks.options[1].revision shouldBe 201
+          pollUntil(5.seconds) { events.any { e -> e is WatchRecoveryEvent.Resynced } } shouldBe true
+          events.filterIsInstance<WatchRecoveryEvent.Resynced>().first().anchorRevision shouldBe 201
+        }
+    }
+
+    "recovery listener sees Suspended then Resubscribed" {
+      val mocks = WatchMocks()
+      val events = CopyOnWriteArrayList<WatchRecoveryEvent>()
+      mocks.client.watcher("/rw/order", WatchOption.DEFAULT, quickRetries(), { events += it }, null) { }
+        .use {
+          mocks.listeners.first().die()
+          pollUntil(5.seconds) { events.size >= 2 } shouldBe true
+          events[0].shouldBeInstanceOf<WatchRecoveryEvent.Suspended>()
+          events[1].shouldBeInstanceOf<WatchRecoveryEvent.Resubscribed>()
+        }
+    }
+
+    "user close does not trigger resubscribe and closes the inner watcher" {
+      val mocks = WatchMocks()
+      val received = CopyOnWriteArrayList<WatchResponse>()
+      val watcher = mocks.client.watcher("/rw/close", WatchOption.DEFAULT, quickRetries()) { received += it }
+      mocks.listeners.first().onNext(eventResponse(7))
+      pollUntil(5.seconds) { received.size == 1 } shouldBe true
+      watcher.close()
+      // jetcd fires onCompleted when the inner watcher is closed; that must not recover
+      mocks.listeners.first().onCompleted()
+      Thread.sleep(100)
+      mocks.listeners.size shouldBe 1
+      verify { mocks.watchers.first().close() }
+      // events arriving after close are dropped, not dispatched
+      mocks.listeners.first().onNext(eventResponse(8))
+      Thread.sleep(100)
+      received.size shouldBe 1
+    }
+
+    "retry-policy exhaustion emits Failed and stops" {
+      val mocks = WatchMocks()
+      val events = CopyOnWriteArrayList<WatchRecoveryEvent>()
+      mocks.failSubscribesAfter = 1
+      val resilience = WatchResilience(RetryPolicy.bounded(maxAttempts = 1, delay = 10.milliseconds))
+      mocks.client.watcher("/rw/exhaust", WatchOption.DEFAULT, resilience, { events += it }, null) { }
+        .use {
+          mocks.listeners.first().die()
+          pollUntil(5.seconds) { events.any { e -> e is WatchRecoveryEvent.Failed } } shouldBe true
+          // initial subscribe + exactly one failed retry
+          verify(exactly = 2) { mocks.watch.watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) }
+        }
+    }
+
+    "never policy emits Failed without resubscribing" {
+      val mocks = WatchMocks()
+      val events = CopyOnWriteArrayList<WatchRecoveryEvent>()
+      mocks.client.watcher("/rw/never", WatchOption.DEFAULT, WatchResilience.DISABLED, { events += it }, null) { }
+        .use {
+          mocks.listeners.first().die()
+          pollUntil(5.seconds) { events.any { e -> e is WatchRecoveryEvent.Failed } } shouldBe true
+          verify(exactly = 1) { mocks.watch.watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) }
+        }
+    }
+
+    "watch options are preserved across resubscribe" {
+      val mocks = WatchMocks()
+      val original = watchOption { isPrefix(true).withNoDelete(true).withPrevKV(true) }
+      mocks.client.watcher("/rw/opts", original, quickRetries()) { }
+        .use {
+          mocks.listeners.first().die()
+          pollUntil(5.seconds) { mocks.listeners.size == 2 } shouldBe true
+          with(mocks.options[1]) {
+            isPrefix shouldBe true
+            isNoDelete shouldBe true
+            isPrevKV shouldBe true
+          }
+          // resilience default asks etcd for progress notifications on every subscribe
+          mocks.options[0].isProgressNotify shouldBe true
+          mocks.options[1].isProgressNotify shouldBe true
+        }
+    }
+
+    "events from the replacement watcher flow to the same block" {
+      val mocks = WatchMocks()
+      val received = CopyOnWriteArrayList<Long>()
+      mocks.client.watcher("/rw/flow", WatchOption.DEFAULT, quickRetries()) { resp ->
+        resp.events.forEach { received += it.keyValue.modRevision }
+      }.use {
+        mocks.listeners.first().onNext(eventResponse(41, 42))
+        mocks.listeners.first().die()
+        pollUntil(5.seconds) { mocks.listeners.size == 2 } shouldBe true
+        mocks.listeners[1].onNext(eventResponse(50))
+        pollUntil(5.seconds) { received.size == 3 } shouldBe true
+        received shouldBe listOf(41L, 42L, 50L)
+        received shouldContain 50L
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/RetryPolicyTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/RetryPolicyTests.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Unit tests for [RetryPolicy]. Pure logic — no etcd connection.
+ */
+class RetryPolicyTests : StringSpec() {
+  init {
+    "never yields null on the first attempt" {
+      RetryPolicy.never.nextDelay(1, Duration.ZERO).shouldBeNull()
+    }
+
+    "bounded returns the fixed delay for maxAttempts attempts then null" {
+      val policy = RetryPolicy.bounded(maxAttempts = 3, delay = 100.milliseconds)
+      policy.nextDelay(1, Duration.ZERO) shouldBe 100.milliseconds
+      policy.nextDelay(2, Duration.ZERO) shouldBe 100.milliseconds
+      policy.nextDelay(3, Duration.ZERO) shouldBe 100.milliseconds
+      policy.nextDelay(4, Duration.ZERO).shouldBeNull()
+    }
+
+    "exponentialBackoff grows by factor and caps at maxDelay" {
+      val policy = RetryPolicy.exponentialBackoff(
+        initialDelay = 100.milliseconds,
+        maxDelay = 500.milliseconds,
+        factor = 2.0,
+        jitterRatio = 0.0,
+      )
+      policy.nextDelay(1, Duration.ZERO) shouldBe 100.milliseconds
+      policy.nextDelay(2, Duration.ZERO) shouldBe 200.milliseconds
+      policy.nextDelay(3, Duration.ZERO) shouldBe 400.milliseconds
+      policy.nextDelay(4, Duration.ZERO) shouldBe 500.milliseconds // capped
+      policy.nextDelay(10, Duration.ZERO) shouldBe 500.milliseconds // stays capped
+    }
+
+    "exponentialBackoff honors maxAttempts" {
+      val policy = RetryPolicy.exponentialBackoff(jitterRatio = 0.0, maxAttempts = 2)
+      policy.nextDelay(1, Duration.ZERO).shouldNotBeNull()
+      policy.nextDelay(2, Duration.ZERO).shouldNotBeNull()
+      policy.nextDelay(3, Duration.ZERO).shouldBeNull()
+    }
+
+    "exponentialBackoff honors maxElapsed" {
+      val policy = RetryPolicy.exponentialBackoff(jitterRatio = 0.0, maxElapsed = 5.seconds)
+      policy.nextDelay(1, 4.seconds).shouldNotBeNull()
+      policy.nextDelay(1, 5.seconds).shouldBeNull()
+      policy.nextDelay(1, 6.seconds).shouldBeNull()
+    }
+
+    "exponentialBackoff jitter stays within the configured ratio" {
+      val base = 1000.milliseconds
+      val policy = RetryPolicy.exponentialBackoff(
+        initialDelay = base,
+        maxDelay = 10.seconds,
+        jitterRatio = 0.25,
+      )
+      repeat(200) {
+        val delay = policy.nextDelay(1, Duration.ZERO)
+        delay.shouldNotBeNull()
+        (delay >= 750.milliseconds) shouldBe true
+        (delay <= 1250.milliseconds) shouldBe true
+      }
+    }
+
+    "forever keeps producing delays for large attempt counts" {
+      RetryPolicy.forever.nextDelay(1, Duration.ZERO).shouldNotBeNull()
+      RetryPolicy.forever.nextDelay(10_000, 365.seconds).shouldNotBeNull()
+    }
+
+    "exponentialBackoff rejects non-positive attempt numbers" {
+      val policy = RetryPolicy.exponentialBackoff(jitterRatio = 0.0)
+      shouldThrow<IllegalArgumentException> { policy.nextDelay(0, Duration.ZERO) }
+      shouldThrow<IllegalArgumentException> { policy.nextDelay(-1, Duration.ZERO) }
+    }
+
+    "exponentialBackoff validates its configuration" {
+      shouldThrow<IllegalArgumentException> { RetryPolicy.exponentialBackoff(factor = 0.5) }
+      shouldThrow<IllegalArgumentException> { RetryPolicy.exponentialBackoff(jitterRatio = -0.1) }
+      shouldThrow<IllegalArgumentException> { RetryPolicy.exponentialBackoff(jitterRatio = 1.1) }
+      shouldThrow<IllegalArgumentException> { RetryPolicy.bounded(maxAttempts = 0) }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceCacheResyncTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceCacheResyncTests.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.discovery
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.KeyValue
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.common.exception.EtcdExceptionFactory
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.pollUntil
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives [ServiceCache] through a compaction-killed watch with a mocked jetcd
+ * [Client]: the cache must reconcile its instance map from a fresh snapshot and
+ * re-anchor the replacement watch, so [ServiceCache.instances] converges despite
+ * the lost history. (ServiceCache had no manual rebuild at all before resilience.)
+ */
+class ServiceCacheResyncTests : StringSpec() {
+  private val namesPath = "/discovery/resync"
+  private val serviceName = "svc"
+
+  private val v1 = ServiceInstance(serviceName, "payload-1")
+  private val v1Updated = v1.copy(jsonPayload = "payload-1-updated")
+  private val v2 = ServiceInstance(serviceName, "payload-2")
+
+  private inner class CacheMocks {
+    val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    val options = CopyOnWriteArrayList<WatchOption>()
+    private val getCount = AtomicInteger(0)
+
+    private fun kv(
+      id: String,
+      json: String,
+    ): KeyValue =
+      mockk {
+        every { key } returns "$namesPath/$serviceName/$id".asByteSequence
+        every { value } returns json.asByteSequence
+      }
+
+    // GET #1 (initial snapshot): {v1} at revision 10. Every later GET (resync
+    // snapshot): {v1Updated, v2} at revision 20.
+    private fun getResponse(): GetResponse {
+      val first = getCount.incrementAndGet() == 1
+      return mockk {
+        every { kvs } returns
+          if (first) {
+            listOf(kv(v1.id, v1.toJson()))
+          } else {
+            listOf(kv(v1.id, v1Updated.toJson()), kv(v2.id, v2.toJson()))
+          }
+        every { isMore } returns false
+        every { header } returns mockk { every { revision } returns if (first) 10L else 20L }
+      }
+    }
+
+    val client: Client =
+      mockk {
+        every { kvClient } returns
+          mockk<KV> {
+            every { get(any<ByteSequence>(), any()) } answers {
+              CompletableFuture.completedFuture(getResponse())
+            }
+          }
+        every { watchClient } returns
+          mockk<Watch> {
+            every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+              options += secondArg<WatchOption>()
+              listeners += thirdArg<Watch.Listener>()
+              mockk<Watch.Watcher>(relaxed = true)
+            }
+          }
+      }
+  }
+
+  init {
+    "compaction-killed service cache watch reconciles instances and re-anchors" {
+      val mocks = CacheMocks()
+      val recovery = CopyOnWriteArrayList<WatchRecoveryEvent>()
+
+      ServiceCache(mocks.client, namesPath, serviceName).use { cache ->
+        cache.addRecoveryListener { recovery += it }
+        cache.start()
+
+        cache.instances.map { it.jsonPayload } shouldBe listOf("payload-1")
+        mocks.options.first().revision shouldBe 11 // snapshot revision + 1
+
+        // etcd compacted away the watch anchor: jetcd reports a fatal death
+        mocks.listeners.first().onError(EtcdExceptionFactory.newCompactedException(15))
+        mocks.listeners.first().onCompleted()
+
+        pollUntil(10.seconds) { recovery.any { it is WatchRecoveryEvent.Resynced } } shouldBe true
+        pollUntil(10.seconds) {
+          mocks.options.size == 2 && mocks.options[1].revision == 21L
+        } shouldBe true
+        cache.instances.map { it.jsonPayload }.sorted() shouldBe listOf("payload-1-updated", "payload-2")
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorCloseDeadlockTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorCloseDeadlockTests.kt
@@ -49,6 +49,11 @@ class LeaderSelectorCloseDeadlockTests : StringSpec() {
     )
 
     init {
+        // Boot the (possibly Testcontainers) etcd fixture outside the tight per-test
+        // invocation timeouts below: the first `urls` access lazily starts the etcd +
+        // Ryuk containers, which can take over a minute on a busy Docker daemon.
+        beforeSpec { urls }
+
         // The bounded join + isAlive assertion turn a regression into a clean FAIL
         // (closer thread still alive after the timeout) rather than a hung suite.
         "close() releases a takeLeadership blocked on waitUntilFinished()".config(timeout = 60.seconds) {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/CompactExtensionTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/CompactExtensionTests.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import io.etcd.recipes.common.compact
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.getValue
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Exercises [compact] against a private Testcontainers etcd. Compaction is
+ * cluster-wide, so this must never run against the shared local etcd.
+ */
+class CompactExtensionTests : StringSpec() {
+  private val path = "/fault/${javaClass.simpleName}"
+
+  init {
+    "compact removes read access to history below the given revision" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        client.putValue("$path/key", "v1")
+        val rev1 = client.getResponse("$path/key").kvs.first().modRevision
+        client.putValue("$path/key", "v2")
+        val rev2 = client.getResponse("$path/key").kvs.first().modRevision
+
+        client.compact(rev2)
+
+        val thrown =
+          shouldThrowAny {
+            client.getResponse("$path/key", getOption { withRevision(rev1) })
+          }
+        generateSequence(thrown as Throwable) { it.cause.takeIf { c -> c !== it } }
+          .any { it.message?.contains("compacted") == true } shouldBe true
+
+        client.getValue("$path/key", "def") shouldBe "v2"
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/FaultInjectionSupport.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/FaultInjectionSupport.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Skips the test cleanly when run without `-PuseTestcontainers`.
+ *
+ * Fault-injection tests mutate cluster-wide etcd state (compaction, container
+ * pause/restart), which would disturb other test classes sharing the local etcd at
+ * `localhost:2379`. Under Testcontainers each forked test JVM owns a private etcd
+ * container (`forkEvery=1` + per-JVM lazy fixture), so faults are fully isolated.
+ */
+internal fun assumeFaultInjection() {
+  assumeTrue(
+    System.getProperty("etcd.recipes.testcontainers") == "true",
+    "Fault-injection tests require -PuseTestcontainers (they must not disturb a shared local etcd)",
+  )
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/RecipeFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/RecipeFaultTests.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.common.EtcdTestContainer
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.discovery.ServiceCache
+import io.etcd.recipes.discovery.ServiceInstance
+import io.etcd.recipes.election.LeaderSelector
+import io.etcd.recipes.queue.DistributedQueue
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives whole recipes through an etcd restart on a private Testcontainers node.
+ * These are end-to-end checks that recipe state converges and blocked operations
+ * complete once the server returns.
+ */
+class RecipeFaultTests : StringSpec() {
+  private val path = "/fault/${javaClass.simpleName}"
+
+  init {
+    "PathChildrenCache converges with etcd contents across a restart" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        val cachePath = "$path/cache"
+        PathChildrenCache(client, cachePath).start(true).use { cache ->
+          client.putValue("$cachePath/a", "1")
+          pollUntil(10.seconds) { cache.getCurrentData("a")?.asString == "1" } shouldBe true
+
+          EtcdTestContainer.restart()
+
+          client.putValue("$cachePath/b", "2")
+          pollUntil(60.seconds) {
+            cache.currentDataAsMap.mapValues { it.value.asString } == mapOf("a" to "1", "b" to "2")
+          } shouldBe true
+        }
+      }
+    }
+
+    "ServiceCache reflects registrations made after a restart" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        val namesPath = "$path/discovery"
+        val serviceName = "svc"
+        val before = ServiceInstance(serviceName, "before")
+        val after = ServiceInstance(serviceName, "after")
+
+        ServiceCache(client, namesPath, serviceName).use { cache ->
+          cache.start()
+          client.putValue("$namesPath/$serviceName/${before.id}", before.toJson())
+          pollUntil(10.seconds) { cache.instances.size == 1 } shouldBe true
+
+          EtcdTestContainer.restart()
+
+          client.putValue("$namesPath/$serviceName/${after.id}", after.toJson())
+          pollUntil(60.seconds) {
+            cache.instances.map { it.jsonPayload }.sorted() == listOf("after", "before")
+          } shouldBe true
+        }
+      }
+    }
+
+    "candidate is elected after the leader relinquishes post-restart" {
+      assumeFaultInjection()
+      val electionPath = "$path/election"
+      val releaseLeader = BooleanMonitor(false)
+      val aLeaderships = AtomicInteger(0)
+      val bLeaderships = AtomicInteger(0)
+
+      connectToEtcd(urls) { clientA ->
+        connectToEtcd(urls) { clientB ->
+          val selectorA =
+            LeaderSelector(
+              clientA,
+              electionPath,
+              takeLeadershipBlock = { _ ->
+                aLeaderships.incrementAndGet()
+                releaseLeader.waitUntilTrue()
+              },
+            )
+          val selectorB =
+            LeaderSelector(
+              clientB,
+              electionPath,
+              takeLeadershipBlock = { _ -> bLeaderships.incrementAndGet() },
+            )
+
+          selectorA.use { a ->
+            selectorB.use { b ->
+              a.start()
+              pollUntil(15.seconds) { aLeaderships.get() == 1 } shouldBe true
+              b.start()
+
+              // The candidate's leader-key watch must survive the restart to ever
+              // see the DELETE that follows the leader stepping down.
+              EtcdTestContainer.restart()
+
+              releaseLeader.set(true)
+              pollUntil(60.seconds) { bLeaderships.get() == 1 } shouldBe true
+              a.waitOnLeadershipComplete(30.seconds) shouldBe true
+              b.waitOnLeadershipComplete(30.seconds) shouldBe true
+            }
+          }
+        }
+      }
+    }
+
+    "parked dequeue completes for an item enqueued after a restart" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        val queuePath = "$path/queue"
+        DistributedQueue(client, queuePath).use { queue ->
+          val result = AtomicReference<String?>()
+          val error = AtomicReference<Throwable?>()
+          val consumer =
+            thread(name = "fault-dequeue") {
+              try {
+                result.set(queue.dequeue().asString)
+              } catch (e: Throwable) {
+                error.set(e)
+              }
+            }
+
+          Thread.sleep(1_000) // let the dequeue park on its watch
+
+          EtcdTestContainer.restart()
+
+          connectToEtcd(urls) { producer -> DistributedQueue(producer, queuePath).use { it.enqueue("recovered") } }
+
+          pollUntil(60.seconds) { result.get() != null || error.get() != null } shouldBe true
+          error.get() shouldBe null
+          result.get() shouldBe "recovered"
+          consumer.join(5_000)
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/ResilientWatcherFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/ResilientWatcherFaultTests.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.recipes.common.EtcdTestContainer
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchResilience
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.compact
+import io.etcd.recipes.common.compactOption
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.keyAsString
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.common.valueAsString
+import io.etcd.recipes.common.watchOption
+import io.etcd.recipes.common.watcher
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives the resilient watcher through real faults on a private Testcontainers etcd:
+ * process restart, pause/unpause (partition), and compaction of the watched revision.
+ */
+class ResilientWatcherFaultTests : StringSpec() {
+  private val path = "/fault/${javaClass.simpleName}"
+
+  init {
+    "watcher keeps receiving events across an etcd restart" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        val prefix = "$path/restart"
+        val seen = CopyOnWriteArrayList<String>()
+        client.watcher(prefix, watchOption { isPrefix(true) }) { resp ->
+          resp.events.forEach { seen += it.valueAsString }
+        }.use {
+          client.putValue("$prefix/a", "before")
+          pollUntil(10.seconds) { seen.contains("before") } shouldBe true
+
+          EtcdTestContainer.restart()
+
+          client.putValue("$prefix/b", "after")
+          pollUntil(30.seconds) { seen.contains("after") } shouldBe true
+        }
+      }
+    }
+
+    "watcher survives a paused etcd and delivers events after unpause" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        val prefix = "$path/pause"
+        val seen = CopyOnWriteArrayList<String>()
+        client.watcher(prefix, watchOption { isPrefix(true) }) { resp ->
+          resp.events.forEach { seen += it.valueAsString }
+        }.use {
+          client.putValue("$prefix/a", "before")
+          pollUntil(10.seconds) { seen.contains("before") } shouldBe true
+
+          EtcdTestContainer.pause()
+          try {
+            Thread.sleep(3_000)
+          } finally {
+            EtcdTestContainer.unpause()
+          }
+          EtcdTestContainer.awaitReady()
+
+          client.putValue("$prefix/b", "after")
+          pollUntil(30.seconds) { seen.contains("after") } shouldBe true
+        }
+      }
+    }
+
+    "watcher anchored at a compacted revision resyncs and emits Resynced" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        val prefix = "$path/compacted"
+        val key = "$prefix/key"
+
+        client.putValue(key, "v1")
+        val oldRevision = client.getResponse(key).kvs.first().modRevision
+        client.putValue(key, "v2")
+        client.putValue(key, "v3")
+        val headRevision = client.getResponse(key).header.revision
+        client.compact(headRevision, compactOption { withCompactPhysical(true) })
+
+        val seen = CopyOnWriteArrayList<Pair<String, String>>()
+        val recovery = CopyOnWriteArrayList<WatchRecoveryEvent>()
+        val resyncWith = {
+          val resp = client.getResponse(prefix, getOption { isPrefix(true) })
+          resp.kvs.forEach { kv -> seen += kv.key.asString to kv.value.asString }
+          resp.header.revision + 1
+        }
+        // anchor below the compaction point: etcd kills this watch with ErrCompacted
+        val anchored = watchOption { isPrefix(true).withRevision(oldRevision) }
+        client.watcher(prefix, anchored, WatchResilience.DEFAULT, { recovery += it }, resyncWith) { resp ->
+          resp.events.forEach { seen += it.keyAsString to it.valueAsString }
+        }.use {
+          pollUntil(30.seconds) { recovery.any { it is WatchRecoveryEvent.Resynced } } shouldBe true
+          val resync = recovery.filterIsInstance<WatchRecoveryEvent.Resynced>().first()
+          (resync.compactRevision > 0L) shouldBe true
+          (resync.anchorRevision > resync.compactRevision) shouldBe true
+          // the resync GET observed the current state despite the lost history
+          pollUntil(10.seconds) { seen.any { it.first == key && it.second == "v3" } } shouldBe true
+
+          // and the re-anchored watch is live for new events
+          client.putValue(key, "v4")
+          pollUntil(30.seconds) { seen.any { it.second == "v4" } } shouldBe true
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueueWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueueWatchRecoveryTests.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.queue
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.KeyValue
+import io.etcd.jetcd.Txn
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.kv.TxnResponse
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.pollUntil
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives a parked [AbstractQueue.dequeue] through a fatal watch death with a mocked
+ * jetcd [Client]. An item that arrived while the watch stream was dead must be
+ * delivered after recovery (the recovery re-poll), and an abandoned recovery must
+ * fail the dequeue instead of parking it forever.
+ */
+class QueueWatchRecoveryTests : StringSpec() {
+  private class QueueMocks(
+    /** GET calls up to this count return an empty queue; later ones return the item. */
+    private val emptyGets: Int,
+  ) {
+    val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    val getCount = AtomicInteger(0)
+
+    private val item: KeyValue =
+      mockk {
+        every { key } returns "/queue/recovery/0001".asByteSequence
+        every { value } returns "hello".asByteSequence
+        every { modRevision } returns 5L
+      }
+
+    private fun getResponse(): GetResponse {
+      val empty = getCount.incrementAndGet() <= emptyGets
+      return mockk {
+        every { kvs } returns if (empty) emptyList() else listOf(item)
+        every { isMore } returns false
+      }
+    }
+
+    val client: Client =
+      mockk {
+        every { kvClient } returns
+          mockk<KV> {
+            every { get(any<ByteSequence>(), any()) } answers {
+              CompletableFuture.completedFuture(getResponse())
+            }
+            every { txn() } returns
+              mockk<Txn> {
+                every { If(*anyVararg()) } returns this
+                every { Then(*anyVararg()) } returns this
+                every { commit() } returns
+                  CompletableFuture.completedFuture(mockk<TxnResponse> { every { isSucceeded } returns true })
+              }
+          }
+        every { watchClient } returns
+          mockk<Watch> {
+            every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+              listeners += thirdArg<Watch.Listener>()
+              mockk<Watch.Watcher>(relaxed = true)
+            }
+          }
+      }
+  }
+
+  private fun Watch.Listener.die() {
+    onError(RuntimeException("fatal watch error"))
+    onCompleted()
+  }
+
+  init {
+    "parked dequeue delivers an item that arrived while the watch stream was dead" {
+      // GET #1 (fast path) and #2 (pre-live gap poll) see an empty queue; the
+      // recovery re-poll and everything after see the item.
+      val mocks = QueueMocks(emptyGets = 2)
+      val result = AtomicReference<ByteSequence?>()
+      val error = AtomicReference<Throwable?>()
+
+      DistributedQueue(mocks.client, "/queue/recovery").use { queue ->
+        val worker =
+          thread(name = "dequeue-under-test") {
+            try {
+              result.set(queue.dequeue())
+            } catch (e: Throwable) {
+              error.set(e)
+            }
+          }
+
+        pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
+        mocks.listeners.first().die()
+
+        pollUntil(10.seconds) { result.get() != null || error.get() != null } shouldBe true
+        error.get() shouldBe null
+        result.get()!!.asString shouldBe "hello"
+        worker.join(5_000)
+      }
+    }
+
+    "parked dequeue fails fast when watch recovery is abandoned" {
+      // Queue stays empty forever and recovery is disabled: the dequeue must
+      // surface an error instead of parking forever.
+      val mocks = QueueMocks(emptyGets = Int.MAX_VALUE)
+      val error = AtomicReference<Throwable?>()
+      val result = AtomicReference<ByteSequence?>()
+
+      DistributedQueue(mocks.client, "/queue/recovery", ResilienceConfig.DISABLED).use { queue ->
+        val worker =
+          thread(name = "dequeue-under-test") {
+            try {
+              result.set(queue.dequeue())
+            } catch (e: Throwable) {
+              error.set(e)
+            }
+          }
+
+        pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
+        mocks.listeners.first().die()
+
+        pollUntil(10.seconds) { error.get() != null } shouldBe true
+        error.get().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
+        result.get() shouldBe null
+        worker.join(5_000)
+      }
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=com.pambrose
-version=0.11.0
+version=0.12.0
 
 kotlin.code.style=official
 kotlin.incremental=true


### PR DESCRIPTION
Implements the first phase of product idea #3 (connection resilience) from `docs/PRODUCT_IDEAS_JULY_26.md`: watchers that survive fatal watch-stream deaths, on by default.

## Problem

Every watcher in the library used jetcd's `Consumer<WatchResponse>` overload, whose `onError`/`onCompleted` are no-ops. jetcd internally retries *transient* stream errors (connection blips, etcd restarts) with revision continuity, but *fatal* deaths — compaction of the watched revision, halt-error statuses, "etcdserver: no leader" — abandon the watch with no signal. Consequences:

- `PathChildrenCache.cacheMap` / `ServiceCache.serviceMap` went permanently stale
- A parked queue `dequeue()` or barrier waiter hung forever
- A `LeaderSelector` whose leader-key watch died never ran for leader again

## Changes

- **Resilient watcher** (`WatchExtensions.kt`): subscribes via `Watch.Listener`, tracks the last observed revision, auto-resubscribes fatal deaths from `lastSeen + 1`, paced by a new **`RetryPolicy`** (exponential backoff / bounded / forever / never). On compaction it invokes a `resyncWith` hook so the caller re-reads its world and re-anchors. Recovery is observable via `WatchRecoveryListener` (`Suspended` / `Resubscribed` / `Resynced` / `Failed`).
- **Recipe adoption, ON by default** (`ResilienceConfig.DISABLED` restores pre-0.12 behavior; every recipe takes an optional trailing `resilience` parameter):
  - `PathChildrenCache` / `ServiceCache`: reconcile their maps during a compaction resync (`addRecoveryListener` exposed); `rebuild()` refactored onto the same reconcile path
  - `AbstractQueue.dequeue()` / both barriers: re-probe their condition after each recovery; an abandoned recovery unparks the waiter with `EtcdRecipeRuntimeException` instead of hanging forever
  - `LeaderSelector`: re-probes the leader key after recovery (re-election survives lost DELETEs); `reportLeader` replays current state when a gap is possible
- **`Client.compact(revision, option)`** KV extension; `EtcdRecipeRuntimeException` gains an optional `cause`
- **Fault-injection harness**: `EtcdTestContainer` gains `pause()`/`unpause()`/`restart()`/`awaitReady()` with a **fixed host port** (Docker reassigns ephemeral ports across `docker restart` — verified empirically); fault tests under `io.etcd.recipes.fault` gated behind `-PuseTestcontainers`
- Docs: README "Connection resilience" section, CHANGELOG, runnable `ResilientPathChildrenCacheExample`

## Testing

- 32 new unit tests (Kotest `StringSpec` + MockK), written test-first: `RetryPolicyTests`, `ResilientWatcherTests` (mock-driven stream kills), per-recipe recovery tests (`PathChildrenCacheResyncTests`, `ServiceCacheResyncTests`, `QueueWatchRecoveryTests`, `BarrierWatchRecoveryTests`, `BarrierWithCountWatchRecoveryTests`)
- 8 fault-injection tests driving real container restart / pause-partition / compaction, all passing
- `make lint` clean; `make tests-tc` full check: **185 tests, 0 failures** (includes `DesignFixesTests` source invariants, all preserved)
- Two pre-existing tests with tight 60/90s invocation timeouts now warm the etcd fixture in `beforeSpec` — container boot on a busy Docker daemon was eating their budgets

## Follow-ups (next phases of idea #3)

- PR 2: self-healing leases, connection-state listeners, `LeaderSelector` step-down on lease loss
- PR 3: RPC retry + operation timeouts, resilient client defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP