### PR TITLE
Add bounded and non-blocking queue consumption: poll, tryDequeue, enqueueAll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Connection-resilience release: watchers survive fatal stream deaths (part 1),
 leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
-gain timeouts and retries (part 3).
+gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
+non-blocking consumption on the existing queues.
+
+### Added (queues: bounded and non-blocking consumption)
+
+- `tryDequeue(): ByteSequence?` (non-blocking) and `poll(timeout): ByteSequence?`
+  (bounded, Duration and Long/TimeUnit overloads) on `DistributedQueue` and
+  `DistributedPriorityQueue` — removes the "the only take blocks forever" footgun.
+  `dequeue()` is unchanged: it is now the unbounded case of the same internal loop.
+- `DistributedQueue.enqueueAll(values)` — atomic batch enqueue in one transaction;
+  entries share the transaction's revision and keys embed the argument index so
+  within-batch order follows argument order.
 
 ### Added (part 3: RPC timeouts/retries, client defaults)
 

--- a/docs/superpowers/specs/2026-07-11-reliable-queues-design.md
+++ b/docs/superpowers/specs/2026-07-11-reliable-queues-design.md
@@ -1,0 +1,58 @@
+# Reliable Queue Semantics — Design (product idea #4)
+
+Approved 2026-07-11. Three sequential PRs, each merged before the next starts.
+
+## PR A — poll / tryDequeue / batch enqueue (existing queues)
+
+- `tryDequeue(): ByteSequence?` — non-blocking CAS-take of the head, null when empty.
+- `poll(timeout): ByteSequence?` (Duration + Long/TimeUnit overloads) — bounded wait,
+  null on timeout. `dequeue()` becomes the wait-forever case of the same internal
+  loop; its signature and the DesignFixesTests source invariants (`dequeue()` exactly
+  once, `while (true)` present) are preserved.
+- `enqueueAll(values)` on `DistributedQueue` — one transaction; entries share a
+  revision and preserve argument order. Priority queue excluded (per-item CAS
+  sequencing makes batched slots a poor fit).
+
+## PR B — DistributedWorkQueue (at-least-once, DLQ)
+
+New recipe; existing queues keep at-most-once semantics untouched. Payloads are
+never bound to the consumer's lease — only the claim marker is:
+
+| Key | Content | Leased |
+|---|---|---|
+| `items/<k>` | pending payload (time-ordered key) | no |
+| `claimed/<k>` | in-flight payload copy | no (survives crashes) |
+| `claims/<k>` | consumer id | yes — TTL = visibility timeout |
+| `attempts/<k>` | delivery count | no |
+| `dlq/<k>` | dead-lettered payload | no |
+
+- `receive()` claims the head atomically (txn guarded on `items/<k>` mod-revision):
+  delete item, copy to `claimed`, put leased `claims` marker, bump `attempts`.
+  Returns `WorkItem(value, id, attempt)` with `ack()` (txn-deletes all three keys,
+  guarded on the claim still being ours; returns false if the claim was lost — the
+  documented at-least-once window) and `requeue()` (early nack, attempts kept).
+- Consumer crash ⇒ lease expiry ⇒ `claims/<k>` vanishes, `claimed/<k>` survives.
+  Consumer-driven reclaim (no elected janitor): every consumer sweeps on
+  empty-queue waits plus a jittered interval; orphans CAS-move back to `items/<k>`
+  (same key ⇒ original FIFO position) or to `dlq/<k>` once `attempts >= maxDeliveries`.
+- One plain (deliberately NOT self-healing) lease per consumer instance — expiry
+  must release claims. After lease loss the instance grants a fresh lease for
+  future claims and surfaces the event via lease listeners / connection state.
+- `WorkQueueConfig(visibilityTimeoutSecs, maxDeliveries, sweepInterval)`; DLQ
+  inspection/requeue/purge. Empty-queue wait reuses the resilient-watcher pattern
+  via a helper shared with `AbstractQueue`.
+
+## PR C — delayed delivery (on the work queue)
+
+- `enqueue(value, delay)` writes `delayed/<readyTimestampMillis>-<uniq>`.
+- Sweeps and empty-queue waits promote matured items into `items/` via CAS (one
+  winner); waits sleep no longer than the head's maturity. Client-clock skew is
+  documented; tolerable at visibility-timeout scale. No standalone delay queue.
+
+## Decisions (user-approved)
+
+- Three sequential PRs; consumer-driven reclaim; batch enqueue only.
+- Testing: TDD; MockK unit suites for claim/ack/reclaim/DLQ transitions; real-etcd
+  tests using out-of-band lease revocation to simulate consumer crashes; fault
+  tests (pause > visibility timeout, restart mid-receive). README/CHANGELOG/
+  examples per phase; `make lint` + full `make tests-tc` gate per PR.

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -18,6 +18,7 @@
 
 package io.etcd.recipes.queue
 
+import com.pambrose.common.time.timeUnitToDuration
 import io.etcd.jetcd.ByteSequence
 import io.etcd.jetcd.Client
 import io.etcd.jetcd.KeyValue
@@ -37,7 +38,11 @@ import io.etcd.recipes.common.watchOption
 import io.etcd.recipes.common.withWatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.ComparableTimeMark
+import kotlin.time.Duration
+import kotlin.time.TimeSource
 
 abstract class AbstractQueue(
   client: Client,
@@ -49,13 +54,39 @@ abstract class AbstractQueue(
     require(queuePath.isNotEmpty()) { "Queue path cannot be empty" }
   }
 
-  @Suppress("LoopWithTooManyJumpStatements")
-  fun dequeue(): ByteSequence {
+  fun dequeue(): ByteSequence = checkNotNull(takeWithDeadline(null)) { "unbounded take returned empty" }
+
+  /** Non-blocking take: the head item, or null when the queue is empty. */
+  fun tryDequeue(): ByteSequence? {
+    checkCloseNotCalled()
+    while (true) {
+      val childList = client.getFirstChild(queuePath, target, resilience.rpc).kvs
+      if (childList.isEmpty()) return null
+      val child = childList.first()
+      if (deleteRevKey(child)) return child.value
+      // CAS lost to a concurrent consumer; retry until a win or the queue drains
+    }
+  }
+
+  /** Bounded take: the head item, or null once [timeout] elapses without one. */
+  fun poll(timeout: Duration): ByteSequence? {
+    require(timeout > Duration.ZERO) { "Timeout must be positive: $timeout" }
+    return takeWithDeadline(TimeSource.Monotonic.markNow() + timeout)
+  }
+
+  fun poll(
+    timeout: Long,
+    timeUnit: TimeUnit,
+  ): ByteSequence? = poll(timeUnitToDuration(timeout, timeUnit))
+
+  // The single consumption loop: a null [deadline] never expires (the unbounded
+  // take), otherwise the wait is bounded and an expired deadline yields null.
+  @Suppress("LoopWithTooManyJumpStatements", "ReturnCount")
+  private fun takeWithDeadline(deadline: ComparableTimeMark?): ByteSequence? {
     checkCloseNotCalled()
 
-    // Loop instead of recursing on CAS-conflict retries: the previous
-    // implementation called itself recursively, and each recursive frame
-    // could allocate a new watcher (with its own dispatcher executor).
+    // Loop instead of recursing on CAS-conflict retries: a recursive frame per
+    // retry could allocate a new watcher (with its own dispatcher executor).
     // Under high contention the resulting churn was unbounded.
     while (true) {
       val childList = client.getFirstChild(queuePath, target, resilience.rpc).kvs
@@ -68,15 +99,17 @@ abstract class AbstractQueue(
         continue
       }
 
+      if (deadline != null && deadline.hasPassedNow()) return null
+
       // Queue is empty; wait under a single watcher. If the CAS delete fails
       // after waking up, loop and retry — withWatcher closes its dispatcher
       // before we retry, so no executor or watcher resources accumulate.
-      val winner = waitForFirstChild() ?: continue
+      val winner = waitForFirstChild(deadline) ?: continue
       if (deleteRevKey(winner)) return winner.value
     }
   }
 
-  private fun waitForFirstChild(): KeyValue? {
+  private fun waitForFirstChild(deadline: ComparableTimeMark? = null): KeyValue? {
     val watchLatch = CountDownLatch(1)
     val watchOption =
       watchOption {
@@ -120,7 +153,14 @@ abstract class AbstractQueue(
           }
         }
       }
-      watchLatch.await()
+      if (deadline == null) {
+        watchLatch.await()
+      } else {
+        val remaining = -deadline.elapsedNow() // negative elapsed = time still left
+        if (remaining > Duration.ZERO) {
+          watchLatch.await(remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        }
+      }
 
       // STRICT ORDERING: whichever PUT the watcher observed first (in keyFound) is not
       // necessarily the head by sort order — a lower-priority key can be committed just

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedQueue.kt
@@ -26,6 +26,8 @@ import io.etcd.jetcd.options.GetOption.SortTarget
 import io.etcd.recipes.common.ResilienceConfig
 import io.etcd.recipes.common.asByteSequence
 import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.setTo
+import io.etcd.recipes.common.transaction
 
 fun <T> withDistributedQueue(
   client: Client,
@@ -52,7 +54,24 @@ class DistributedQueue
     client.putValue(key, value, rpc = resilience.rpc)
   }
 
+  /**
+   * Enqueues every value in one transaction (all-or-nothing). Entries share the
+   * transaction's revision; their keys embed the argument index so within-batch
+   * order follows argument order.
+   */
+  fun enqueueAll(values: Collection<ByteSequence>) {
+    checkCloseNotCalled()
+    if (values.isEmpty()) return
+    val millis = System.currentTimeMillis()
+    val puts =
+      values.mapIndexed { index, value ->
+        batchKeyFormat.format(queuePath, millis, index, randomId(3)) setTo value
+      }
+    client.transaction(resilience.rpc) { Then(*puts.toTypedArray()) }
+  }
+
   companion object {
     private val keyFormat = "%s/%0${Long.MAX_VALUE.length}d-%s"
+    private val batchKeyFormat = "%s/%0${Long.MAX_VALUE.length}d-%05d-%s"
   }
 }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueuePollTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueuePollTests.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.queue
+
+import io.etcd.jetcd.options.GetOption
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getKeyValuePairs
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Bounded and non-blocking consumption on the existing queues: the pre-0.12 API
+ * offered only a forever-blocking take, so consumers could not opt out of waiting
+ * or bound their wait. Also covers atomic batch enqueue.
+ */
+class QueuePollTests : StringSpec() {
+  private val base = "/queue/${javaClass.simpleName}"
+
+  init {
+    "tryDequeue returns null on an empty queue" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren("$base/try-empty")
+        DistributedQueue(client, "$base/try-empty").use { queue ->
+          queue.tryDequeue().shouldBeNull()
+        }
+      }
+    }
+
+    "tryDequeue takes items in FIFO order then reports empty" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren("$base/try-fifo")
+        DistributedQueue(client, "$base/try-fifo").use { queue ->
+          queue.enqueue("first")
+          queue.enqueue("second")
+          queue.tryDequeue()?.asString shouldBe "first"
+          queue.tryDequeue()?.asString shouldBe "second"
+          queue.tryDequeue().shouldBeNull()
+        }
+      }
+    }
+
+    "poll returns null after the timeout on an empty queue" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren("$base/poll-timeout")
+        DistributedQueue(client, "$base/poll-timeout").use { queue ->
+          val start = TimeSource.Monotonic.markNow()
+          queue.poll(2.seconds).shouldBeNull()
+          (start.elapsedNow() >= 1.5.seconds) shouldBe true
+          (start.elapsedNow() < 30.seconds) shouldBe true
+        }
+      }
+    }
+
+    "poll returns an item enqueued while waiting" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren("$base/poll-late")
+        DistributedQueue(client, "$base/poll-late").use { queue ->
+          val producer =
+            thread {
+              Thread.sleep(1_000)
+              connectToEtcd(urls) { p ->
+                DistributedQueue(p, "$base/poll-late").use { it.enqueue("late-arrival") }
+              }
+            }
+          val item = queue.poll(30.seconds)
+          item.shouldNotBeNull()
+          item.asString shouldBe "late-arrival"
+          producer.join(5_000)
+        }
+      }
+    }
+
+    "poll on the priority queue respects priority order" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren("$base/poll-priority")
+        DistributedPriorityQueue(client, "$base/poll-priority", 0.seconds).use { queue ->
+          queue.enqueue("low", 9)
+          queue.enqueue("high", 1)
+          queue.poll(10.seconds)?.asString shouldBe "high"
+          queue.poll(10.seconds)?.asString shouldBe "low"
+          queue.tryDequeue().shouldBeNull()
+        }
+      }
+    }
+
+    "enqueueAll commits atomically and preserves argument order" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren("$base/batch")
+        DistributedQueue(client, "$base/batch").use { queue ->
+          queue.enqueueAll(listOf("a", "b", "c").map { it.asByteSequence })
+
+          // one transaction => every entry shares the same mod revision
+          val option: GetOption = getOption { isPrefix(true) }
+          val pairs = client.getKeyValuePairs("$base/batch/", option)
+          pairs shouldHaveSize 3
+          val revisions =
+            client.getResponse("$base/batch/", getOption { isPrefix(true) }).kvs.map { it.modRevision }.toSet()
+          revisions shouldHaveSize 1
+
+          queue.tryDequeue()?.asString shouldBe "a"
+          queue.tryDequeue()?.asString shouldBe "b"
+          queue.tryDequeue()?.asString shouldBe "c"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Phase A of product idea #4 (reliable queue semantics) — design spec in `docs/superpowers/specs/2026-07-11-reliable-queues-design.md`.

## Problem

`dequeue()` was the queues' only take operation and it blocks forever — consumers could neither opt out of waiting nor bound their wait (called out in the product doc as the "dequeue blocks forever" footgun).

## Changes

- **`tryDequeue(): ByteSequence?`** — non-blocking: CAS-takes the head or returns null when empty (retrying only on CAS conflicts while items exist).
- **`poll(timeout): ByteSequence?`** — bounded take with `Duration` and `Long/TimeUnit` overloads; null once the timeout elapses. Internally the blocking take became the unbounded case of one shared deadline loop — `dequeue()`'s signature, behavior, and the `DesignFixesTests` source invariants are unchanged.
- **`DistributedQueue.enqueueAll(values)`** — atomic batch enqueue in a single transaction. Entries share the transaction's revision; keys embed the argument index so within-batch order follows argument order. (The priority queue is deliberately excluded — its per-item CAS sequencing doesn't fit batched slots.)

## Testing

6 new tests (test-first, real etcd): tryDequeue empty/FIFO-drain, poll timeout bounds, poll delivery mid-wait, priority order via poll, batch atomicity (single shared revision) + order. `make lint` clean; full `make tests-tc`: **229 tests, 0 failures**.

Next phases: `DistributedWorkQueue` (claim/ack at-least-once + DLQ), then delayed delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP