### PR TITLE
Add connection resilience, part 2: self-healing leases and leader step-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Connection-resilience release, part 1: watchers survive fatal stream deaths.
+Connection-resilience release: watchers survive fatal stream deaths (part 1),
+leases self-heal and leaders step down on lease loss (part 2).
 
-### Added
+### Added (part 2: self-healing leases, connection state)
+
+- `Client.selfHealingKeepAlive(ttl, resilience, listener, establish)` — a keep-alive
+  that re-grants an expired lease and re-runs the caller's establish hook, paced by
+  `LeaseResilience`/`RetryPolicy`. Lease lifecycle is observable via `LeaseListener`
+  events (`Suspended` / `Expired` / `Restored` / `Failed`); `addLeaseListener` on
+  `TransientKeyValue` and `ServiceRegistry`.
+- Connection-state machinery on `EtcdConnector`: `connectionState`
+  (`CONNECTED` / `SUSPENDED` / `RECONNECTED` / `LOST`) derived passively from each
+  recipe's own watch and lease streams, with `addConnectionStateListener`.
+- `interruptOnLeaseLoss` constructor parameter on `LeaderSelector` (default true).
+
+### Changed (part 2)
+
+- **Behavior:** lease-holding recipes no longer lose their keys permanently after a
+  partition longer than the TTL. `TransientKeyValue` re-puts its key,
+  `ServiceRegistry` re-registers instances, `DistributedBarrier` re-arms, and a
+  parked `DistributedBarrierWithCount` waiter's registration heals.
+- **Behavior:** `LeaderSelector` steps down on leadership-lease loss instead of
+  reporting `isLeader=true` while another node takes over (split-brain fix):
+  `isLeader` turns false immediately, `waitUntilFinished()` releases, the
+  `takeLeadership` thread is interrupted if still parked in user code, and
+  `relinquishLeadership` always runs once leadership was taken (previously skipped
+  when `takeLeadership` threw). Leadership is never auto-reclaimed.
+- `ServiceInstance` JSON now encodes default field values (`encodeDefaults`), fixing
+  a round-trip corruption where `registrationTimeUTC` was omitted whenever
+  serialization ran in the same millisecond as construction — a later parse then
+  back-filled a different timestamp. Old-format JSON still parses.
+
+### Added (part 1: resilient watchers)
 
 - `RetryPolicy` (exponential backoff / bounded / forever / never) pacing all watch
   recovery, and `WatchResilience` / `ResilienceConfig` to tune or disable it
@@ -26,7 +56,7 @@ Connection-resilience release, part 1: watchers survive fatal stream deaths.
   restart-stable client port) and fault tests under `io.etcd.recipes.fault`,
   gated behind `-PuseTestcontainers`.
 
-### Changed
+### Changed (part 1)
 
 - **Behavior:** watch-backed recipes no longer go silently stale after a fatal
   watch death. `PathChildrenCache` and `ServiceCache` reconcile their maps during a

--- a/README.md
+++ b/README.md
@@ -114,6 +114,42 @@ extension. `Failed` (retry policy exhausted) is also recorded in the connector's
 resume revision stays fresh on quiet keys; watch blocks see them as
 `WatchResponse`s with an empty event list.
 
+### Self-healing leases
+
+Lease-holding recipes survive lease expiry (a partition longer than the TTL) — also
+on by default. jetcd restarts a keep-alive stream after transient errors by itself;
+what it cannot recover is an *expired* lease, whose bound keys etcd has deleted.
+The `Client.selfHealingKeepAlive(ttl, resilience, listener) { lease -> ... }`
+primitive re-grants the lease and re-runs the recipe's establish hook, and every
+lease-holding recipe uses it:
+
+| Recipe | On lease expiry |
+|---|---|
+| `TransientKeyValue` | Key is re-put under the healed lease |
+| `ServiceRegistry` | Instance is re-registered (CAS; unique ids make this safe) |
+| `DistributedBarrier` | Barrier re-arms for future waiters (waiters that saw the expiry DELETE already passed — that window is unavoidable; the `Expired` event is the signal) |
+| `DistributedBarrierWithCount` | A parked waiter's registration heals so the barrier can still trip |
+| `LeaderSelector` (participation) | Candidacy is re-advertised |
+| `LeaderSelector` (leadership) | **Never healed — the leader steps down**: `isLeader` turns false, the `takeLeadership` block is released (interrupted if parked in its own code; disable via the `interruptOnLeaseLoss` constructor parameter), and `relinquishLeadership` runs. Another node may already lead; reclaiming would race it. |
+
+Lease events (`Suspended`, `Expired`, `Restored`, `Failed`) are observable via
+`addLeaseListener` on `TransientKeyValue` and `ServiceRegistry`, and are recorded
+on the connector's `exceptions` list.
+
+### Connection-state listeners
+
+Every recipe derives a coarse connection state — `CONNECTED`, `SUSPENDED`,
+`RECONNECTED`, `LOST` — passively from its own watch and lease streams:
+
+```kotlin
+selector.addConnectionStateListener { new, prev ->
+    if (new == ConnectionState.LOST) log.warn("ownership may be gone")
+}
+```
+
+`LOST` means a lease expired or recovery was abandoned — ownership may have been
+lost during the outage (a leader, for example, has already stepped down by then).
+
 ## Compatibility
 
 - Built on [jetcd](https://github.com/etcd-io/jetcd) and targets etcd v3.

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/basics/ConnectionStateExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/basics/ConnectionStateExample.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.basics
+
+import com.pambrose.common.util.sleep
+import io.etcd.recipes.common.ConnectionState
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.keyvalue.TransientKeyValue
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Demonstrates connection-state listeners: a TransientKeyValue derives
+ * CONNECTED / SUSPENDED / RECONNECTED / LOST from its own lease stream. Kill and
+ * restart the local etcd (`./etcd.sh`) while this runs — a short outage reports
+ * SUSPENDED then RECONNECTED; one longer than the TTL reports LOST (the lease
+ * expired; the key is healed) then RECONNECTED.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+
+  connectToEtcd(urls) { client ->
+    TransientKeyValue(client, "/examples/connection-state", "up", leaseTtlSecs = 2).use { tkv ->
+      tkv.addConnectionStateListener { new, prev ->
+        logger.info { "Connection state: $prev -> $new" }
+        if (new == ConnectionState.LOST) logger.warn { "Ownership may have been lost during the outage" }
+      }
+      repeat(120) {
+        sleep(2.seconds)
+        logger.info { "state=${tkv.connectionState}" }
+      }
+    }
+  }
+}

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/discovery/SelfHealingServiceRegistryExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/discovery/SelfHealingServiceRegistryExample.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.discovery
+
+import com.pambrose.common.util.sleep
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.discovery.ServiceInstance
+import io.etcd.recipes.discovery.ServiceRegistry
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Demonstrates self-healing service registration: kill and restart the local etcd
+ * (`./etcd.sh`) — or stop it for longer than the TTL — while this runs. The
+ * instance registration expires with its lease and is automatically re-registered
+ * when the healer re-grants it; every lease event is printed.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val servicePath = "/services/self-healing-example"
+
+  connectToEtcd(urls) { client ->
+    ServiceRegistry(client, servicePath, leaseTtlSecs = 2).use { registry ->
+      registry.addLeaseListener { event -> logger.info { "Lease event: $event" } }
+      registry.addConnectionStateListener { new, prev -> logger.info { "Connection state: $prev -> $new" } }
+
+      val instance = ServiceInstance("ExampleService", """{"port": 8080}""")
+      registry.registerService(instance)
+      logger.info { "Registered ${instance.name}/${instance.id}" }
+
+      repeat(120) {
+        sleep(2.seconds)
+        logger.info { "Still running; exceptions so far: ${registry.exceptions.size}" }
+      }
+    }
+  }
+}

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/election/LeaderStepDownExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/election/LeaderStepDownExample.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.election
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.election.LeaderSelector
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+/**
+ * Demonstrates leader step-down on lease loss: the elected leader holds leadership
+ * until its lease disappears (kill etcd for longer than the TTL, or revoke the
+ * LEADER key's lease with etcdctl), at which point isLeader turns false, the
+ * takeLeadership block is released, and relinquishLeadership runs — no split brain.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val electionPath = "/election/step-down-example"
+
+  connectToEtcd(urls) { client ->
+    LeaderSelector(
+      client,
+      electionPath,
+      takeLeadershipBlock = { selector ->
+        logger.info { "Took leadership; holding until shutdown or lease loss" }
+        selector.waitUntilFinished()
+        logger.info { "takeLeadership released (isLeader=${selector.isLeader})" }
+      },
+      relinquishLeadershipBlock = { _ ->
+        logger.info { "Relinquished leadership" }
+      },
+    ).use { selector ->
+      selector.addConnectionStateListener { new, prev -> logger.info { "Connection state: $prev -> $new" } }
+      selector.start()
+      selector.waitOnLeadershipComplete()
+      logger.info { "Election over; exceptions recorded: ${selector.exceptions.map { it.message }}" }
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -21,25 +21,25 @@ package io.etcd.recipes.barrier
 import com.pambrose.common.time.timeUnitToDuration
 import com.pambrose.common.util.randomId
 import io.etcd.jetcd.Client
-import io.etcd.jetcd.support.CloseableClient
 import io.etcd.jetcd.watch.WatchEvent.EventType.DELETE
 import io.etcd.recipes.barrier.DistributedBarrier.Companion.defaultClientId
 import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.LeaseEvent
 import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.SelfHealingKeepAlive
 import io.etcd.recipes.common.WatchRecoveryEvent
 import io.etcd.recipes.common.WatchRecoveryListener
 import io.etcd.recipes.common.deleteKey
 import io.etcd.recipes.common.doesNotExist
 import io.etcd.recipes.common.isKeyPresent
-import io.etcd.recipes.common.keepAlive
-import io.etcd.recipes.common.leaseGrant
-import io.etcd.recipes.common.leaseRevoke
 import io.etcd.recipes.common.putOption
+import io.etcd.recipes.common.selfHealingKeepAlive
 import io.etcd.recipes.common.setTo
 import io.etcd.recipes.common.transaction
 import io.etcd.recipes.common.watchOption
 import io.etcd.recipes.common.withWatcher
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -69,7 +69,7 @@ constructor(
   resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
 ) : EtcdConnector(client, resilience) {
   // Plain var: all reads/writes are inside @Synchronized methods on this instance.
-  private var keepAliveLease: CloseableClient? = null
+  private var keepAliveLease: SelfHealingKeepAlive? = null
   private val barrierRemoved = AtomicBoolean(false)
 
   init {
@@ -90,28 +90,56 @@ constructor(
       // Create unique token to avoid collision from clients with same id
       val uniqueToken = "$clientId:${randomId(TOKEN_LENGTH)}"
 
-      // Grant the barrier lease with the configurable TTL; keepAlive renews it until the barrier is removed
-      val lease = client.leaseGrant(leaseTtlSecs.seconds)
-
-      // Do a CAS on the key name. If it is not found, then set it
-      val txn =
-        client.transaction {
-          If(barrierPath.doesNotExist)
-          Then(barrierPath.setTo(uniqueToken, putOption { withLeaseId(lease.id) }))
+      // The barrier key is bound to a self-healing lease: if the lease expires
+      // (partition longer than the TTL), waiters see a spurious lift — that window
+      // is unavoidable, etcd deleted the key — but the healer re-arms the barrier
+      // for future waiters and surfaces an Expired event so the owner knows. The
+      // CAS is authoritative: on the initial attempt a loss aborts (another client
+      // holds the barrier; the healer revokes its own lease before throwing). On a
+      // heal-time loss another client re-set the barrier meanwhile — the barrier
+      // stays armed, just not maintained by this instance (a Failed event says so).
+      try {
+        keepAliveLease = client.selfHealingKeepAlive(
+          leaseTtlSecs.seconds,
+          resilience.lease,
+          leaseListener = { event -> onBarrierLeaseEvent(event) },
+        ) { lease ->
+          if (barrierRemoved.load()) {
+            false // explicitly removed: do not re-arm
+          } else {
+            client.transaction {
+              If(barrierPath.doesNotExist)
+              Then(barrierPath.setTo(uniqueToken, putOption { withLeaseId(lease.id) }))
+            }.isSucceeded
+          }
         }
-
-      // The CAS is authoritative: txn.isSucceeded means this client created the
-      // barrier key. (The previous getValue re-read only guarded the tiny window
-      // where a concurrent removeBarrier ran between commit and read.)
-      if (txn.isSucceeded) {
-        keepAliveLease = client.keepAlive(lease) { e -> exceptionList.value += e }
         true
-      } else {
-        // Lease leaked the original implementation: when the CAS lost or the
-        // value verification failed we returned without ever revoking the
-        // lease, so it sat in etcd until TTL — wasteful in tight retry loops.
-        client.leaseRevoke(lease)
+      } catch (e: EtcdRecipeRuntimeException) {
+        // Initial CAS lost: another client set the barrier between the presence
+        // check and the txn. The healer already revoked the lease it granted.
+        logger.debug(e) { "setBarrier lost the CAS for $barrierPath" }
         false
+      }
+    }
+  }
+
+  // Record lease trouble on the exceptions list, drive connection state, and log
+  // healing outcomes.
+  private fun onBarrierLeaseEvent(event: LeaseEvent) {
+    reportLeaseEvent(event)
+    when (event) {
+      is LeaseEvent.Suspended -> exceptionList.value += event.cause
+
+      is LeaseEvent.Expired -> exceptionList.value += (
+        event.cause ?: EtcdRecipeRuntimeException("Barrier lease for $barrierPath expired; healing")
+      )
+
+      is LeaseEvent.Failed -> exceptionList.value += (
+        event.cause ?: EtcdRecipeRuntimeException("Barrier lease healing for $barrierPath abandoned")
+      )
+
+      is LeaseEvent.Restored -> logger.info {
+        "Barrier lease for $barrierPath healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
       }
     }
   }
@@ -197,6 +225,7 @@ constructor(
     watchFailure: AtomicReference<Throwable?>,
   ): WatchRecoveryListener =
     WatchRecoveryListener { event ->
+      reportRecoveryEvent(event)
       when (event) {
         is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
           if (!isBarrierSet() && (barrierPresentAtStart || !waitOnMissingBarriers))
@@ -224,6 +253,8 @@ constructor(
   }
 
   companion object {
+    private val logger = KotlinLogging.logger {}
+
     internal fun defaultClientId() = EtcdConnector.defaultClientId(DistributedBarrier::class.simpleName!!)
   }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -23,14 +23,15 @@ import com.pambrose.common.time.timeUnitToDuration
 import com.pambrose.common.util.ensureSuffix
 import com.pambrose.common.util.randomId
 import io.etcd.jetcd.Client
-import io.etcd.jetcd.support.CloseableClient
 import io.etcd.jetcd.watch.WatchEvent.EventType.DELETE
 import io.etcd.jetcd.watch.WatchEvent.EventType.PUT
 import io.etcd.recipes.barrier.DistributedBarrierWithCount.Companion.defaultClientId
 import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdRecipeException
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.LeaseEvent
 import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.SelfHealingKeepAlive
 import io.etcd.recipes.common.WatchRecoveryEvent
 import io.etcd.recipes.common.WatchRecoveryListener
 import io.etcd.recipes.common.appendToPath
@@ -41,14 +42,13 @@ import io.etcd.recipes.common.doesExist
 import io.etcd.recipes.common.doesNotExist
 import io.etcd.recipes.common.getChildCount
 import io.etcd.recipes.common.isKeyPresent
-import io.etcd.recipes.common.keepAlive
-import io.etcd.recipes.common.leaseGrant
-import io.etcd.recipes.common.leaseRevoke
 import io.etcd.recipes.common.putOption
+import io.etcd.recipes.common.selfHealingKeepAlive
 import io.etcd.recipes.common.setTo
 import io.etcd.recipes.common.transaction
 import io.etcd.recipes.common.watchOption
 import io.etcd.recipes.common.withWatcher
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.time.Duration
@@ -127,7 +127,7 @@ constructor(
   @Suppress("CyclomaticComplexMethod", "LongMethod")
   @Throws(InterruptedException::class, EtcdRecipeException::class)
   fun waitOnBarrier(timeout: Duration): Boolean {
-    val keepAliveLease = AtomicReference<CloseableClient?>(null)
+    val keepAliveLease = AtomicReference<SelfHealingKeepAlive?>(null)
     val keepAliveClosed = BooleanMonitor(false)
     val cancelled = BooleanMonitor(false)
     val uniqueToken = "$clientId:${randomId(TOKEN_LENGTH)}"
@@ -181,38 +181,49 @@ constructor(
         Then(readyPath setTo uniqueToken)
       }
 
-      val lease = client.leaseGrant(leaseTtlSecs.seconds)
-
-      val txn =
-        client.transaction {
-          If(myWaitingPath.doesNotExist)
-          Then(myWaitingPath.setTo(uniqueToken, putOption { withLeaseId(lease.id) }))
-        }
-
-      when {
-        !txn.isSucceeded -> {
-          // Revoke the lease we just granted; otherwise it lingers in etcd
-          // until its TTL expires — wasteful in tight retry loops.
-          client.leaseRevoke(lease)
+      // The waiting key is bound to a self-healing lease: if it expires while the
+      // waiter is parked (partition longer than the TTL), the healer re-registers
+      // it so the barrier can still trip. Healing stops once the barrier lifted or
+      // the wait was cancelled (keepAliveClosed). A heal-time CAS loss means the
+      // key unexpectedly exists — ownership is not reclaimed.
+      val healer =
+        try {
+          client.selfHealingKeepAlive(
+            leaseTtlSecs.seconds,
+            resilience.lease,
+            leaseListener = { event -> onWaiterLeaseEvent(event) },
+          ) { lease ->
+            if (keepAliveClosed.get()) {
+              false
+            } else {
+              client.transaction {
+                If(myWaitingPath.doesNotExist)
+                Then(myWaitingPath.setTo(uniqueToken, putOption { withLeaseId(lease.id) }))
+              }.isSucceeded
+            }
+          }
+        } catch (e: EtcdRecipeRuntimeException) {
+          // Initial CAS lost (the healer already revoked its lease).
+          logger.debug(e) { "Waiting-path CAS lost for $myWaitingPath" }
           throw EtcdRecipeException("Failed to set waitingPath")
         }
 
-        // No getValue re-read: txn.isSucceeded already proves this client set the
-        // waiting-path key (the re-read only guarded a commit-to-read race window).
-        else -> {
-          // Keep key alive
-          keepAliveLease.store(client.keepAlive(lease) { e -> exceptionList.value += e })
+      // No getValue re-read: the establish CAS already proves this client set the
+      // waiting-path key (the re-read only guarded a commit-to-read race window).
 
-          // Reconcile with a close() that may have fired before the store above: its
-          // closeKeepAlive() would have found a null ref and closed nothing, stranding
-          // the just-created client. onCancel sets `cancelled` before calling
-          // closeKeepAlive(), so observing it here means we own closing our client.
-          if (cancelled.get()) closeKeepAlive()
+      // Keep key alive (self-healing across lease expiry)
+      keepAliveLease.store(healer)
 
-          checkWaiterCount()
+      // Reconcile with a close() that may have fired before the store above: its
+      // closeKeepAlive() would have found a null ref and closed nothing, stranding
+      // the just-created client. onCancel sets `cancelled` before calling
+      // closeKeepAlive(), so observing it here means we own closing our client.
+      if (cancelled.get()) closeKeepAlive()
 
-          // Do not bother starting watcher if latch is already done
-          return if (keepAliveClosed.get()) {
+      checkWaiterCount()
+
+      // Do not bother starting watcher if latch is already done
+      return if (keepAliveClosed.get()) {
             // Cancellation by close() also flips keepAliveClosed; report
             // satisfied-only-when-not-cancelled.
             !cancelled.get()
@@ -229,6 +240,7 @@ constructor(
             // the failure recorded so the caller errors out instead of parking.
             val recoveryListener =
               WatchRecoveryListener { event ->
+                reportRecoveryEvent(event)
                 when (event) {
                   is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
                     checkWaiterCount()
@@ -283,8 +295,6 @@ constructor(
               signalled && !cancelled.get()
             }
           }
-        }
-      }
     } finally {
       activeWaiter.compareAndSet(active, null)
     }
@@ -294,7 +304,30 @@ constructor(
     activeWaiter.exchange(null)?.onCancel?.invoke()
   }
 
+  // Record lease trouble on the exceptions list, drive connection state, and log
+  // healing outcomes.
+  private fun onWaiterLeaseEvent(event: LeaseEvent) {
+    reportLeaseEvent(event)
+    when (event) {
+      is LeaseEvent.Suspended -> exceptionList.value += event.cause
+
+      is LeaseEvent.Expired -> exceptionList.value += (
+        event.cause ?: EtcdRecipeRuntimeException("Waiter lease for $barrierPath expired; healing")
+      )
+
+      is LeaseEvent.Failed -> exceptionList.value += (
+        event.cause ?: EtcdRecipeRuntimeException("Waiter lease healing for $barrierPath abandoned")
+      )
+
+      is LeaseEvent.Restored -> logger.info {
+        "Waiter lease for $barrierPath healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+      }
+    }
+  }
+
   companion object {
+    private val logger = KotlinLogging.logger {}
+
     internal fun defaultClientId() = defaultClientId(DistributedBarrierWithCount::class.simpleName!!)
   }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -308,6 +308,7 @@ class PathChildrenCache
 
   @Suppress("TooGenericExceptionCaught")
   private fun onRecoveryEvent(event: WatchRecoveryEvent) {
+    reportRecoveryEvent(event)
     if (event is WatchRecoveryEvent.Failed) {
       exceptionList.value += event.cause
         ?: EtcdRecipeRuntimeException("Watch on $cachePath abandoned; cache is no longer updating")

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ConnectionState.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ConnectionState.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.common
+
+/**
+ * Coarse connection health of a recipe, derived passively from its own watch and
+ * lease streams (a connector with no active watch or lease reports nothing).
+ *
+ * - [CONNECTED]: initial state; no failures observed yet.
+ * - [SUSPENDED]: a stream reported an error; recovery (jetcd's or the recipe
+ *   layer's) is in progress.
+ * - [RECONNECTED]: a stream was re-established after a suspension; for leases,
+ *   ownership was re-established too.
+ * - [LOST]: a lease expired (ownership may have been lost — e.g. a leader should
+ *   consider stepping down), or recovery was abandoned.
+ */
+enum class ConnectionState {
+  CONNECTED,
+  SUSPENDED,
+  RECONNECTED,
+  LOST,
+}
+
+fun interface ConnectionStateListener {
+  fun stateChanged(
+    newState: ConnectionState,
+    previous: ConnectionState,
+  )
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
@@ -23,7 +23,9 @@ import com.pambrose.common.util.randomId
 import io.etcd.jetcd.Client
 import java.io.Closeable
 import java.util.Collections.synchronizedList
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
 
 open class EtcdConnector(
   protected val client: Client,
@@ -58,6 +60,60 @@ open class EtcdConnector(
 
   protected fun checkStartCalled() {
     if (!startCalled.load()) throw EtcdRecipeRuntimeException("start() not called")
+  }
+
+  private val connectionStateRef = AtomicReference(ConnectionState.CONNECTED)
+  private val connectionStateListeners = CopyOnWriteArrayList<ConnectionStateListener>()
+
+  /**
+   * Coarse connection health, derived passively from the watch-recovery and lease
+   * events this connector's own streams report — see [ConnectionState].
+   */
+  val connectionState: ConnectionState get() = connectionStateRef.load()
+
+  fun addConnectionStateListener(listener: ConnectionStateListener) {
+    connectionStateListeners += listener
+  }
+
+  fun removeConnectionStateListener(listener: ConnectionStateListener) {
+    connectionStateListeners -= listener
+  }
+
+  /** Recipes feed their watch-recovery events here to drive [connectionState]. */
+  protected fun reportRecoveryEvent(event: WatchRecoveryEvent) {
+    when (event) {
+      is WatchRecoveryEvent.Suspended -> transitionTo(ConnectionState.SUSPENDED)
+      is WatchRecoveryEvent.Resubscribed -> transitionTo(ConnectionState.RECONNECTED)
+      is WatchRecoveryEvent.Resynced -> transitionTo(ConnectionState.RECONNECTED)
+      is WatchRecoveryEvent.Failed -> transitionTo(ConnectionState.LOST)
+    }
+  }
+
+  /** Recipes feed their lease events here to drive [connectionState]. */
+  protected fun reportLeaseEvent(event: LeaseEvent) {
+    when (event) {
+      is LeaseEvent.Suspended -> transitionTo(ConnectionState.SUSPENDED)
+      is LeaseEvent.Expired -> transitionTo(ConnectionState.LOST)
+      is LeaseEvent.Restored -> transitionTo(ConnectionState.RECONNECTED)
+      is LeaseEvent.Failed -> transitionTo(ConnectionState.LOST)
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun transitionTo(newState: ConnectionState) {
+    // exchange() makes the transition atomic; equal states are dropped so repeated
+    // Suspended reports during one outage notify once. Listeners run on the
+    // reporting thread — recipes report from their own dispatcher/healer threads,
+    // never from jetcd's event loop.
+    val previous = connectionStateRef.exchange(newState)
+    if (previous == newState) return
+    connectionStateListeners.forEach { listener ->
+      try {
+        listener.stateChanged(newState, previous)
+      } catch (e: Throwable) {
+        exceptionList.value += e
+      }
+    }
   }
 
   // Template-method close: idempotency is enforced here so subclasses cannot

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LeaseResilience.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LeaseResilience.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.common
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Configures how a [SelfHealingKeepAlive] recovers from lease expiry.
+ *
+ * jetcd auto-restarts a keep-alive stream after transient errors with the observer
+ * still registered, so renewal resumes by itself. What jetcd cannot recover — and
+ * this layer heals — is an *expired* lease (renewal stopped longer than the TTL, or
+ * etcd reports the lease as gone): the lease must be re-granted and the owned keys
+ * re-established. [RetryPolicy.never] disables healing, restoring the pre-0.12
+ * behavior where an expired lease meant the recipe's keys were gone for good.
+ */
+class LeaseResilience
+  @JvmOverloads
+  constructor(
+    val retryPolicy: RetryPolicy = RetryPolicy.exponentialBackoff(),
+    /**
+     * Per-RPC deadline for the re-grant during healing, so heal attempts fail and
+     * retry under the policy instead of parking forever on an unreachable server.
+     */
+    val healOperationTimeout: Duration = 10.seconds,
+  ) {
+    companion object {
+      @JvmField
+      val DEFAULT = LeaseResilience()
+
+      @JvmField
+      val DISABLED = LeaseResilience(RetryPolicy.never)
+    }
+  }
+
+/**
+ * Events describing the lifecycle of a [SelfHealingKeepAlive], delivered to a
+ * [LeaseListener].
+ */
+sealed interface LeaseEvent {
+  /** The keep-alive stream reported a transient error; jetcd is retrying it. */
+  data class Suspended(
+    val leaseId: Long,
+    val cause: Throwable,
+  ) : LeaseEvent
+
+  /**
+   * The lease expired (renewal stopped past its TTL, or etcd reported it gone).
+   * Ownership of the bound keys may have been lost to another party; healing
+   * follows unless the retry policy forbids it.
+   */
+  data class Expired(
+    val leaseId: Long,
+    val cause: Throwable?,
+  ) : LeaseEvent
+
+  /** A replacement lease was granted and the owned keys were re-established. */
+  data class Restored(
+    val oldLeaseId: Long,
+    val newLeaseId: Long,
+  ) : LeaseEvent
+
+  /** Healing was abandoned (policy exhausted, or the establish hook declined). */
+  data class Failed(
+    val leaseId: Long,
+    val cause: Throwable?,
+  ) : LeaseEvent
+}
+
+fun interface LeaseListener {
+  fun onLeaseEvent(event: LeaseEvent)
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ResilienceConfig.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ResilienceConfig.kt
@@ -23,12 +23,13 @@ package io.etcd.recipes.common
  */
 data class ResilienceConfig(
   val watch: WatchResilience = WatchResilience.DEFAULT,
+  val lease: LeaseResilience = LeaseResilience.DEFAULT,
 ) {
   companion object {
     @JvmField
     val DEFAULT = ResilienceConfig()
 
     @JvmField
-    val DISABLED = ResilienceConfig(watch = WatchResilience.DISABLED)
+    val DISABLED = ResilienceConfig(watch = WatchResilience.DISABLED, lease = LeaseResilience.DISABLED)
   }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/SelfHealingKeepAlive.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/SelfHealingKeepAlive.kt
@@ -1,0 +1,261 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.common.exception.ErrorCode
+import io.etcd.jetcd.common.exception.EtcdException
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
+import io.etcd.jetcd.support.CloseableClient
+import io.etcd.jetcd.support.Observers
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.io.Closeable
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * A keep-alive that survives lease expiry.
+ *
+ * jetcd auto-restarts the keep-alive stream after transient errors with observers
+ * kept, so renewal resumes by itself; those surface as [LeaseEvent.Suspended] only.
+ * What jetcd reports as *gone* — `onCompleted` (renewal stopped past the TTL) or a
+ * NOT_FOUND "requested lease not found" — triggers healing: re-grant the lease,
+ * re-run the establish hook to re-create the owned keys, and re-register the
+ * keep-alive, paced by the configured [RetryPolicy].
+ *
+ * Threading: jetcd delivers lease-stream callbacks on its own scheduler; everything
+ * here hops onto a dedicated single-thread executor so the blocking heal RPCs (and
+ * listener callbacks) stay off jetcd's threads. Backoff delays are scheduled, never
+ * slept, so [close] can cancel a pending attempt immediately.
+ */
+class SelfHealingKeepAlive internal constructor(
+  private val client: Client,
+  private val ttl: Duration,
+  private val resilience: LeaseResilience,
+  private val leaseListener: LeaseListener?,
+  private val establish: (lease: LeaseGrantResponse) -> Boolean,
+) : Closeable {
+  private val healer: ScheduledExecutorService =
+    Executors.newSingleThreadScheduledExecutor { runnable ->
+      Thread(runnable, "etcd-lease-healer").apply { isDaemon = true }
+    }
+  private val closed = AtomicBoolean(false)
+  private val lock = Any() // guards registration + pendingAttempt against close() racing a heal
+
+  @Volatile
+  private var lease: LeaseGrantResponse? = null
+  private var registration: CloseableClient? = null
+  private var pendingAttempt: ScheduledFuture<*>? = null
+
+  @Volatile
+  private var healthy = true
+
+  // Healer-thread-confined after the initial establish:
+  private var healing = false
+  private var attempt = 0
+  private var healStart: TimeMark? = null
+  private var lastCause: Throwable? = null
+
+  val currentLeaseId: Long get() = lease?.id ?: -1L
+  val isHealthy: Boolean get() = healthy && !closed.load()
+
+  internal fun start() {
+    val granted = client.leaseGrant(ttl)
+    if (!establish(granted)) {
+      client.leaseRevoke(granted)
+      throw EtcdRecipeRuntimeException("Establish hook declined initial lease ${granted.id}")
+    }
+    lease = granted
+    synchronized(lock) { registration = register(granted) }
+  }
+
+  override fun close() {
+    if (!closed.compareAndSet(false, true)) return
+    synchronized(lock) {
+      pendingAttempt?.cancel(false)
+      registration?.close()
+      registration = null
+    }
+    healer.shutdown()
+    try {
+      if (!healer.awaitTermination(5, TimeUnit.SECONDS)) {
+        logger.warn { "Lease healer did not terminate within 5 seconds; a heal attempt may still be running" }
+      }
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+    lease?.let { client.leaseRevoke(it) }
+  }
+
+  private fun register(granted: LeaseGrantResponse): CloseableClient =
+    client.leaseClient.keepAlive(
+      granted.id,
+      Observers.builder<LeaseKeepAliveResponse>()
+        .onNext { next -> logger.debug { "KeepAlive next resp: $next" } }
+        .onError { e -> onStreamEvent(granted, e) }
+        .onCompleted { onStreamEvent(granted, null) }
+        .build(),
+    )
+
+  // jetcd semantics: onCompleted = the lease outlived its TTL unrenewed (DeadLine
+  // service); onError(NOT_FOUND "requested lease not found") = etcd reports the
+  // lease gone. Both mean expired -> heal. Any other onError is transient: jetcd
+  // restarts the stream itself with this observer still registered.
+  private fun onStreamEvent(
+    granted: LeaseGrantResponse,
+    error: Throwable?,
+  ) {
+    if (closed.load()) return
+    if (granted.id != lease?.id) return // stale generation
+    val expired = error == null || error.isLeaseNotFound()
+    dispatch {
+      if (expired) {
+        startHeal(granted.id, error)
+      } else {
+        emit(LeaseEvent.Suspended(granted.id, error))
+      }
+    }
+  }
+
+  private fun dispatch(task: () -> Unit) {
+    try {
+      healer.execute {
+        if (closed.load()) return@execute
+        runCatching(task).onFailure { e -> logger.error(e) { "Lease healer task threw" } }
+      }
+    } catch (_: RejectedExecutionException) {
+      // closed concurrently; nothing left to heal
+    }
+  }
+
+  private fun startHeal(
+    expiredLeaseId: Long,
+    cause: Throwable?,
+  ) {
+    if (healing) return
+    healing = true
+    healthy = false
+    lastCause = cause
+    logger.warn(cause) { "Lease $expiredLeaseId expired; attempting to re-grant and re-establish" }
+    emit(LeaseEvent.Expired(expiredLeaseId, cause))
+    attempt = 0
+    healStart = TimeSource.Monotonic.markNow()
+    scheduleNextAttempt(expiredLeaseId)
+  }
+
+  private fun scheduleNextAttempt(expiredLeaseId: Long) {
+    attempt += 1
+    val elapsed = healStart?.elapsedNow() ?: Duration.ZERO
+    val delay = resilience.retryPolicy.nextDelay(attempt, elapsed)
+    if (delay == null) {
+      logger.error(lastCause) { "Abandoning lease heal: retry policy exhausted after ${attempt - 1} attempts" }
+      emit(LeaseEvent.Failed(expiredLeaseId, lastCause))
+      return
+    }
+    synchronized(lock) {
+      if (closed.load()) return
+      pendingAttempt = healer.schedule({ runAttempt(expiredLeaseId) }, delay.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught", "ReturnCount")
+  private fun runAttempt(expiredLeaseId: Long) {
+    if (closed.load()) return
+    try {
+      val granted =
+        client.leaseClient
+          .grant(
+            ttl.toDouble(DurationUnit.SECONDS).toLong(),
+            resilience.healOperationTimeout.inWholeMilliseconds,
+            TimeUnit.MILLISECONDS,
+          ).get()
+      if (!runEstablishForHeal(granted, expiredLeaseId)) return
+      synchronized(lock) {
+        if (closed.load()) {
+          client.leaseRevoke(granted)
+          return
+        }
+        registration?.close()
+        registration = register(granted)
+      }
+      lease = granted
+      healing = false
+      healthy = true
+      logger.info { "Lease healed: $expiredLeaseId -> ${granted.id} (attempt $attempt)" }
+      emit(LeaseEvent.Restored(expiredLeaseId, granted.id))
+    } catch (e: Throwable) {
+      lastCause = e
+      scheduleNextAttempt(expiredLeaseId)
+    }
+  }
+
+  // Returns false (after emitting Failed) when the establish hook declines the new
+  // lease — ownership is gone and must not be reclaimed.
+  private fun runEstablishForHeal(
+    granted: LeaseGrantResponse,
+    expiredLeaseId: Long,
+  ): Boolean {
+    if (establish(granted)) return true
+    client.leaseRevoke(granted)
+    logger.warn { "Establish hook declined healed lease ${granted.id}; abandoning heal of $expiredLeaseId" }
+    emit(LeaseEvent.Failed(expiredLeaseId, lastCause))
+    return false
+  }
+
+  private fun emit(event: LeaseEvent) {
+    runCatching { leaseListener?.onLeaseEvent(event) }
+      .onFailure { e -> logger.error(e) { "Lease listener threw on $event" } }
+  }
+}
+
+/**
+ * Grants a lease with [ttl], invokes [establish] to create the caller's keys bound
+ * to it (synchronously — a `false` return or a throw aborts), keeps the lease
+ * alive, and heals it on expiry: re-grant, re-run [establish] with the fresh lease,
+ * re-register the keep-alive. On every heal, [establish] must put/CAS the keys it
+ * owns under the new lease id and return `true` — or return `false` to signal that
+ * ownership is gone and must not be reclaimed (emits [LeaseEvent.Failed]).
+ */
+fun Client.selfHealingKeepAlive(
+  ttl: Duration,
+  resilience: LeaseResilience = LeaseResilience.DEFAULT,
+  leaseListener: LeaseListener? = null,
+  establish: (lease: LeaseGrantResponse) -> Boolean,
+): SelfHealingKeepAlive = SelfHealingKeepAlive(this, ttl, resilience, leaseListener, establish).also { it.start() }
+
+/**
+ * True when this failure (or any cause in its chain) is etcd's NOT_FOUND
+ * "requested lease not found" — jetcd's signal that a lease is gone for good,
+ * as opposed to a transient stream error it retries itself.
+ */
+internal fun Throwable.isLeaseNotFound(): Boolean =
+  generateSequence(this) { it.cause.takeIf { c -> c !== it } }
+    .filterIsInstance<EtcdException>()
+    .any { it.errorCode == ErrorCode.NOT_FOUND }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
@@ -155,6 +155,7 @@ class ServiceCache
 
   @Suppress("TooGenericExceptionCaught")
   private fun onRecoveryEvent(event: WatchRecoveryEvent) {
+    reportRecoveryEvent(event)
     if (event is WatchRecoveryEvent.Failed) {
       exceptionList.value += event.cause
         ?: EtcdRecipeRuntimeException("Watch on $servicePath abandoned; service cache is no longer updating")

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceInstance.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceInstance.kt
@@ -43,11 +43,19 @@ data class ServiceInstance(
     require(name.isNotEmpty()) { "Name cannot be empty" }
   }
 
-  fun toJson() = Json.encodeToString(serializer(), this)
+  fun toJson() = wireFormat.encodeToString(serializer(), this)
 
   companion object {
+    // encodeDefaults: registrationTimeUTC's default is Instant.now(), so with the
+    // stock configuration kotlinx omits the field whenever serialization runs in
+    // the same clock millisecond as construction — and a later parse back-fills a
+    // fresh (different) timestamp, corrupting the round-trip. Encoding defaults
+    // makes the wire format stable regardless of serialization timing; readers of
+    // the old format are unaffected (fields only become more complete).
+    private val wireFormat = Json { encodeDefaults = true }
+
     @JvmStatic
-    fun toObject(json: String) = Json.decodeFromString(serializer(), json)
+    fun toObject(json: String) = wireFormat.decodeFromString(serializer(), json)
 
     class ServiceInstanceBuilder(
       val name: String,

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
@@ -21,23 +21,26 @@ package io.etcd.recipes.discovery
 import com.google.common.collect.Maps.newConcurrentMap
 import com.pambrose.common.delegate.AtomicDelegates.nonNullableReference
 import io.etcd.jetcd.Client
-import io.etcd.jetcd.lease.LeaseGrantResponse
-import io.etcd.jetcd.support.CloseableClient
 import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdConnector.Companion.DEFAULT_TTL_SECS
 import io.etcd.recipes.common.EtcdRecipeException
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.LeaseListener
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.SelfHealingKeepAlive
 import io.etcd.recipes.common.appendToPath
 import io.etcd.recipes.common.deleteKey
 import io.etcd.recipes.common.doesExist
 import io.etcd.recipes.common.doesNotExist
-import io.etcd.recipes.common.keepAlive
-import io.etcd.recipes.common.leaseGrant
-import io.etcd.recipes.common.leaseRevoke
 import io.etcd.recipes.common.putOption
+import io.etcd.recipes.common.selfHealingKeepAlive
 import io.etcd.recipes.common.setTo
 import io.etcd.recipes.common.transaction
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.Closeable
 import java.util.concurrent.ConcurrentMap
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -51,9 +54,16 @@ constructor(
   client: Client,
   val servicePath: String,
   val leaseTtlSecs: Long = DEFAULT_TTL_SECS,
-) : EtcdConnector(client) {
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+) : EtcdConnector(client, resilience) {
   private val namesPath = servicePath.appendToPath("/names")
   private val serviceContextMap: ConcurrentMap<String, ServiceInstanceContext> = newConcurrentMap()
+  private val leaseListeners = CopyOnWriteArrayList<LeaseListener>()
+
+  /** Registers a listener for lease lifecycle events (expiry, healing, failure). */
+  fun addLeaseListener(listener: LeaseListener) {
+    leaseListeners += listener
+  }
 
   init {
     require(servicePath.isNotEmpty()) { "Service base path cannot be empty" }
@@ -64,15 +74,18 @@ constructor(
     val client: Client,
     val instancePath: String,
   ) : Closeable {
-    var lease: LeaseGrantResponse by nonNullableReference()
-    var keepAlive: CloseableClient by nonNullableReference()
+    // The JSON re-put on every heal; updateService refreshes it so a heal that
+    // races an update never resurrects a stale payload.
+    @Volatile
+    var currentJson: String = service.toJson()
+    var healer: SelfHealingKeepAlive by nonNullableReference()
 
     override fun close() {
-      keepAlive.close()
-      // Revoke the lease so it (and its bound key) is released promptly on
-      // unregister/close instead of lingering until TTL (#7). Revoking already
-      // deletes the lease-bound key; deleteKey is kept as belt-and-suspenders.
-      client.leaseRevoke(lease)
+      // Closing the healer stops any healing and revokes the current lease, so the
+      // instance key is released promptly on unregister/close instead of lingering
+      // until TTL (#7). Revoking already deletes the lease-bound key; deleteKey is
+      // kept as belt-and-suspenders.
+      healer.close()
       client.deleteKey(instancePath)
     }
   }
@@ -85,25 +98,28 @@ constructor(
     val instancePath = getNamesPath(service)
     val context = ServiceInstanceContext(service, client, instancePath)
 
-    context.lease = client.leaseGrant(leaseTtlSecs.seconds)
-
-    val txn =
-      client.transaction {
-        If(instancePath.doesNotExist)
-        Then(instancePath.setTo(service.toJson(), putOption { withLeaseId(context.lease.id) }))
+    // Self-healing: if the instance lease expires (partition longer than the TTL),
+    // the healer re-grants it and re-runs this CAS, re-registering the instance.
+    // Re-registration is safe because instance ids are unique to this process; a
+    // CAS loss means the key unexpectedly exists, so ownership is not reclaimed.
+    try {
+      context.healer = client.selfHealingKeepAlive(
+        leaseTtlSecs.seconds,
+        resilience.lease,
+        leaseListener = { event -> onLeaseEvent(instancePath, event) },
+      ) { lease ->
+        client.transaction {
+          If(instancePath.doesNotExist)
+          Then(instancePath.setTo(context.currentJson, putOption { withLeaseId(lease.id) }))
+        }.isSucceeded
       }
-
-    if (!txn.isSucceeded) {
-      // CAS lost (key already present). Revoke the lease we just granted so it does
-      // not linger until its TTL, and leave serviceContextMap untouched so a
-      // half-built context (with an unset keepAlive) is never published — doClose()
-      // would otherwise crash reading the unset delegate and abort the whole close.
-      client.leaseRevoke(context.lease)
+    } catch (e: EtcdRecipeRuntimeException) {
+      // Initial CAS lost (key already present); the healer already revoked its lease.
+      logger.debug(e) { "Registration CAS lost for $instancePath" }
       throw EtcdRecipeException("Service registration failed for $instancePath")
     }
 
-    // Only publish a fully-built context (lease + keepAlive set) into the map.
-    context.keepAlive = client.keepAlive(context.lease) { e -> exceptionList.value += e }
+    // Only publish a fully-built context (healer set) into the map.
     serviceContextMap[service.id] = context
   }
 
@@ -117,9 +133,49 @@ constructor(
     val txn =
       client.transaction {
         If(instancePath.doesExist)
-        Then(instancePath.setTo(service.toJson(), putOption { withLeaseId(context.lease.id) }))
+        Then(instancePath.setTo(service.toJson(), putOption { withLeaseId(context.healer.currentLeaseId) }))
       }
     if (!txn.isSucceeded) throw EtcdRecipeException("Service update failed for $instancePath")
+    context.currentJson = service.toJson()
+  }
+
+  // Record lease trouble on the exceptions list the way the old keep-alive error
+  // callback did, drive connection state, and forward to user listeners.
+  @Suppress("TooGenericExceptionCaught")
+  private fun onLeaseEvent(
+    instancePath: String,
+    event: LeaseEvent,
+  ) {
+    reportLeaseEvent(event)
+    when (event) {
+      is LeaseEvent.Suspended -> {
+        exceptionList.value += event.cause
+      }
+
+      is LeaseEvent.Expired -> {
+        event.cause?.let { exceptionList.value += it }
+        ?: run { exceptionList.value += EtcdRecipeRuntimeException("Lease for $instancePath expired; healing") }
+      }
+
+      is LeaseEvent.Failed -> {
+        exceptionList.value += event.cause
+        ?: EtcdRecipeRuntimeException("Lease healing for $instancePath abandoned; instance is unregistered")
+      }
+
+      is LeaseEvent.Restored -> {
+        logger.info {
+        "Lease for $instancePath healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+      }
+      }
+    }
+    leaseListeners.forEach { listener ->
+      try {
+        listener.onLeaseEvent(event)
+      } catch (e: Throwable) {
+        logger.error(e) { "Exception in lease listener" }
+        exceptionList.value += e
+      }
+    }
   }
 
   @Synchronized
@@ -144,4 +200,8 @@ constructor(
   internal val namesBasePath: String get() = namesPath
 
   private fun getNamesPath(service: ServiceInstance) = namesPath.appendToPath("${service.name}/${service.id}")
+
+  companion object {
+    private val logger = KotlinLogging.logger {}
+  }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -23,7 +23,9 @@ import com.pambrose.common.time.timeUnitToDuration
 import com.pambrose.common.util.randomId
 import com.pambrose.common.util.sleep
 import io.etcd.jetcd.Client
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
 import io.etcd.jetcd.options.WatchOption
+import io.etcd.jetcd.support.Observers
 import io.etcd.jetcd.watch.WatchEvent.EventType.DELETE
 import io.etcd.jetcd.watch.WatchEvent.EventType.PUT
 import io.etcd.jetcd.watch.WatchEvent.EventType.UNRECOGNIZED
@@ -31,6 +33,7 @@ import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdConnector.Companion.DEFAULT_TTL_SECS
 import io.etcd.recipes.common.EtcdRecipeException
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.LeaseEvent
 import io.etcd.recipes.common.ResilienceConfig
 import io.etcd.recipes.common.WatchRecoveryEvent
 import io.etcd.recipes.common.WatchRecoveryListener
@@ -43,10 +46,11 @@ import io.etcd.recipes.common.getChildrenValues
 import io.etcd.recipes.common.getValue
 import io.etcd.recipes.common.isKeyNotPresent
 import io.etcd.recipes.common.isKeyPresent
-import io.etcd.recipes.common.keepAliveWith
+import io.etcd.recipes.common.isLeaseNotFound
 import io.etcd.recipes.common.leaseGrant
 import io.etcd.recipes.common.leaseRevoke
 import io.etcd.recipes.common.putOption
+import io.etcd.recipes.common.selfHealingKeepAlive
 import io.etcd.recipes.common.setTo
 import io.etcd.recipes.common.transaction
 import io.etcd.recipes.common.watchOption
@@ -59,6 +63,8 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
@@ -106,6 +112,7 @@ constructor(
   private val userExecutor: Executor? = null,
   val clientId: String = defaultClientId(),
   resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  private val interruptOnLeaseLoss: Boolean = true,
 ) : EtcdConnector(client, resilience) {
   // For Kotlin clients
   @JvmOverloads
@@ -117,6 +124,8 @@ constructor(
     leaseTtlSecs: Long = DEFAULT_TTL_SECS,
     executorService: ExecutorService? = null,
     clientId: String = defaultClientId(),
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+    interruptOnLeaseLoss: Boolean = true,
   ) :
     this(
       client,
@@ -133,6 +142,8 @@ constructor(
       leaseTtlSecs,
       executorService,
       clientId,
+      resilience,
+      interruptOnLeaseLoss,
     )
 
   private var executor: Executor = userExecutor ?: Executors.newFixedThreadPool(3)
@@ -152,6 +163,12 @@ constructor(
   private val electionLock = Any()
   private val startCallAllowed = AtomicBoolean(true)
   private val leaderPath = electionPath.withLeaderSuffix
+
+  // Step-down machinery: set for the duration of a leadership hold so a fatal
+  // keep-alive event (lease gone) can end leadership from the observer thread.
+  private val leadershipThreadRef = AtomicReference<Thread?>(null)
+  private val leadershipLeaseId = AtomicLong(-1L)
+  private val leaseLostDuringLeadership = AtomicBoolean(false)
 
   init {
     require(electionPath.isNotEmpty()) { "Election path cannot be empty" }
@@ -203,6 +220,7 @@ constructor(
             // attemptToBecomeLeader CAS-guards against a concurrent winner.
             val recoveryListener =
               WatchRecoveryListener { event ->
+                reportRecoveryEvent(event)
                 when (event) {
                   is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
                     if (client.isKeyNotPresent(leaderPath))
@@ -355,28 +373,53 @@ constructor(
       }
     }
 
-    // Prime lease with leaseTtlSecs seconds to give keepAlive a chance to get started
-    val lease = client.leaseGrant(leaseTtlSecs.seconds)
-    val txn =
-      client.transaction {
-        If(path.doesNotExist)
-        Then(path.setTo(clientId, putOption { withLeaseId(lease.id) }))
+    // Participation is self-healing: if its lease expires (partition longer than
+    // the TTL), the healer re-grants it and re-registers this candidate, so the
+    // node stays visible in getParticipants() instead of silently disappearing.
+    val healer =
+      try {
+        client.selfHealingKeepAlive(
+          leaseTtlSecs.seconds,
+          resilience.lease,
+          leaseListener = { event -> onParticipationLeaseEvent(event) },
+        ) { lease ->
+          client.transaction {
+            If(path.doesNotExist)
+            Then(path.setTo(clientId, putOption { withLeaseId(lease.id) }))
+          }.isSucceeded
+        }
+      } catch (e: EtcdRecipeRuntimeException) {
+        // Initial CAS lost (the healer already revoked its lease).
+        logger.debug(e) { "Participation CAS lost for $path" }
+        throw EtcdRecipeException("Participation registration failed [$path]")
       }
 
-    if (!txn.isSucceeded) {
-      // Revoke the lease we just granted; otherwise it lingers in etcd until
-      // its TTL expires whenever registration loses the CAS.
-      client.leaseRevoke(lease)
-      throw EtcdRecipeException("Participation registration failed [$path]")
-    }
-
-    // Run keep-alive until closed, then revoke the participation lease promptly
+    // Run until closed; closing the healer revokes the participation lease promptly
     // (#7) so the participant key is evicted on relinquish instead of lingering
     // until TTL (which is what forces the pre-CAS wait loop above).
     try {
-      client.keepAliveWith(lease, { e -> exceptionList.value += e }) { terminateKeepAlive.waitUntilTrue() }
+      terminateKeepAlive.waitUntilTrue()
     } finally {
-      client.leaseRevoke(lease)
+      healer.close()
+    }
+  }
+
+  private fun onParticipationLeaseEvent(event: LeaseEvent) {
+    reportLeaseEvent(event)
+    when (event) {
+      is LeaseEvent.Suspended -> exceptionList.value += event.cause
+
+      is LeaseEvent.Expired -> exceptionList.value += (
+        event.cause ?: EtcdRecipeRuntimeException("Participation lease for $clientId expired; healing")
+      )
+
+      is LeaseEvent.Failed -> exceptionList.value += (
+        event.cause ?: EtcdRecipeRuntimeException("Participation lease healing for $clientId abandoned")
+      )
+
+      is LeaseEvent.Restored -> logger.info {
+        "Participation lease for $clientId healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+      }
     }
   }
 
@@ -426,21 +469,48 @@ constructor(
     // Phase 2 — hold leadership with NO lock held, so a close() on another thread
     // can run doClose() -> markLeadershipComplete() and release a takeLeadership
     // that is waiting on isFinished/waitUntilFinished. Exits when leadership is
-    // relinquished (takeLeadership returns).
+    // relinquished (takeLeadership returns) or the lease is lost (step-down).
+    //
+    // Leadership is intentionally NOT self-healed: an expired lease means etcd
+    // deleted the leader key and another candidate may already lead — reclaiming
+    // would race the new leader. A fatal keep-alive event (stream completed, or
+    // NOT_FOUND "requested lease not found") instead steps this leader down.
+    leadershipThreadRef.store(Thread.currentThread())
+    leadershipLeaseId.store(lease.id)
+    leaseLostDuringLeadership.store(false)
+    val registration = client.leaseClient.keepAlive(lease.id, leadershipKeepAliveObserver(lease.id))
     try {
-      client.keepAliveWith(lease, { e -> exceptionList.value += e }) {
+      var takeLeadershipError: Throwable? = null
+      try {
         listener.takeLeadership(this)
+      } catch (e: Throwable) {
+        if (!leaseLostDuringLeadership.load()) takeLeadershipError = e
       }
-      // Leadership was relinquished
-      listener.relinquishLeadership(this)
-      return true
+      // Clear a step-down interrupt that may have landed after (or instead of)
+      // unblocking takeLeadership, so cleanup below is not disrupted by it.
+      if (leaseLostDuringLeadership.load()) Thread.interrupted()
+
+      // Leadership is over (relinquished or stepped down): always notify, even when
+      // takeLeadership threw, so the listener can release its resources. (Pre-0.12
+      // a throw skipped relinquishLeadership.)
+      try {
+        listener.relinquishLeadership(this)
+      } catch (e: Throwable) {
+        logger.error(e) { "In relinquishLeadership()" }
+        exceptionList.value += e
+      }
+
+      takeLeadershipError?.let { throw it }
+      return !leaseLostDuringLeadership.load()
     } catch (e: Throwable) {
       logger.error(e) { "In attemptToBecomeLeader()" }
       exceptionList.value += e
       return false
     } finally {
+      registration.close()
       // Revoke the leadership lease promptly on relinquish (#7) instead of at TTL.
       client.leaseRevoke(lease)
+      leadershipThreadRef.store(null)
       // Reset the election guards under the same lock Phase 1 reads them, so a
       // concurrent candidate never observes a half-updated guard set.
       synchronized(electionLock) {
@@ -451,6 +521,44 @@ constructor(
       // Do this after leadership is complete so the thread does not terminate early
       markLeadershipComplete()
     }
+  }
+
+  // Discriminates leadership keep-alive stream events: fatal (stream completed =
+  // lease outlived its TTL unrenewed, or NOT_FOUND = lease gone) steps the leader
+  // down; anything else is transient — jetcd restarts the stream itself.
+  private fun leadershipKeepAliveObserver(leaseId: Long) =
+    Observers.builder<LeaseKeepAliveResponse>()
+      .onNext { next -> logger.debug { "Leadership keep-alive resp: $next" } }
+      .onError { e ->
+        if (e.isLeaseNotFound()) {
+          stepDownFromLeadership(e)
+        } else {
+          exceptionList.value += e
+          reportLeaseEvent(LeaseEvent.Suspended(leaseId, e))
+        }
+      }
+      .onCompleted { stepDownFromLeadership(null) }
+      .build()
+
+  // Ends leadership when the lease is gone: isLeader turns false immediately, the
+  // finished monitors are flipped so waitUntilFinished()/waitOnLeadershipComplete()
+  // release, and (when [interruptOnLeaseLoss]) the takeLeadership thread is
+  // interrupted in case it is parked in its own code where only an interrupt
+  // reaches it. Runs on jetcd's lease callback thread — no blocking work here.
+  // internal (not private) so step-down mechanics can be driven directly in tests.
+  internal fun stepDownFromLeadership(cause: Throwable?) {
+    if (!electedLeader.load()) return
+    if (!leaseLostDuringLeadership.compareAndSet(false, true)) return
+
+    logger.warn(cause) { "Leadership lease lost for $clientId; stepping down" }
+    exceptionList.value += (cause ?: EtcdRecipeRuntimeException("Leadership lease expired; stepping down"))
+    electedLeader.store(false)
+    reportLeaseEvent(LeaseEvent.Expired(leadershipLeaseId.load(), cause))
+
+    // Release monitor-parked holders first; then interrupt for user code parked
+    // elsewhere (sleep/IO). waitUntilFinished callers wake without an interrupt.
+    leadershipComplete.set(true)
+    if (interruptOnLeaseLoss) leadershipThreadRef.load()?.interrupt()
   }
 
   companion object {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
@@ -21,10 +21,16 @@ package io.etcd.recipes.keyvalue
 import io.etcd.jetcd.Client
 import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
-import io.etcd.recipes.common.asByteSequence
-import io.etcd.recipes.common.putValuesWithKeepAlive
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.LeaseListener
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.SelfHealingKeepAlive
+import io.etcd.recipes.common.putOption
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.selfHealingKeepAlive
 import io.etcd.recipes.keyvalue.TransientKeyValue.Companion.defaultClientId
 import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import java.util.concurrent.ExecutorService
@@ -62,10 +68,17 @@ constructor(
   autoStart: Boolean = true,
   private val userExecutor: Executor? = null,
   val clientId: String = defaultClientId(),
-) : EtcdConnector(client) {
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+) : EtcdConnector(client, resilience) {
   private val executor = userExecutor ?: Executors.newSingleThreadExecutor()
   private val keepAliveWaitLatch = CountDownLatch(1)
   private val keepAliveStartedLatch = CountDownLatch(1)
+  private val leaseListeners = CopyOnWriteArrayList<LeaseListener>()
+
+  /** Registers a listener for lease lifecycle events (expiry, healing, failure). */
+  fun addLeaseListener(listener: LeaseListener) {
+    leaseListeners += listener
+  }
 
   init {
     require(keyPath.isNotEmpty()) { "Key path cannot be empty" }
@@ -82,24 +95,29 @@ constructor(
     checkCloseNotCalled()
 
     executor.execute {
+      var healer: SelfHealingKeepAlive? = null
       try {
         val leaseTtl = leaseTtlSecs.seconds
         logger.debug { "$leaseTtl keep-alive started for $clientId $keyPath" }
-        client.putValuesWithKeepAlive(
-          listOf(keyPath to keyValue.asByteSequence),
+        // Self-healing: if the lease expires (partition longer than the TTL), the
+        // healer re-grants it and re-puts the key, instead of the key silently
+        // vanishing while this recipe still looks healthy.
+        healer = client.selfHealingKeepAlive(
           leaseTtl,
-          // Record a keep-alive death so a caller polling exceptions/hasExceptions
-          // sees the key is no longer being renewed, instead of it silently expiring.
-          onKeepAliveError = { e -> exceptionList.value += e },
-        ) {
-          keepAliveStartedLatch.countDown()
-          keepAliveWaitLatch.await()
-          logger.debug { "$leaseTtl keep-alive terminated for $clientId $keyPath" }
+          resilience.lease,
+          leaseListener = { event -> onLeaseEvent(event) },
+        ) { lease ->
+          client.putValue(keyPath, keyValue, putOption { withLeaseId(lease.id) })
+          true
         }
+        keepAliveStartedLatch.countDown()
+        keepAliveWaitLatch.await()
+        logger.debug { "$leaseTtl keep-alive terminated for $clientId $keyPath" }
       } catch (e: Throwable) {
         logger.error(e) { "In start()" }
         exceptionList.value += e
       } finally {
+        runCatching { healer?.close() }
         // Always release the start() caller, even on failure. The previous
         // version only counted down inside the keepAlive callback, so if the
         // initial put / lease grant threw, start() would block on
@@ -135,6 +153,41 @@ constructor(
     startThreadComplete.waitUntilTrue()
 
     if (userExecutor == null) (executor as ExecutorService).shutdown()
+  }
+
+  // Record every lease event on the exceptions list the way the old keep-alive
+  // error callback did (a caller polling exceptions must still see renewal
+  // trouble), drive connection state, and forward to user listeners.
+  @Suppress("TooGenericExceptionCaught")
+  private fun onLeaseEvent(event: LeaseEvent) {
+    reportLeaseEvent(event)
+    when (event) {
+      is LeaseEvent.Suspended -> {
+        exceptionList.value += event.cause
+      }
+
+      is LeaseEvent.Expired -> {
+        event.cause?.let { exceptionList.value += it }
+        ?: run { exceptionList.value += EtcdRecipeRuntimeException("Lease for $keyPath expired; healing") }
+      }
+
+      is LeaseEvent.Failed -> {
+        exceptionList.value += event.cause
+        ?: EtcdRecipeRuntimeException("Lease healing for $keyPath abandoned; key is gone")
+      }
+
+      is LeaseEvent.Restored -> {
+        logger.info { "Lease for $keyPath healed: ${event.oldLeaseId} -> ${event.newLeaseId}" }
+      }
+    }
+    leaseListeners.forEach { listener ->
+      try {
+        listener.onLeaseEvent(event)
+      } catch (e: Throwable) {
+        logger.error(e) { "Exception in lease listener" }
+        exceptionList.value += e
+      }
+    }
   }
 
   companion object {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -151,6 +151,7 @@ abstract class AbstractQueue(
     watchFailure: AtomicReference<Throwable?>,
   ): WatchRecoveryListener =
     WatchRecoveryListener { event ->
+      reportRecoveryEvent(event)
       when (event) {
         is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
           val children = client.getFirstChild(queuePath, target).kvs

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierLeaseHealTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierLeaseHealTests.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.barrier
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.getChildrenKeys
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.isKeyPresent
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives lease loss for real by revoking a barrier's lease out-of-band (etcd
+ * exposes every key's lease id), which is what a partition longer than the TTL
+ * produces. The lease-bound keys must be re-established by the self-healing
+ * keep-alive instead of silently vanishing.
+ */
+class BarrierLeaseHealTests : StringSpec() {
+  private val path = "/barrier/${javaClass.simpleName}"
+
+  private fun revokeLeaseOf(
+    client: io.etcd.jetcd.Client,
+    keyPath: String,
+  ) {
+    val leaseId = client.getResponse(keyPath).kvs.first().lease
+    (leaseId > 0L) shouldBe true
+    client.leaseClient.revoke(leaseId).get()
+  }
+
+  init {
+    "a set barrier re-arms after its lease is lost" {
+      connectToEtcd(urls) { client ->
+        val barrierPath = "$path/rearm"
+        DistributedBarrier(client, barrierPath).use { barrier ->
+          barrier.setBarrier() shouldBe true
+          barrier.isBarrierSet() shouldBe true
+
+          // Simulate lease expiry: the barrier key vanishes...
+          revokeLeaseOf(client, barrierPath)
+          pollUntil(10.seconds) { !client.isKeyPresent(barrierPath) } shouldBe true
+
+          // ...and the self-healing lease re-arms it for future waiters
+          pollUntil(20.seconds) { barrier.isBarrierSet() } shouldBe true
+
+          barrier.removeBarrier() shouldBe true
+          barrier.isBarrierSet() shouldBe false
+        }
+      }
+    }
+
+    "a counted-barrier waiter's key heals while the waiter is parked" {
+      connectToEtcd(urls) { client ->
+        val barrierPath = "$path/counted"
+        val waitingPath = "$barrierPath/waiting"
+        DistributedBarrierWithCount(client, barrierPath, memberCount = 2).use { barrier ->
+          val released = AtomicReference<Boolean?>()
+          val waiter = thread { released.set(barrier.waitOnBarrier(1.minutes)) }
+
+          pollUntil(20.seconds) { client.getChildrenKeys(waitingPath).size == 1 } shouldBe true
+          val waiterKey = client.getChildrenKeys(waitingPath).first()
+
+          revokeLeaseOf(client, waiterKey)
+          pollUntil(10.seconds) { !client.isKeyPresent(waiterKey) } shouldBe true
+
+          // The waiter's registration heals, so the barrier can still trip
+          pollUntil(20.seconds) { client.isKeyPresent(waiterKey) } shouldBe true
+
+          // Second member arrives; both released
+          DistributedBarrierWithCount(client, barrierPath, memberCount = 2).use { second ->
+            second.waitOnBarrier(1.minutes) shouldBe true
+          }
+          pollUntil(20.seconds) { released.get() == true } shouldBe true
+          waiter.join(5_000)
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ConnectionStateTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ConnectionStateTests.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.Client
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.mockk
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Unit tests for the connection-state machinery on [EtcdConnector]: recipes feed
+ * their watch-recovery and lease events into the protected report hooks, and the
+ * connector derives CONNECTED/SUSPENDED/RECONNECTED/LOST transitions for listeners.
+ * No etcd needed — the client is never touched.
+ */
+class ConnectionStateTests : StringSpec() {
+  private class TestConnector : EtcdConnector(mockk<Client>()) {
+    fun watchEvent(event: WatchRecoveryEvent) = reportRecoveryEvent(event)
+
+    fun leaseEvent(event: LeaseEvent) = reportLeaseEvent(event)
+  }
+
+  private val boom = RuntimeException("stream error")
+
+  init {
+    "initial state is CONNECTED" {
+      TestConnector().connectionState shouldBe ConnectionState.CONNECTED
+    }
+
+    "watch suspension and recovery drive SUSPENDED then RECONNECTED" {
+      val connector = TestConnector()
+      val transitions = CopyOnWriteArrayList<Pair<ConnectionState, ConnectionState>>()
+      connector.addConnectionStateListener { new, prev -> transitions += new to prev }
+
+      connector.watchEvent(WatchRecoveryEvent.Suspended("/k", boom))
+      connector.connectionState shouldBe ConnectionState.SUSPENDED
+
+      connector.watchEvent(WatchRecoveryEvent.Resubscribed("/k", 42))
+      connector.connectionState shouldBe ConnectionState.RECONNECTED
+
+      transitions shouldBe listOf(
+        ConnectionState.SUSPENDED to ConnectionState.CONNECTED,
+        ConnectionState.RECONNECTED to ConnectionState.SUSPENDED,
+      )
+    }
+
+    "lease expiry drives LOST and restoration drives RECONNECTED" {
+      val connector = TestConnector()
+      connector.leaseEvent(LeaseEvent.Expired(7L, null))
+      connector.connectionState shouldBe ConnectionState.LOST
+
+      connector.leaseEvent(LeaseEvent.Restored(7L, 8L))
+      connector.connectionState shouldBe ConnectionState.RECONNECTED
+    }
+
+    "abandoned recovery drives LOST" {
+      val connector = TestConnector()
+      connector.watchEvent(WatchRecoveryEvent.Failed("/k", boom))
+      connector.connectionState shouldBe ConnectionState.LOST
+    }
+
+    "repeated events do not re-notify" {
+      val connector = TestConnector()
+      val transitions = CopyOnWriteArrayList<ConnectionState>()
+      connector.addConnectionStateListener { new, _ -> transitions += new }
+
+      connector.watchEvent(WatchRecoveryEvent.Suspended("/k", boom))
+      connector.leaseEvent(LeaseEvent.Suspended(7L, boom))
+      connector.watchEvent(WatchRecoveryEvent.Suspended("/k2", boom))
+
+      transitions shouldBe listOf(ConnectionState.SUSPENDED)
+    }
+
+    "listener exceptions are recorded and do not block other listeners" {
+      val connector = TestConnector()
+      val seen = CopyOnWriteArrayList<ConnectionState>()
+      connector.addConnectionStateListener { _, _ -> throw IllegalStateException("listener bug") }
+      connector.addConnectionStateListener { new, _ -> seen += new }
+
+      connector.watchEvent(WatchRecoveryEvent.Suspended("/k", boom))
+
+      seen shouldBe listOf(ConnectionState.SUSPENDED)
+      connector.hasExceptions shouldBe true
+      connector.exceptions.first().shouldBeInstanceOf<IllegalStateException>()
+    }
+
+    "removed listeners stop receiving transitions" {
+      val connector = TestConnector()
+      val seen = CopyOnWriteArrayList<ConnectionState>()
+      val listener = ConnectionStateListener { new, _ -> seen += new }
+      connector.addConnectionStateListener(listener)
+      connector.watchEvent(WatchRecoveryEvent.Suspended("/k", boom))
+      connector.removeConnectionStateListener(listener)
+      connector.watchEvent(WatchRecoveryEvent.Resubscribed("/k", 1))
+
+      seen shouldBe listOf(ConnectionState.SUSPENDED)
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/SelfHealingKeepAliveTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/SelfHealingKeepAliveTests.kt
@@ -1,0 +1,222 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.Lease
+import io.etcd.jetcd.common.exception.ErrorCode
+import io.etcd.jetcd.common.exception.EtcdExceptionFactory
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
+import io.etcd.jetcd.support.CloseableClient
+import io.grpc.stub.StreamObserver
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Unit tests for [SelfHealingKeepAlive]. jetcd's [Lease] is mocked (in the style of
+ * [FailingLeaseMocks]) so tests can drive the captured keep-alive [StreamObserver]:
+ * jetcd reports lease expiry via `onCompleted` (deadline passed unrenewed) or
+ * `onError(NOT_FOUND "requested lease not found")`, and transient stream failures
+ * via other `onError`s — exactly what these tests simulate. No etcd needed.
+ */
+class SelfHealingKeepAliveTests : StringSpec() {
+  private class HealMocks {
+    val observers = CopyOnWriteArrayList<StreamObserver<LeaseKeepAliveResponse>>()
+    val registrations = CopyOnWriteArrayList<CloseableClient>()
+    private val nextId = AtomicLong(100)
+
+    /** Heal-path grant calls that should fail before one succeeds. */
+    val grantFailures = AtomicInteger(0)
+
+    private fun granted(): CompletableFuture<LeaseGrantResponse> {
+      val id = nextId.getAndIncrement()
+      return CompletableFuture.completedFuture(mockk<LeaseGrantResponse> { every { this@mockk.id } returns id })
+    }
+
+    val lease: Lease =
+      mockk {
+        every { grant(any()) } answers { granted() }
+        every { grant(any(), any(), any()) } answers {
+          if (grantFailures.getAndDecrement() > 0) {
+            CompletableFuture.failedFuture(IllegalStateException("grant refused"))
+          } else {
+            granted()
+          }
+        }
+        every { keepAlive(any(), any()) } answers {
+          observers += secondArg<StreamObserver<LeaseKeepAliveResponse>>()
+          mockk<CloseableClient>(relaxed = true).also { registrations += it }
+        }
+        every { revoke(any()) } returns CompletableFuture.completedFuture(mockk())
+      }
+
+    val client: Client = mockk { every { leaseClient } returns lease }
+  }
+
+  private fun quickHeals() = LeaseResilience(RetryPolicy.bounded(maxAttempts = 5, delay = 10.milliseconds))
+
+  private fun leaseNotFound() =
+    EtcdExceptionFactory.newEtcdException(ErrorCode.NOT_FOUND, "etcdserver: requested lease not found")
+
+  init {
+    "re-grants and re-establishes after keep-alive completion" {
+      val mocks = HealMocks()
+      val events = CopyOnWriteArrayList<LeaseEvent>()
+      val establishedIds = CopyOnWriteArrayList<Long>()
+      mocks.client.selfHealingKeepAlive(2.seconds, quickHeals(), { events += it }) { lease ->
+        establishedIds += lease.id
+        true
+      }.use { healer ->
+        healer.currentLeaseId shouldBe 100L
+        healer.isHealthy shouldBe true
+
+        // jetcd's DeadLine service fires onCompleted when the lease outlives its TTL unrenewed
+        mocks.observers.first().onCompleted()
+
+        pollUntil(10.seconds) { events.any { it is LeaseEvent.Restored } } shouldBe true
+        establishedIds shouldBe listOf(100L, 101L)
+        healer.currentLeaseId shouldBe 101L
+        healer.isHealthy shouldBe true
+        mocks.registrations.size shouldBe 2
+
+        val expired = events.filterIsInstance<LeaseEvent.Expired>().first()
+        expired.leaseId shouldBe 100L
+        val restored = events.filterIsInstance<LeaseEvent.Restored>().first()
+        restored.oldLeaseId shouldBe 100L
+        restored.newLeaseId shouldBe 101L
+      }
+    }
+
+    "NOT_FOUND stream error heals like an expiry" {
+      val mocks = HealMocks()
+      val events = CopyOnWriteArrayList<LeaseEvent>()
+
+      mocks.client.selfHealingKeepAlive(2.seconds, quickHeals(), { events += it }) { true }
+        .use { healer ->
+          mocks.observers.first().onError(leaseNotFound())
+          pollUntil(10.seconds) { events.any { it is LeaseEvent.Restored } } shouldBe true
+          healer.currentLeaseId shouldBe 101L
+        }
+    }
+
+    "transient stream errors report Suspended without healing" {
+      val mocks = HealMocks()
+      val events = CopyOnWriteArrayList<LeaseEvent>()
+
+      mocks.client.selfHealingKeepAlive(2.seconds, quickHeals(), { events += it }) { true }
+        .use { healer ->
+          mocks.observers.first().onError(IllegalStateException("connection reset"))
+          pollUntil(5.seconds) { events.any { it is LeaseEvent.Suspended } } shouldBe true
+          Thread.sleep(100)
+          events.none { it is LeaseEvent.Expired } shouldBe true
+          healer.currentLeaseId shouldBe 100L // no re-grant
+          mocks.registrations.size shouldBe 1
+        }
+    }
+
+    "establish returning false on heal emits Failed and stops" {
+      val mocks = HealMocks()
+      val events = CopyOnWriteArrayList<LeaseEvent>()
+      val calls = AtomicInteger(0)
+
+      mocks.client.selfHealingKeepAlive(2.seconds, quickHeals(), { events += it }) {
+        calls.incrementAndGet() == 1 // initial establish succeeds; heals decline
+      }.use { healer ->
+        mocks.observers.first().onCompleted()
+        pollUntil(10.seconds) { events.any { it is LeaseEvent.Failed } } shouldBe true
+        Thread.sleep(100)
+        events.none { it is LeaseEvent.Restored } shouldBe true
+        healer.isHealthy shouldBe false
+      }
+    }
+
+    "heal attempts retry grant failures under the policy" {
+      val mocks = HealMocks()
+      val events = CopyOnWriteArrayList<LeaseEvent>()
+      mocks.grantFailures.set(2)
+
+      mocks.client.selfHealingKeepAlive(2.seconds, quickHeals(), { events += it }) { true }
+        .use { healer ->
+          mocks.observers.first().onCompleted()
+          pollUntil(10.seconds) { events.any { it is LeaseEvent.Restored } } shouldBe true
+          healer.currentLeaseId shouldBe 101L
+        }
+    }
+
+    "policy exhaustion emits Failed" {
+      val mocks = HealMocks()
+      val events = CopyOnWriteArrayList<LeaseEvent>()
+      mocks.grantFailures.set(Int.MAX_VALUE)
+      val resilience = LeaseResilience(RetryPolicy.bounded(maxAttempts = 2, delay = 10.milliseconds))
+
+      mocks.client.selfHealingKeepAlive(2.seconds, resilience, { events += it }) { true }
+        .use {
+          mocks.observers.first().onCompleted()
+          pollUntil(10.seconds) { events.any { it is LeaseEvent.Failed } } shouldBe true
+          events.none { it is LeaseEvent.Restored } shouldBe true
+        }
+    }
+
+    "close during healing cancels further attempts" {
+      val mocks = HealMocks()
+      val events = CopyOnWriteArrayList<LeaseEvent>()
+      mocks.grantFailures.set(Int.MAX_VALUE)
+      val resilience = LeaseResilience(RetryPolicy.bounded(maxAttempts = 1000, delay = 20.milliseconds))
+
+      val healer = mocks.client.selfHealingKeepAlive(2.seconds, resilience, { events += it }) { true }
+      mocks.observers.first().onCompleted()
+      pollUntil(5.seconds) { events.any { it is LeaseEvent.Expired } } shouldBe true
+      healer.close()
+
+      Thread.sleep(200)
+      val grantsAtClose = mocks.grantFailures.get()
+      Thread.sleep(300)
+      // grantFailures decrements once per heal-grant attempt; no movement = no attempts
+      (mocks.grantFailures.get() >= grantsAtClose - 1) shouldBe true
+      events.none { it is LeaseEvent.Restored } shouldBe true
+    }
+
+    "initial establish returning false aborts and revokes the lease" {
+      val mocks = HealMocks()
+
+      shouldThrow<EtcdRecipeRuntimeException> {
+        mocks.client.selfHealingKeepAlive(2.seconds, quickHeals(), null) { false }
+      }
+      verify { mocks.lease.revoke(100L) }
+    }
+
+    "close revokes the current lease best-effort" {
+      val mocks = HealMocks()
+      mocks.client.selfHealingKeepAlive(2.seconds, quickHeals(), null) { true }.close()
+      verify { mocks.lease.revoke(100L) }
+      verify { mocks.registrations.first().close() }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/design/BugFixesTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/design/BugFixesTests.kt
@@ -186,7 +186,13 @@ class BugFixesTests : StringSpec() {
 
     "fix #5: DistributedBarrier source revokes the lease when CAS fails" {
       val src = readSource("src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt")
-      src.contains("client.leaseRevoke(lease)") shouldBe true
+      // Since 0.12 the barrier lease is owned by selfHealingKeepAlive, whose
+      // establish-declined path revokes the lease it granted — the leak-on-failed-CAS
+      // fix lives there now (see SelfHealingKeepAliveTests "initial establish
+      // returning false aborts and revokes the lease"). The barrier source must keep
+      // routing lease ownership through it rather than hand-rolling grant/keepAlive.
+      src.contains("selfHealingKeepAlive(") shouldBe true
+      src.contains("leaseClient.grant") shouldBe false
     }
 
     "fix #5: losing setBarrier returns false cleanly and the winner remains active" {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceInstanceJsonTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceInstanceJsonTests.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.discovery
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+/**
+ * Guards the ServiceInstance wire format against a subtle round-trip corruption:
+ * registrationTimeUTC's default is `Instant.now()`, so with encodeDefaults=false
+ * kotlinx-serialization OMITS the field whenever serialization runs in the same
+ * clock millisecond as construction — and a later parse then back-fills a fresh
+ * (different) timestamp. Every field must round-trip byte-identically no matter
+ * when toJson() is called relative to construction.
+ */
+class ServiceInstanceJsonTests : StringSpec() {
+  init {
+    "toJson always encodes registrationTimeUTC" {
+      // Tight loop: construction and serialization land in the same millisecond
+      // on almost every iteration, which is exactly the case that used to omit
+      // the field.
+      repeat(1_000) {
+        val instance = ServiceInstance("svc", "payload")
+        instance.toJson() shouldContain "\"registrationTimeUTC\""
+      }
+    }
+
+    "instances round-trip identically regardless of serialization timing" {
+      repeat(1_000) {
+        val instance = ServiceInstance("svc", "payload")
+        ServiceInstance.toObject(instance.toJson()) shouldBe instance
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceRegistryHealTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceRegistryHealTests.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.discovery
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.Lease
+import io.etcd.jetcd.Txn
+import io.etcd.jetcd.kv.DeleteResponse
+import io.etcd.jetcd.kv.TxnResponse
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
+import io.etcd.jetcd.support.CloseableClient
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.pollUntil
+import io.grpc.stub.StreamObserver
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives [ServiceRegistry] through a lease expiry with a mocked jetcd [Client]:
+ * the instance key must be re-registered (CAS re-put) under a freshly granted
+ * lease, so discovery recovers automatically after a partition longer than the
+ * TTL.
+ */
+class ServiceRegistryHealTests : StringSpec() {
+  private class RegistryHealMocks {
+    val observers = CopyOnWriteArrayList<StreamObserver<LeaseKeepAliveResponse>>()
+    val txnCount = AtomicInteger(0)
+    private val nextId = AtomicLong(100)
+
+    val client: Client =
+      mockk {
+        every { leaseClient } returns
+          mockk<Lease> {
+            every { grant(any()) } answers {
+              CompletableFuture.completedFuture(
+                mockk<LeaseGrantResponse> { every { id } returns nextId.getAndIncrement() },
+              )
+            }
+            every { grant(any(), any(), any()) } answers {
+              CompletableFuture.completedFuture(
+                mockk<LeaseGrantResponse> { every { id } returns nextId.getAndIncrement() },
+              )
+            }
+            every { keepAlive(any(), any()) } answers {
+              observers += secondArg<StreamObserver<LeaseKeepAliveResponse>>()
+              mockk<CloseableClient>(relaxed = true)
+            }
+            every { revoke(any()) } returns CompletableFuture.completedFuture(mockk())
+          }
+        every { kvClient } returns
+          mockk<KV> {
+            every { txn() } answers {
+              txnCount.incrementAndGet()
+              mockk<Txn> {
+                every { If(*anyVararg()) } returns this
+                every { Then(*anyVararg()) } returns this
+                every { commit() } returns
+                  CompletableFuture.completedFuture(mockk<TxnResponse> { every { isSucceeded } returns true })
+              }
+            }
+            every { delete(any()) } returns CompletableFuture.completedFuture(mockk<DeleteResponse>())
+          }
+      }
+  }
+
+  init {
+    "expired instance lease is re-granted and the instance re-registered" {
+      val mocks = RegistryHealMocks()
+      val events = CopyOnWriteArrayList<LeaseEvent>()
+      val service = ServiceInstance("svc", "payload")
+
+      ServiceRegistry(mocks.client, "/registry/heal").use { registry ->
+        registry.addLeaseListener { events += it }
+        registry.registerService(service)
+        mocks.txnCount.get() shouldBe 1 // initial CAS registration
+
+        // jetcd's DeadLine service fires onCompleted when the lease expires unrenewed
+        mocks.observers.first().onCompleted()
+
+        pollUntil(10.seconds) { events.any { it is LeaseEvent.Restored } } shouldBe true
+        mocks.txnCount.get() shouldBe 2 // re-registration CAS under the healed lease
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderStepDownTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderStepDownTests.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.election
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.isKeyPresent
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives lease loss for real by revoking a recipe's lease out-of-band: etcd exposes
+ * every key's lease id ([io.etcd.jetcd.KeyValue.getLease]), and revoking it kills
+ * the keep-alive stream with NOT_FOUND — exactly what a partition longer than the
+ * TTL produces, without needing a container pause.
+ *
+ * Split-brain regression: before step-down, a leader whose lease vanished kept
+ * reporting isLeader=true while another candidate took over.
+ */
+class LeaderStepDownTests : StringSpec() {
+  private val path = "/election/${javaClass.simpleName}"
+
+  private fun revokeLeaseOf(
+    client: io.etcd.jetcd.Client,
+    keyPath: String,
+  ) {
+    val leaseId = client.getResponse(keyPath).kvs.first().lease
+    (leaseId > 0L) shouldBe true
+    client.leaseClient.revoke(leaseId).get()
+  }
+
+  init {
+    "leader steps down when its leadership lease is lost" {
+      connectToEtcd(urls) { client ->
+        val electionPath = "$path/stepdown"
+        val relinquishCount = AtomicInteger(0)
+        val bLeaderships = AtomicInteger(0)
+        val aElected = BooleanMonitor(false)
+
+        val selectorA =
+          LeaderSelector(
+            client,
+            electionPath,
+            takeLeadershipBlock = { selector ->
+              aElected.set(true)
+              // Parks on the finished monitor: step-down must release it.
+              selector.waitUntilFinished()
+            },
+            relinquishLeadershipBlock = { relinquishCount.incrementAndGet() },
+          )
+        val selectorB =
+          LeaderSelector(
+            client,
+            electionPath,
+            takeLeadershipBlock = { bLeaderships.incrementAndGet() },
+          )
+
+        selectorA.use { a ->
+          selectorB.use { b ->
+            a.start()
+            aElected.waitUntilTrue(20.seconds) shouldBe true
+            b.start()
+
+            // Simulate lease expiry: revoke the leadership lease out-of-band
+            revokeLeaseOf(client, "$electionPath/LEADER")
+
+            pollUntil(20.seconds) { !a.isLeader } shouldBe true
+            a.waitOnLeadershipComplete(20.seconds) shouldBe true
+            pollUntil(10.seconds) { relinquishCount.get() == 1 } shouldBe true
+
+            // The other candidate takes over (no split brain: A already stepped down)
+            pollUntil(20.seconds) { bLeaderships.get() == 1 } shouldBe true
+            b.waitOnLeadershipComplete(20.seconds) shouldBe true
+          }
+        }
+      }
+    }
+
+    "step-down interrupts a takeLeadership parked in its own code" {
+      connectToEtcd(urls) { client ->
+        val electionPath = "$path/interrupt"
+        val aElected = BooleanMonitor(false)
+        val interrupted = BooleanMonitor(false)
+
+        LeaderSelector(
+          client,
+          electionPath,
+          takeLeadershipBlock = { _ ->
+            aElected.set(true)
+            try {
+              Thread.sleep(300_000) // user code parked where only an interrupt reaches it
+            } catch (e: InterruptedException) {
+              interrupted.set(true)
+            }
+          },
+        ).use { a ->
+          a.start()
+          aElected.waitUntilTrue(20.seconds) shouldBe true
+
+          revokeLeaseOf(client, "$electionPath/LEADER")
+
+          pollUntil(20.seconds) { !a.isLeader } shouldBe true
+          a.waitOnLeadershipComplete(20.seconds) shouldBe true
+          interrupted.waitUntilTrue(10.seconds) shouldBe true
+        }
+      }
+    }
+
+    "participation key heals after its lease is lost" {
+      connectToEtcd(urls) { client ->
+        val electionPath = "$path/participation"
+        val holdLeadership = BooleanMonitor(false)
+
+        LeaderSelector(
+          client,
+          electionPath,
+          takeLeadershipBlock = { _ -> holdLeadership.waitUntilTrue() },
+          clientId = "healing-participant",
+        ).use { selector ->
+          selector.start()
+          val participationPath = "$electionPath/participants/healing-participant"
+          pollUntil(20.seconds) { client.isKeyPresent(participationPath) } shouldBe true
+
+          // Simulate lease expiry for the participation key only
+          revokeLeaseOf(client, participationPath)
+          pollUntil(10.seconds) { !client.isKeyPresent(participationPath) } shouldBe true
+
+          // The self-healing participation lease re-registers the key
+          pollUntil(20.seconds) { client.isKeyPresent(participationPath) } shouldBe true
+
+          holdLeadership.set(true)
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/SelfHealingLeaseFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/SelfHealingLeaseFaultTests.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import io.etcd.recipes.common.ConnectionState
+import io.etcd.recipes.common.EtcdTestContainer
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.isKeyPresent
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.keyvalue.TransientKeyValue
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives real TTL expiry: pausing the etcd container freezes renewals until the
+ * client-side lease deadline fires (jetcd's DeadLine service → onCompleted) — the
+ * genuine partition-longer-than-TTL path, complementing the out-of-band revoke
+ * tests which exercise the NOT_FOUND path.
+ */
+class SelfHealingLeaseFaultTests : StringSpec() {
+  private val path = "/fault/${javaClass.simpleName}"
+
+  init {
+    "TransientKeyValue key reappears after a partition longer than the TTL" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        val keyPath = "$path/tkv"
+        val events = CopyOnWriteArrayList<LeaseEvent>()
+
+        TransientKeyValue(client, keyPath, "value", leaseTtlSecs = 2, autoStart = false).use { tkv ->
+          tkv.addLeaseListener { events += it }
+          tkv.start()
+          pollUntil(10.seconds) { client.isKeyPresent(keyPath) } shouldBe true
+
+          EtcdTestContainer.pause()
+          try {
+            Thread.sleep(7_000) // well past the 2s TTL: lease expires server-side too
+          } finally {
+            EtcdTestContainer.unpause()
+          }
+          EtcdTestContainer.awaitReady()
+
+          pollUntil(60.seconds) { events.any { it is LeaseEvent.Expired } } shouldBe true
+          pollUntil(60.seconds) { events.any { it is LeaseEvent.Restored } } shouldBe true
+          pollUntil(30.seconds) { client.isKeyPresent(keyPath) } shouldBe true
+          tkv.connectionState shouldBe ConnectionState.RECONNECTED
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueHealTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueHealTests.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.keyvalue
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.Lease
+import io.etcd.jetcd.kv.PutResponse
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
+import io.etcd.jetcd.options.PutOption
+import io.etcd.jetcd.support.CloseableClient
+import io.etcd.recipes.common.ConnectionState
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.pollUntil
+import io.grpc.stub.StreamObserver
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives [TransientKeyValue] through a lease expiry with a mocked jetcd [Client]:
+ * the key must be re-put under a freshly granted lease (self-healing), the lease
+ * events must be observable, and the connector's connection state must go
+ * LOST -> RECONNECTED. jetcd reports expiry via the keep-alive observer's
+ * onCompleted, which is what the test drives.
+ */
+class TransientKeyValueHealTests : StringSpec() {
+  private class KvHealMocks {
+    val observers = CopyOnWriteArrayList<StreamObserver<LeaseKeepAliveResponse>>()
+    val putLeaseIds = CopyOnWriteArrayList<Long>()
+    private val nextId = AtomicLong(100)
+
+    val client: Client =
+      mockk {
+        every { leaseClient } returns
+          mockk<Lease> {
+            every { grant(any()) } answers {
+              CompletableFuture.completedFuture(
+                mockk<LeaseGrantResponse> {
+                  every { id } returns nextId.getAndIncrement()
+                },
+              )
+            }
+            every { grant(any(), any(), any()) } answers {
+              CompletableFuture.completedFuture(
+                mockk<LeaseGrantResponse> {
+                  every { id } returns nextId.getAndIncrement()
+                },
+              )
+            }
+            every { keepAlive(any(), any()) } answers {
+              observers += secondArg<StreamObserver<LeaseKeepAliveResponse>>()
+              mockk<CloseableClient>(relaxed = true)
+            }
+            every { revoke(any()) } returns CompletableFuture.completedFuture(mockk())
+          }
+        every { kvClient } returns
+          mockk<KV> {
+            every { put(any<ByteSequence>(), any<ByteSequence>(), any<PutOption>()) } answers {
+              putLeaseIds += thirdArg<PutOption>().leaseId
+              CompletableFuture.completedFuture(mockk<PutResponse>())
+            }
+          }
+      }
+  }
+
+  init {
+    "expired lease is re-granted and the key re-put under the new lease" {
+      val mocks = KvHealMocks()
+      val events = CopyOnWriteArrayList<LeaseEvent>()
+
+      TransientKeyValue(mocks.client, "/tkv/heal", "value", autoStart = false).use { tkv ->
+        tkv.addLeaseListener { events += it }
+        tkv.start()
+
+        mocks.putLeaseIds shouldBe listOf(100L)
+
+        // jetcd's DeadLine service fires onCompleted when the lease expires unrenewed
+        mocks.observers.first().onCompleted()
+
+        pollUntil(10.seconds) { events.any { it is LeaseEvent.Restored } } shouldBe true
+        mocks.putLeaseIds shouldBe listOf(100L, 101L)
+        tkv.connectionState shouldBe ConnectionState.RECONNECTED
+        tkv.hasExceptions shouldBe true // the expiry itself is still recorded
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueKeepAliveErrorTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueKeepAliveErrorTests.kt
@@ -26,6 +26,7 @@ import io.etcd.jetcd.lease.LeaseGrantResponse
 import io.etcd.jetcd.lease.LeaseKeepAliveResponse
 import io.etcd.jetcd.lease.LeaseRevokeResponse
 import io.etcd.jetcd.support.CloseableClient
+import io.etcd.recipes.common.pollUntil
 import io.grpc.stub.StreamObserver
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContain
@@ -34,6 +35,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.seconds
 
 class TransientKeyValueKeepAliveErrorTests : StringSpec() {
     init {
@@ -68,7 +70,9 @@ class TransientKeyValueKeepAliveErrorTests : StringSpec() {
             val boom = RuntimeException("keep-alive stream died")
             observerSlot.captured.onError(boom)
 
-            tkv.hasExceptions shouldBe true
+            // Lease events are dispatched on the healer thread (off jetcd's callback
+            // thread), so the recording is asynchronous.
+            pollUntil(10.seconds) { tkv.hasExceptions } shouldBe true
             tkv.exceptions shouldContain boom
 
             tkv.close()


### PR DESCRIPTION
Part 2 of product idea #3 (connection resilience), **stacked on #51** (base branch `0.12.0`) — merge #51 first.

## Problem

A partition longer than the lease TTL permanently destroyed recipe state: `TransientKeyValue` keys, `ServiceRegistry` instances, and barrier keys expired with their leases and were never re-established; keep-alive failures landed only on the pull-only `exceptions` list. Worst of all, a leader whose lease expired kept reporting `isLeader=true` while another candidate took over — a **split-brain window**.

## Changes

- **`Client.selfHealingKeepAlive(ttl, resilience, listener) { lease -> ... }`** — grants a lease, establishes the caller's keys, and on expiry (jetcd `onCompleted` = TTL passed unrenewed, or `NOT_FOUND "requested lease not found"`) re-grants and re-runs the establish hook, paced by `LeaseResilience`/`RetryPolicy`. Transient stream errors report `LeaseEvent.Suspended` only — jetcd restarts the stream itself. Observable via `LeaseListener` (`Suspended`/`Expired`/`Restored`/`Failed`).
- **Recipe adoption, ON by default** (`ResilienceConfig.DISABLED` opts out): `TransientKeyValue` re-puts its key; `ServiceRegistry` re-registers instances (CAS — unique ids make reclaim safe; `updateService` tracks the healed lease id); `DistributedBarrier` re-arms for future waiters; a parked `DistributedBarrierWithCount` waiter re-registers; `LeaderSelector` re-advertises candidacy.
- **`LeaderSelector` steps down on leadership-lease loss** (never heals it — another node may already lead): `isLeader` turns false immediately, `waitUntilFinished()` releases, the `takeLeadership` thread is interrupted if parked in user code (new `interruptOnLeaseLoss` param, default true), and `relinquishLeadership` now always runs once leadership was taken (previously skipped on throw).
- **Connection state on `EtcdConnector`**: `CONNECTED`/`SUSPENDED`/`RECONNECTED`/`LOST` derived passively from each recipe's own watch + lease events; `addConnectionStateListener`.
- **Latent `ServiceInstance` wire-format fix**: `registrationTimeUTC` (dynamic default + `encodeDefaults=false`) was omitted from JSON whenever serialization ran in the same clock millisecond as construction, so a later parse back-filled a different timestamp. The wire format now always encodes defaults (old JSON still parses). Found when a threaded discovery test caught a 45 ms round-trip drift.

## Testing

- 23 new tests: MockK unit suites (`SelfHealingKeepAliveTests` — 9 scenarios including establish-decline, policy exhaustion, close-during-heal; `ConnectionStateTests`; per-recipe heal suites), plus real-etcd integration tests that drive lease loss **deterministically by revoking a key's lease out-of-band** (`KeyValue.getLease`) — the NOT_FOUND path — and a container-pause-beyond-TTL fault test — the `onCompleted` deadline path.
- Split-brain regression test: two candidates, leadership lease revoked → old leader steps down (relinquish exactly once, `waitUnitFinished` released, interrupt delivered to parked user code) and the second candidate takes over.
- `make lint` clean; `make tests-tc` full check: **211 tests, 0 failures**.
- `BugFixesTests` fix #5 source assertion updated in lockstep: the leak-on-failed-CAS revoke now lives inside `selfHealingKeepAlive` (covered by its unit test).

## Follow-up (final phase of idea #3)

- PR 3: RPC retry + operation timeouts, resilient client defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP