### PR TITLE
Add DistributedWorkQueue: at-least-once delivery with dead-lettering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (queues: at-least-once work queue)
+
+- `DistributedWorkQueue` — claim-based at-least-once delivery: `receive()` claims
+  the head atomically (payload copied to `claimed/`, a lease-bound claim marker,
+  and an attempt counter, all in one CAS transaction) and returns a `WorkItem`
+  with `ack()` / `requeue()`. A crashed or partitioned consumer's markers expire
+  with its lease (`visibilityTimeoutSecs`); every consumer's reclaim sweep
+  returns orphaned items to their original FIFO position or dead-letters them
+  after `maxDeliveries` (`deadLetters()` / `requeueDeadLetter` / `purgeDeadLetter`).
+  Existing queues keep their at-most-once semantics untouched.
+
 ### Added (queues: bounded and non-blocking consumption)
 
 - `tryDequeue(): ByteSequence?` (non-blocking) and `poll(timeout): ByteSequence?`

--- a/README.md
+++ b/README.md
@@ -72,6 +72,42 @@ See the `etcd-recipes-examples/` module for runnable
 and [Kotlin](https://github.com/pambrose/etcd-recipes/tree/master/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples)
 demos of every recipe.
 
+## Reliable work queue
+
+`DistributedQueue`'s take is at-most-once by construction: the item is deleted
+before the consumer processes it, so a crash between the two loses the message.
+`DistributedWorkQueue` is the at-least-once alternative — an item survives until
+it is explicitly acknowledged:
+
+```kotlin
+import io.etcd.recipes.queue.DistributedWorkQueue
+import io.etcd.recipes.queue.WorkQueueConfig
+
+DistributedWorkQueue(client, "/queues/emails", WorkQueueConfig(maxDeliveries = 3)).use { queue ->
+    queue.enqueue("send-invoice-42")
+
+    val item = queue.receive()      // or receive(timeout) / tryReceive()
+    try {
+        process(item.value)
+        item.ack()                  // false = the claim was lost; work may have been redone
+    } catch (e: Exception) {
+        item.requeue()              // early nack: back to its original position
+    }
+}
+```
+
+Received items are *claimed*, not deleted: the payload stays in etcd and only the
+claim marker is bound to the consumer's lease. If the consumer crashes (or is
+partitioned longer than `visibilityTimeoutSecs`), the marker expires and any
+consumer's reclaim sweep returns the item to its original FIFO position — with
+`attempt` incremented — or moves it to the dead-letter space once `maxDeliveries`
+is exhausted (`deadLetters()` / `requeueDeadLetter(id)` / `purgeDeadLetter(id)`).
+A live consumer renews its lease, so processing may take longer than the
+visibility timeout — it bounds crash detection, not processing time.
+
+For fire-and-forget delivery the plain queues also gained bounded consumption:
+`tryDequeue()` (non-blocking), `poll(timeout)`, and atomic `enqueueAll(values)`.
+
 ## Connection resilience
 
 Watchers created through this library survive fatal watch-stream deaths — **on by

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/queue/WorkQueueExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/queue/WorkQueueExample.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.queue
+
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.queue.DistributedWorkQueue
+import io.etcd.recipes.queue.WorkQueueConfig
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Demonstrates at-least-once consumption: the flaky consumer "crashes" (skips the
+ * ack) on its first delivery, and the item comes back with an incremented attempt
+ * until it succeeds — or would dead-letter after maxDeliveries.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+
+  connectToEtcd(urls) { client ->
+    val config = WorkQueueConfig(visibilityTimeoutSecs = 2, maxDeliveries = 3)
+    DistributedWorkQueue(client, "/examples/workqueue", config).use { queue ->
+      queue.enqueue("flaky-job")
+
+      var done = false
+      do {
+        val item = queue.receive(30.seconds)
+        when {
+          item == null -> {
+            done = true
+          }
+
+          item.attempt == 1 -> {
+            logger.info { "Received ${item.value.asString} (attempt 1); simulating a failure — requeueing" }
+            item.requeue()
+          }
+
+          else -> {
+            logger.info { "Received ${item.value.asString} (attempt ${item.attempt}); ack=${item.ack()}" }
+            done = true
+          }
+        }
+      } while (!done)
+
+      logger.info { "Dead letters: ${queue.deadLetters().map { it.value.asString }}" }
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/SelfHealingKeepAlive.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/SelfHealingKeepAlive.kt
@@ -252,10 +252,18 @@ fun Client.selfHealingKeepAlive(
 
 /**
  * True when this failure (or any cause in its chain) is etcd's NOT_FOUND
- * "requested lease not found" — jetcd's signal that a lease is gone for good,
- * as opposed to a transient stream error it retries itself.
+ * "requested lease not found" — the signal that a lease is gone for good, as
+ * opposed to a transient stream error jetcd retries itself. Keep-alive streams
+ * surface it as jetcd's [EtcdException]; transactions and puts surface the raw
+ * gRPC [io.grpc.StatusRuntimeException] instead.
  */
 internal fun Throwable.isLeaseNotFound(): Boolean =
   generateSequence(this) { it.cause.takeIf { c -> c !== it } }
-    .filterIsInstance<EtcdException>()
-    .any { it.errorCode == ErrorCode.NOT_FOUND }
+    .any { t ->
+      (t is EtcdException && t.errorCode == ErrorCode.NOT_FOUND) ||
+        (
+          t is io.grpc.StatusRuntimeException &&
+            t.status.code == io.grpc.Status.Code.NOT_FOUND &&
+            t.message?.contains("lease not found") == true
+        )
+    }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
@@ -1,0 +1,472 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.queue
+
+import com.pambrose.common.time.timeUnitToDuration
+import com.pambrose.common.util.length
+import com.pambrose.common.util.randomId
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.op.CmpTarget
+import io.etcd.jetcd.options.GetOption.SortTarget
+import io.etcd.jetcd.watch.WatchEvent
+import io.etcd.recipes.common.EtcdConnector
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.LeaseListener
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.SelfHealingKeepAlive
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.deleteOp
+import io.etcd.recipes.common.doesNotExist
+import io.etcd.recipes.common.equalTo
+import io.etcd.recipes.common.getFirstChild
+import io.etcd.recipes.common.getKeyValuePairs
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.getValue
+import io.etcd.recipes.common.isKeyPresent
+import io.etcd.recipes.common.isLeaseNotFound
+import io.etcd.recipes.common.putOption
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.selfHealingKeepAlive
+import io.etcd.recipes.common.setTo
+import io.etcd.recipes.common.transaction
+import io.etcd.recipes.common.watchOption
+import io.etcd.recipes.common.withWatcher
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.random.Random
+import kotlin.time.ComparableTimeMark
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+class WorkQueueConfig
+  @JvmOverloads
+  constructor(
+    /**
+     * How long after a consumer dies (crash or partition) its claimed items become
+     * reclaimable. A live consumer renews its lease, so processing may take longer
+     * than this — the timeout bounds crash detection, not processing time.
+     */
+    val visibilityTimeoutSecs: Long = 30,
+    /** Delivery attempts before an item is dead-lettered instead of redelivered. */
+    val maxDeliveries: Int = 5,
+    /** How often each consumer sweeps for orphaned claims. */
+    val sweepInterval: Duration = 30.seconds,
+  ) {
+    init {
+      require(visibilityTimeoutSecs >= 1) { "visibilityTimeoutSecs must be >= 1: $visibilityTimeoutSecs" }
+      require(maxDeliveries >= 1) { "maxDeliveries must be >= 1: $maxDeliveries" }
+      require(sweepInterval > Duration.ZERO) { "sweepInterval must be positive: $sweepInterval" }
+    }
+  }
+
+/**
+ * An at-least-once work queue (product idea #4). Unlike [DistributedQueue] — whose
+ * take deletes the item before the consumer processes it, losing it on a crash — a
+ * received item stays in etcd under `claimed/` until [WorkItem.ack] deletes it.
+ *
+ * The payload is never bound to the consumer's lease; only the claim *marker* is.
+ * When a consumer dies, its markers expire with its lease while the payloads
+ * survive, and any consumer's reclaim sweep moves the orphans back to the queue
+ * (same key, so they return to their original FIFO position) — or to the
+ * dead-letter space once [WorkQueueConfig.maxDeliveries] is exhausted.
+ *
+ * Delivery is at-least-once: a consumer that outlives its claim (partition longer
+ * than the visibility timeout) may process an item that is being redelivered
+ * elsewhere; its [WorkItem.ack] then returns false.
+ */
+class DistributedWorkQueue
+  @JvmOverloads
+  constructor(
+    client: Client,
+    val queuePath: String,
+    val config: WorkQueueConfig = WorkQueueConfig(),
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+    val clientId: String = defaultClientId(DistributedWorkQueue::class.simpleName!!),
+  ) : EtcdConnector(client, resilience) {
+  private val itemsPath = "$queuePath/items"
+  private val claimedPath = "$queuePath/claimed"
+  private val claimsPath = "$queuePath/claims"
+  private val attemptsPath = "$queuePath/attempts"
+  private val dlqPath = "$queuePath/dlq"
+  private val leaseListeners = CopyOnWriteArrayList<LeaseListener>()
+
+  init {
+    require(queuePath.isNotEmpty()) { "Queue path cannot be empty" }
+  }
+
+  // The consumer lease all claim markers hang off. Self-healing for FUTURE claims
+  // only: markers made under a dead lease are deliberately lost (that IS the
+  // visibility contract — their items become reclaimable), and the trivial
+  // establish hook re-grants so later claims work. Lazy so enqueue-only producers
+  // never hold a lease or sweeper thread.
+  private val consumerLeaseDelegate =
+    lazy {
+      sweeper // consumers also sweep
+      client.selfHealingKeepAlive(
+        config.visibilityTimeoutSecs.seconds,
+        resilience.lease,
+        leaseListener = { event -> onLeaseEvent(event) },
+      ) { true }
+    }
+  private val consumerLease: SelfHealingKeepAlive by consumerLeaseDelegate
+
+  private val sweeperDelegate =
+    lazy {
+      Executors.newSingleThreadScheduledExecutor { runnable ->
+        Thread(runnable, "workqueue-sweeper").apply { isDaemon = true }
+      }.also { executor ->
+        val period = config.sweepInterval.inWholeMilliseconds
+        // Jitter the start so a fleet of consumers doesn't sweep in lockstep
+        val initial = period + Random.nextLong(period / 2 + 1)
+        executor.scheduleWithFixedDelay(::sweepSafely, initial, period, TimeUnit.MILLISECONDS)
+      }
+    }
+  private val sweeper: ScheduledExecutorService by sweeperDelegate
+
+  /** Registers a listener for the consumer lease's lifecycle events. */
+  fun addLeaseListener(listener: LeaseListener) {
+    leaseListeners += listener
+  }
+
+  fun enqueue(value: String) = enqueue(value.asByteSequence)
+
+  fun enqueue(value: Int) = enqueue(value.asByteSequence)
+
+  fun enqueue(value: Long) = enqueue(value.asByteSequence)
+
+  fun enqueue(value: ByteSequence) {
+    checkCloseNotCalled()
+    val key = keyFormat.format(itemsPath, System.currentTimeMillis(), randomId(3))
+    client.putValue(key, value, rpc = resilience.rpc)
+  }
+
+  /** Enqueues every value in one transaction (all-or-nothing), preserving order. */
+  fun enqueueAll(values: Collection<ByteSequence>) {
+    checkCloseNotCalled()
+    if (values.isEmpty()) return
+    val millis = System.currentTimeMillis()
+    val puts =
+      values.mapIndexed { index, value ->
+        batchKeyFormat.format(itemsPath, millis, index, randomId(3)) setTo value
+      }
+    client.transaction(resilience.rpc) { Then(*puts.toTypedArray()) }
+  }
+
+  /** Blocking receive: waits until an item can be claimed. */
+  fun receive(): WorkItem = checkNotNull(receiveWithDeadline(null)) { "unbounded receive returned empty" }
+
+  /** Bounded receive: a claimed item, or null once [timeout] elapses without one. */
+  fun receive(timeout: Duration): WorkItem? {
+    require(timeout > Duration.ZERO) { "Timeout must be positive: $timeout" }
+    return receiveWithDeadline(TimeSource.Monotonic.markNow() + timeout)
+  }
+
+  fun receive(
+    timeout: Long,
+    timeUnit: TimeUnit,
+  ): WorkItem? = receive(timeUnitToDuration(timeout, timeUnit))
+
+  /** Non-blocking receive: a claimed item, or null when nothing is claimable. */
+  fun tryReceive(): WorkItem? {
+    checkCloseNotCalled()
+    claimHead()?.let { return it }
+    reclaimOrphans()
+    return claimHead()
+  }
+
+  /** The current dead letters (items that exhausted [WorkQueueConfig.maxDeliveries]). */
+  fun deadLetters(): List<DeadLetter> {
+    checkCloseNotCalled()
+    return client.getKeyValuePairs("$dlqPath/", getOption { isPrefix(true) }, resilience.rpc)
+      .map { (key, value) ->
+        val id = key.substringAfterLast('/')
+        DeadLetter(id, value, client.getValue("$attemptsPath/$id", 0, resilience.rpc))
+      }
+  }
+
+  /** Returns a dead letter to the queue with a fresh attempt count. */
+  fun requeueDeadLetter(id: String): Boolean {
+    checkCloseNotCalled()
+    val kv = client.getResponse("$dlqPath/$id", rpc = resilience.rpc).kvs.firstOrNull() ?: return false
+    return client.transaction(resilience.rpc) {
+      If(equalTo(kv.key, CmpTarget.modRevision(kv.modRevision)))
+      Then(
+        "$itemsPath/$id" setTo kv.value,
+        deleteOp(kv.key),
+        deleteOp("$attemptsPath/$id".asByteSequence),
+      )
+    }.isSucceeded
+  }
+
+  /** Discards a dead letter permanently. */
+  fun purgeDeadLetter(id: String): Boolean {
+    checkCloseNotCalled()
+    val kv = client.getResponse("$dlqPath/$id", rpc = resilience.rpc).kvs.firstOrNull() ?: return false
+    return client.transaction(resilience.rpc) {
+      If(equalTo(kv.key, CmpTarget.modRevision(kv.modRevision)))
+      Then(deleteOp(kv.key), deleteOp("$attemptsPath/$id".asByteSequence))
+    }.isSucceeded
+  }
+
+  inner class WorkItem internal constructor(
+    val id: String,
+    val value: ByteSequence,
+    val attempt: Int,
+  ) {
+    /**
+     * Completes the item: deletes its claim, payload copy, and attempt counter in
+     * one transaction, guarded on the claim still being this consumer's. Returns
+     * false when the claim was lost (the visibility timeout passed and the item
+     * was reclaimed) — the work may have been redone elsewhere.
+     */
+    fun ack(): Boolean {
+      checkCloseNotCalled()
+      return client.transaction(resilience.rpc) {
+        If(equalTo("$claimsPath/$id".asByteSequence, CmpTarget.value(clientId.asByteSequence)))
+        Then(
+          deleteOp("$claimsPath/$id".asByteSequence),
+          deleteOp("$claimedPath/$id".asByteSequence),
+          deleteOp("$attemptsPath/$id".asByteSequence),
+        )
+      }.isSucceeded
+    }
+
+    /** Returns the item to the queue early (attempts preserved). */
+    fun requeue(): Boolean {
+      checkCloseNotCalled()
+      return client.transaction(resilience.rpc) {
+        If(equalTo("$claimsPath/$id".asByteSequence, CmpTarget.value(clientId.asByteSequence)))
+        Then(
+          "$itemsPath/$id" setTo value,
+          deleteOp("$claimsPath/$id".asByteSequence),
+          deleteOp("$claimedPath/$id".asByteSequence),
+        )
+      }.isSucceeded
+    }
+  }
+
+  data class DeadLetter(
+    val id: String,
+    val value: ByteSequence,
+    val attempts: Int,
+  )
+
+  @Suppress("ReturnCount")
+  private fun receiveWithDeadline(deadline: ComparableTimeMark?): WorkItem? {
+    checkCloseNotCalled()
+    while (true) {
+      claimHead()?.let { return it }
+      reclaimOrphans()
+      claimHead()?.let { return it }
+      if (deadline != null && deadline.hasPassedNow()) return null
+      awaitItem(deadline)
+    }
+  }
+
+  // Claims the queue head atomically: guarded on the item's mod-revision, one
+  // transaction deletes it from items/, copies it to claimed/, puts the leased
+  // claim marker, and bumps the attempt counter. Reading the prior attempt count
+  // outside the transaction is safe: only the claim winner writes it, and the
+  // items/ guard picks exactly one winner per queue generation.
+  @Suppress("ReturnCount", "TooGenericExceptionCaught", "LoopWithTooManyJumpStatements")
+  private fun claimHead(): WorkItem? {
+    while (true) {
+      val head = client.getFirstChild(itemsPath, SortTarget.KEY, resilience.rpc).kvs.firstOrNull() ?: return null
+      val id = head.key.asString.substringAfterLast('/')
+      val attempt = client.getValue("$attemptsPath/$id", 0, resilience.rpc) + 1
+      val leaseId = consumerLease.currentLeaseId
+      val txn =
+        try {
+          client.transaction(resilience.rpc) {
+            If(equalTo(head.key, CmpTarget.modRevision(head.modRevision)))
+            Then(
+              deleteOp(head.key),
+              "$claimedPath/$id" setTo head.value,
+              "$claimsPath/$id".setTo(clientId, putOption { withLeaseId(leaseId) }),
+              "$attemptsPath/$id" setTo attempt,
+            )
+          }
+        } catch (e: Exception) {
+          // The consumer lease can die between reading its id and committing; the
+          // healer re-grants it shortly (its keep-alive stream reports NOT_FOUND on
+          // the next renewal), so pace briefly and retry with the fresh lease.
+          if (e.isLeaseNotFound()) {
+            Thread.sleep(LEASE_HEAL_PAUSE_MS)
+            continue
+          }
+          throw e
+        }
+      if (txn.isSucceeded) return WorkItem(id, head.value, attempt)
+      // Lost the head to a concurrent consumer; retry with the new head
+    }
+  }
+
+  // Finds claimed items whose claim marker expired (consumer died) and CAS-moves
+  // each back to items/ — or to dlq/ once its attempts are exhausted. Races
+  // between sweeping consumers are harmless: the claimed/ mod-revision guard
+  // picks one winner, losers no-op.
+  @Suppress("LoopWithTooManyJumpStatements")
+  private fun reclaimOrphans() {
+    val orphans = client.getKeyValuePairs("$claimedPath/", getOption { isPrefix(true) }, resilience.rpc)
+    for ((fullKey, payload) in orphans) {
+      val id = fullKey.substringAfterLast('/')
+      if (client.isKeyPresent("$claimsPath/$id", resilience.rpc)) continue // still claimed
+
+      val claimedKv = client.getResponse(fullKey, rpc = resilience.rpc).kvs.firstOrNull() ?: continue
+      val attempts = client.getValue("$attemptsPath/$id", 0, resilience.rpc)
+      val destination =
+        if (attempts >= config.maxDeliveries) "$dlqPath/$id" else "$itemsPath/$id"
+      if (attempts >= config.maxDeliveries) {
+        logger.warn { "Dead-lettering $id after $attempts deliveries" }
+      }
+      client.transaction(resilience.rpc) {
+        If(
+          "$claimsPath/$id".doesNotExist,
+          equalTo(claimedKv.key, CmpTarget.modRevision(claimedKv.modRevision)),
+        )
+        Then(deleteOp(claimedKv.key), destination setTo payload)
+      }
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun sweepSafely() {
+    try {
+      if (!closeCalled.load()) reclaimOrphans()
+    } catch (e: Throwable) {
+      logger.debug(e) { "Reclaim sweep failed; next interval will retry" }
+    }
+  }
+
+  // Parks until an item lands in items/ (or the deadline passes), on the resilient
+  // watcher. Also wakes at least every sweepInterval so a parked consumer keeps
+  // reclaiming even when nothing is enqueued.
+  private fun awaitItem(deadline: ComparableTimeMark?) {
+    val latch = CountDownLatch(1)
+    val watchFailure = AtomicReference<Throwable?>()
+    val recoveryListener =
+      WatchRecoveryListener { event ->
+        reportRecoveryEvent(event)
+        when (event) {
+          is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+            if (client.getFirstChild(itemsPath, SortTarget.KEY, resilience.rpc).kvs.isNotEmpty()) {
+              latch.countDown()
+            }
+          }
+
+          is WatchRecoveryEvent.Failed -> {
+            val cause = event.cause
+              ?: EtcdRecipeRuntimeException("Watch on $itemsPath abandoned while waiting for work")
+            watchFailure.set(cause)
+            exceptionList.value += cause
+            latch.countDown()
+          }
+
+          is WatchRecoveryEvent.Suspended -> {
+            // jetcd (transient) or the recovery loop (fatal) is already on it
+          }
+        }
+      }
+
+    client.withWatcher(
+      "$itemsPath/",
+      watchOption {
+        isPrefix(true)
+        withNoDelete(true)
+      },
+      resilience.watch,
+      recoveryListener,
+      resyncWith = null,
+      { watchResponse ->
+        if (watchResponse.events.any { it.eventType == WatchEvent.EventType.PUT }) latch.countDown()
+      },
+    ) {
+      // Pre-live gap poll: an item may have landed before the watch went live
+      if (latch.count > 0 && client.getFirstChild(itemsPath, SortTarget.KEY, resilience.rpc).kvs.isNotEmpty()) {
+        latch.countDown()
+      }
+      val cap = config.sweepInterval
+      val wait =
+        if (deadline == null) cap else minOf(cap, -deadline.elapsedNow())
+      if (wait > Duration.ZERO) {
+        latch.await(wait.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+      }
+      watchFailure.get()?.let { cause ->
+        throw EtcdRecipeRuntimeException("Work-queue watch on $itemsPath failed while waiting", cause)
+      }
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun onLeaseEvent(event: LeaseEvent) {
+    reportLeaseEvent(event)
+    when (event) {
+      is LeaseEvent.Suspended -> exceptionList.value += event.cause
+
+      is LeaseEvent.Expired -> exceptionList.value += (
+        event.cause ?: EtcdRecipeRuntimeException("Consumer lease expired; outstanding claims are reclaimable")
+      )
+
+      is LeaseEvent.Failed -> exceptionList.value += (
+        event.cause ?: EtcdRecipeRuntimeException("Consumer lease healing abandoned; claims will not renew")
+      )
+
+      is LeaseEvent.Restored -> logger.info {
+        "Consumer lease healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+      }
+    }
+    leaseListeners.forEach { listener ->
+      try {
+        listener.onLeaseEvent(event)
+      } catch (e: Throwable) {
+        logger.error(e) { "Exception in lease listener" }
+        exceptionList.value += e
+      }
+    }
+  }
+
+  override fun doClose() {
+    if (sweeperDelegate.isInitialized()) {
+      sweeper.shutdownNow()
+    }
+    if (consumerLeaseDelegate.isInitialized()) {
+      // Revokes the consumer lease: our unacked claims become reclaimable at once
+      consumerLease.close()
+    }
+  }
+
+  companion object {
+    private val logger = KotlinLogging.logger {}
+    private val keyFormat = "%s/%0${Long.MAX_VALUE.length}d-%s"
+    private val batchKeyFormat = "%s/%0${Long.MAX_VALUE.length}d-%05d-%s"
+    private const val LEASE_HEAL_PAUSE_MS = 250L
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/WorkQueueTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/WorkQueueTests.kt
@@ -1,0 +1,276 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.queue
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getChildrenKeys
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * At-least-once work-queue semantics (product idea #4, phase B): claims, acks,
+ * crash redelivery, and dead-lettering. Consumer crashes are simulated for real by
+ * revoking the consumer's lease out-of-band (etcd exposes the claim key's lease id)
+ * — exactly what a process death or partition longer than the visibility timeout
+ * produces.
+ */
+class WorkQueueTests : StringSpec() {
+  private val base = "/workqueue/${javaClass.simpleName}"
+
+  /** Kills a consumer's claims the way a crash would: revoke the claim's lease. */
+  private fun revokeClaimLease(
+    client: Client,
+    queuePath: String,
+  ) {
+    val claimKeys = client.getChildrenKeys("$queuePath/claims")
+    claimKeys.shouldNotBeNull()
+    (claimKeys.isNotEmpty()) shouldBe true
+    val leaseId = client.getResponse(claimKeys.first()).kvs.first().lease
+    (leaseId > 0L) shouldBe true
+    client.leaseClient.revoke(leaseId).get()
+  }
+
+  init {
+    "enqueue then receive delivers the payload as delivery attempt 1" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/basic"
+        client.deleteChildren(path)
+        DistributedWorkQueue(client, path).use { queue ->
+          queue.enqueue("job-1")
+          val item = queue.receive(10.seconds)
+          item.shouldNotBeNull()
+          item.value.asString shouldBe "job-1"
+          item.attempt shouldBe 1
+          item.ack() shouldBe true
+        }
+      }
+    }
+
+    "ack removes every trace of the item" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/ack"
+        client.deleteChildren(path)
+        DistributedWorkQueue(client, path).use { queue ->
+          queue.enqueue("done-job")
+          queue.receive(10.seconds)!!.ack() shouldBe true
+          queue.tryReceive().shouldBeNull()
+          client.getChildrenKeys(path).shouldBeEmpty()
+        }
+      }
+    }
+
+    "an unacked item from a crashed consumer is redelivered with attempt 2" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/redeliver"
+        client.deleteChildren(path)
+        connectToEtcd(urls) { client2 ->
+          DistributedWorkQueue(client, path).use { crashed ->
+            DistributedWorkQueue(client2, path).use { survivor ->
+              crashed.enqueue("fragile-job")
+              val first = crashed.receive(10.seconds)
+              first.shouldNotBeNull()
+              first.attempt shouldBe 1
+              // no ack: the consumer "crashes"
+              revokeClaimLease(client, path)
+
+              // the survivor's receive reclaims the orphan and re-delivers it
+              val second = survivor.receive(30.seconds)
+              second.shouldNotBeNull()
+              second.value.asString shouldBe "fragile-job"
+              second.attempt shouldBe 2
+              second.ack() shouldBe true
+            }
+          }
+        }
+      }
+    }
+
+    "requeue returns the item to its original position with attempts preserved" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/requeue"
+        client.deleteChildren(path)
+        DistributedWorkQueue(client, path).use { queue ->
+          queue.enqueue("first")
+          queue.enqueue("second")
+
+          val item = queue.receive(10.seconds)
+          item!!.value.asString shouldBe "first"
+          item.requeue() shouldBe true
+
+          // original FIFO position: "first" comes out again before "second"
+          val again = queue.receive(10.seconds)
+          again!!.value.asString shouldBe "first"
+          again.attempt shouldBe 2
+          again.ack() shouldBe true
+          queue.receive(10.seconds)!!.also { it.value.asString shouldBe "second" }.ack()
+        }
+      }
+    }
+
+    "the item dead-letters after maxDeliveries and stops being delivered" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/dlq"
+        client.deleteChildren(path)
+        val config = WorkQueueConfig(maxDeliveries = 2)
+        DistributedWorkQueue(client, path, config).use { queue ->
+          queue.enqueue("poison-pill")
+
+          repeat(2) {
+            queue.receive(10.seconds).shouldNotBeNull()
+            revokeClaimLease(client, path)
+            // wait until the claim marker is really gone before reclaiming
+            pollUntil(10.seconds) { client.getChildrenKeys("$path/claims").isEmpty() } shouldBe true
+          }
+
+          // reclaim now routes the poison pill to the DLQ instead of redelivering
+          queue.receive(5.seconds).shouldBeNull()
+          val dead = queue.deadLetters()
+          dead shouldHaveSize 1
+          dead.first().value.asString shouldBe "poison-pill"
+          dead.first().attempts shouldBe 2
+        }
+      }
+    }
+
+    "requeueDeadLetter returns the item to the queue with a fresh attempt count" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/dlq-requeue"
+        client.deleteChildren(path)
+        val config = WorkQueueConfig(maxDeliveries = 1)
+        DistributedWorkQueue(client, path, config).use { queue ->
+          queue.enqueue("second-chance")
+          queue.receive(10.seconds).shouldNotBeNull()
+          revokeClaimLease(client, path)
+          pollUntil(10.seconds) { client.getChildrenKeys("$path/claims").isEmpty() } shouldBe true
+
+          queue.receive(5.seconds).shouldBeNull() // dead-lettered
+          val dead = queue.deadLetters().first()
+
+          queue.requeueDeadLetter(dead.id) shouldBe true
+          val revived = queue.receive(10.seconds)
+          revived!!.value.asString shouldBe "second-chance"
+          revived.attempt shouldBe 1 // fresh start
+          revived.ack() shouldBe true
+          queue.deadLetters().shouldBeEmpty()
+        }
+      }
+    }
+
+    "purgeDeadLetter discards the item permanently" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/dlq-purge"
+        client.deleteChildren(path)
+        val config = WorkQueueConfig(maxDeliveries = 1)
+        DistributedWorkQueue(client, path, config).use { queue ->
+          queue.enqueue("hopeless")
+          queue.receive(10.seconds).shouldNotBeNull()
+          revokeClaimLease(client, path)
+          pollUntil(10.seconds) { client.getChildrenKeys("$path/claims").isEmpty() } shouldBe true
+          queue.receive(5.seconds).shouldBeNull()
+
+          val dead = queue.deadLetters().first()
+          queue.purgeDeadLetter(dead.id) shouldBe true
+          queue.deadLetters().shouldBeEmpty()
+          queue.tryReceive().shouldBeNull()
+        }
+      }
+    }
+
+    "ack returns false once the claim was lost to redelivery" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/lost-claim"
+        client.deleteChildren(path)
+        connectToEtcd(urls) { client2 ->
+          DistributedWorkQueue(client, path).use { slow ->
+            DistributedWorkQueue(client2, path).use { fast ->
+              slow.enqueue("contended")
+              val slowItem = slow.receive(10.seconds)
+              slowItem.shouldNotBeNull()
+              revokeClaimLease(client, path)
+
+              val fastItem = fast.receive(30.seconds)
+              fastItem.shouldNotBeNull()
+              fastItem.ack() shouldBe true
+
+              // the original consumer's ack must fail: its work may have been redone
+              slowItem.ack() shouldBe false
+            }
+          }
+        }
+      }
+    }
+
+    "receive with a timeout returns null on an empty queue within bounds" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/empty"
+        client.deleteChildren(path)
+        DistributedWorkQueue(client, path).use { queue ->
+          val start = TimeSource.Monotonic.markNow()
+          queue.receive(2.seconds).shouldBeNull()
+          (start.elapsedNow() >= 1.5.seconds) shouldBe true
+          (start.elapsedNow() < 30.seconds) shouldBe true
+        }
+      }
+    }
+
+    "concurrent consumers each receive distinct items exactly once" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/concurrent"
+        client.deleteChildren(path)
+        val count = 20
+        val seen = ConcurrentHashMap.newKeySet<String>()
+
+        DistributedWorkQueue(client, path).use { queue ->
+          queue.enqueueAll((1..count).map { "item-$it".toByteArray().let(io.etcd.jetcd.ByteSequence::from) })
+
+          val workers =
+            (1..3).map {
+              thread {
+                connectToEtcd(urls) { c ->
+                  DistributedWorkQueue(c, path).use { consumer ->
+                    while (true) {
+                      val item = consumer.receive(3.seconds) ?: break
+                      seen.add(item.value.asString) shouldBe true // never delivered twice
+                      item.ack() shouldBe true
+                    }
+                  }
+                }
+              }
+            }
+          workers.forEach { it.join(60_000) }
+          seen shouldHaveSize count
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Phase B of product idea #4 (reliable queue semantics) — design spec in `docs/superpowers/specs/2026-07-11-reliable-queues-design.md`.

## Problem

`DistributedQueue.dequeue()` is at-most-once by construction: the CAS transaction deletes the item, *then* returns it — a consumer crash between delete and processing loses the message. No redelivery, no dead-lettering.

## Design

New `DistributedWorkQueue` recipe (existing queues keep their semantics untouched). The crash-safety insight: **the payload is never bound to the consumer's lease — only the claim marker is.**

| Key | Content | Leased |
|---|---|---|
| `items/<k>` | pending payload (time-ordered key) | no |
| `claimed/<k>` | in-flight payload copy | no — survives crashes |
| `claims/<k>` | consumer id | yes — TTL = `visibilityTimeoutSecs` |
| `attempts/<k>` | delivery count | no |
| `dlq/<k>` | dead-lettered payload | no |

- `receive()` / `receive(timeout)` / `tryReceive()` claim the head in one mod-revision-guarded transaction and return a `WorkItem(value, id, attempt)` with `ack()` (returns false when the claim was lost — the documented at-least-once window) and `requeue()`.
- **Crash recovery**: a dead consumer's markers expire with its lease; every consumer's reclaim sweep (empty-queue waits wake at least every `sweepInterval`, plus a jittered background sweeper) CAS-moves orphans back to `items/<k>` — same key, so items return to their original FIFO position — or to `dlq/<k>` after `maxDeliveries`. Sweep races are harmless: one CAS winner.
- Consumer lease rides on `selfHealingKeepAlive` with a trivial establish hook: expired claims are deliberately **not** re-established (that *is* the visibility contract), but the lease re-grants for future claims. Lease events and connection state surface through the resilience machinery from #51/#52.
- DLQ management: `deadLetters()`, `requeueDeadLetter(id)` (fresh attempt count), `purgeDeadLetter(id)`.
- Also fixes `isLeaseNotFound` to recognize the raw gRPC `NOT_FOUND` that transactions surface (keep-alive streams wrap it in `EtcdException`; txns don't).

## Testing

10 tests, test-first, against real etcd — consumer crashes simulated deterministically by revoking the claim's lease out-of-band (`KeyValue.getLease`): claim/ack lifecycle and key cleanup, crash → redelivery with attempt 2, requeue position/attempt semantics, dead-lettering after `maxDeliveries`, DLQ requeue/purge, lost-claim `ack() == false`, bounded receive, and a 3-consumer × 20-item contention test asserting exactly-once-per-item under acks. `make lint` clean; full `make tests-tc`: **239 tests, 0 failures**.

Next phase: delayed delivery on this queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP