### PR TITLE
Add delayed delivery to DistributedWorkQueue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (queues: delayed delivery)
+
+- `DistributedWorkQueue.enqueue(value, delay)` — the item stays invisible under
+  `delayed/` until it matures, then consumers promote it into the queue (CAS, one
+  winner) and it flows through the normal claim/ack lifecycle in ready-time
+  order. Empty-queue waits wake when the earliest delayed item matures, so
+  delivery is prompt without polling. Maturity is judged against client clocks
+  (documented; skew shifts delivery by the skew).
+
 ### Added (queues: at-least-once work queue)
 
 - `DistributedWorkQueue` — claim-based at-least-once delivery: `receive()` claims

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ is exhausted (`deadLetters()` / `requeueDeadLetter(id)` / `purgeDeadLetter(id)`)
 A live consumer renews its lease, so processing may take longer than the
 visibility timeout — it bounds crash detection, not processing time.
 
+Delivery can be deferred: `enqueue(value, delay)` keeps the item invisible until
+it matures, then it flows through the normal claim/ack lifecycle in ready-time
+order, without blocking immediate items. Maturity rides on client clocks —
+producer/consumer skew shifts delivery by the skew.
+
 For fire-and-forget delivery the plain queues also gained bounded consumption:
 `tryDequeue()` (non-blocking), `poll(timeout)`, and atomic `enqueueAll(values)`.
 

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/queue/DelayedDeliveryExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/queue/DelayedDeliveryExample.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.queue
+
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.queue.DistributedWorkQueue
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Demonstrates delayed delivery: the reminder enqueued with a 5-second delay stays
+ * invisible until it matures, while the immediate item is delivered right away.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+
+  connectToEtcd(urls) { client ->
+    DistributedWorkQueue(client, "/examples/delayed").use { queue ->
+      val start = TimeSource.Monotonic.markNow()
+      queue.enqueue("send-reminder", 5.seconds)
+      queue.enqueue("send-welcome")
+
+      repeat(2) {
+        val item = queue.receive()
+        logger.info { "Received ${item.value.asString} after ${start.elapsedNow()}" }
+        item.ack()
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
@@ -63,6 +63,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
 
@@ -116,6 +117,7 @@ class DistributedWorkQueue
   private val claimsPath = "$queuePath/claims"
   private val attemptsPath = "$queuePath/attempts"
   private val dlqPath = "$queuePath/dlq"
+  private val delayedPath = "$queuePath/delayed"
   private val leaseListeners = CopyOnWriteArrayList<LeaseListener>()
 
   init {
@@ -168,6 +170,31 @@ class DistributedWorkQueue
     client.putValue(key, value, rpc = resilience.rpc)
   }
 
+  fun enqueue(
+    value: String,
+    delay: Duration,
+  ) = enqueue(value.asByteSequence, delay)
+
+  /**
+   * Enqueues [value] for delivery no earlier than [delay] from now (a zero or
+   * negative delay enqueues immediately). Maturity is judged against client
+   * clocks — skew between producers and consumers shifts delivery by the skew,
+   * which is tolerable at visibility-timeout scale.
+   */
+  fun enqueue(
+    value: ByteSequence,
+    delay: Duration,
+  ) {
+    checkCloseNotCalled()
+    if (delay <= Duration.ZERO) {
+      enqueue(value)
+      return
+    }
+    val readyAt = System.currentTimeMillis() + delay.inWholeMilliseconds
+    val key = keyFormat.format(delayedPath, readyAt, randomId(3))
+    client.putValue(key, value, rpc = resilience.rpc)
+  }
+
   /** Enqueues every value in one transaction (all-or-nothing), preserving order. */
   fun enqueueAll(values: Collection<ByteSequence>) {
     checkCloseNotCalled()
@@ -197,6 +224,7 @@ class DistributedWorkQueue
   /** Non-blocking receive: a claimed item, or null when nothing is claimable. */
   fun tryReceive(): WorkItem? {
     checkCloseNotCalled()
+    promoteMatured()
     claimHead()?.let { return it }
     reclaimOrphans()
     return claimHead()
@@ -283,6 +311,7 @@ class DistributedWorkQueue
   private fun receiveWithDeadline(deadline: ComparableTimeMark?): WorkItem? {
     checkCloseNotCalled()
     while (true) {
+      promoteMatured()
       claimHead()?.let { return it }
       reclaimOrphans()
       claimHead()?.let { return it }
@@ -360,11 +389,40 @@ class DistributedWorkQueue
   @Suppress("TooGenericExceptionCaught")
   private fun sweepSafely() {
     try {
-      if (!closeCalled.load()) reclaimOrphans()
+      if (!closeCalled.load()) {
+        promoteMatured()
+        reclaimOrphans()
+      }
     } catch (e: Throwable) {
       logger.debug(e) { "Reclaim sweep failed; next interval will retry" }
     }
   }
+
+  // Moves matured delayed items into items/ in ready-time order. The delayed key's
+  // basename is "<readyMillis>-<uniq>", which becomes the item key — so promoted
+  // items sort by ready time among themselves and interleave correctly with
+  // immediate items. CAS races between promoting consumers pick one winner.
+  private fun promoteMatured() {
+    while (true) {
+      val head = client.getFirstChild(delayedPath, SortTarget.KEY, resilience.rpc).kvs.firstOrNull() ?: return
+      val basename = head.key.asString.substringAfterLast('/')
+      if (readyMillisOf(basename) > System.currentTimeMillis()) return
+      client.transaction(resilience.rpc) {
+        If(equalTo(head.key, CmpTarget.modRevision(head.modRevision)))
+        Then(deleteOp(head.key), "$itemsPath/$basename" setTo head.value)
+      }
+      // win or lose, re-read: the next head may also be mature
+    }
+  }
+
+  // How long until the earliest delayed item matures, or null when none exist.
+  private fun delayedHeadRemaining(): Duration? {
+    val head = client.getFirstChild(delayedPath, SortTarget.KEY, resilience.rpc).kvs.firstOrNull() ?: return null
+    val basename = head.key.asString.substringAfterLast('/')
+    return (readyMillisOf(basename) - System.currentTimeMillis()).coerceAtLeast(0L).milliseconds
+  }
+
+  private fun readyMillisOf(basename: String): Long = basename.substringBefore('-').toLong()
 
   // Parks until an item lands in items/ (or the deadline passes), on the resilient
   // watcher. Also wakes at least every sweepInterval so a parked consumer keeps
@@ -413,7 +471,10 @@ class DistributedWorkQueue
       if (latch.count > 0 && client.getFirstChild(itemsPath, SortTarget.KEY, resilience.rpc).kvs.isNotEmpty()) {
         latch.countDown()
       }
-      val cap = config.sweepInterval
+      // Wake when the deadline passes, the sweep interval elapses, or the earliest
+      // delayed item matures — whichever comes first.
+      var cap = config.sweepInterval
+      delayedHeadRemaining()?.let { cap = minOf(cap, it) }
       val wait =
         if (deadline == null) cap else minOf(cap, -deadline.elapsedNow())
       if (wait > Duration.ZERO) {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/WorkQueueDelayTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/WorkQueueDelayTests.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.queue
+
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Delayed delivery on the work queue (product idea #4, phase C): items enqueued
+ * with a delay stay invisible until they mature, then flow through the normal
+ * claim/ack lifecycle. Maturity rides on client clocks — skew tolerance is at
+ * visibility-timeout scale, documented on the API.
+ */
+class WorkQueueDelayTests : StringSpec() {
+  private val base = "/workqueue/${javaClass.simpleName}"
+
+  init {
+    "a delayed item is invisible before its delay and delivered after it" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/basic"
+        client.deleteChildren(path)
+        DistributedWorkQueue(client, path).use { queue ->
+          val start = TimeSource.Monotonic.markNow()
+          queue.enqueue("later", 3.seconds)
+
+          queue.tryReceive().shouldBeNull() // not yet mature
+
+          val item = queue.receive(30.seconds)
+          item.shouldNotBeNull()
+          item.value.asString shouldBe "later"
+          item.attempt shouldBe 1
+          (start.elapsedNow() >= 2.5.seconds) shouldBe true
+          item.ack() shouldBe true
+        }
+      }
+    }
+
+    "delayed items deliver in ready-time order regardless of enqueue order" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/order"
+        client.deleteChildren(path)
+        DistributedWorkQueue(client, path).use { queue ->
+          queue.enqueue("slow", 5.seconds)
+          queue.enqueue("fast", 2.seconds)
+
+          queue.receive(30.seconds)!!.also { it.value.asString shouldBe "fast" }.ack()
+          queue.receive(30.seconds)!!.also { it.value.asString shouldBe "slow" }.ack()
+        }
+      }
+    }
+
+    "immediate items are not blocked behind delayed ones" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/mixed"
+        client.deleteChildren(path)
+        DistributedWorkQueue(client, path).use { queue ->
+          queue.enqueue("patient", 4.seconds)
+          queue.enqueue("now")
+
+          val start = TimeSource.Monotonic.markNow()
+          queue.receive(10.seconds)!!.also { it.value.asString shouldBe "now" }.ack()
+          (start.elapsedNow() < 3.seconds) shouldBe true
+
+          queue.receive(30.seconds)!!.also { it.value.asString shouldBe "patient" }.ack()
+        }
+      }
+    }
+
+    "a bounded receive returns null when the only item matures after the timeout" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/still-delayed"
+        client.deleteChildren(path)
+        DistributedWorkQueue(client, path).use { queue ->
+          queue.enqueue("distant", 30.seconds)
+          val start = TimeSource.Monotonic.markNow()
+          queue.receive(2.seconds).shouldBeNull()
+          (start.elapsedNow() < 15.seconds) shouldBe true
+        }
+      }
+    }
+
+    "a zero or negative delay enqueues immediately" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/zero"
+        client.deleteChildren(path)
+        DistributedWorkQueue(client, path).use { queue ->
+          queue.enqueue("instant", 0.seconds)
+          queue.receive(10.seconds)!!.also { it.value.asString shouldBe "instant" }.ack()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Phase C (final) of product idea #4 (reliable queue semantics) — design spec in `docs/superpowers/specs/2026-07-11-reliable-queues-design.md`.

## Changes

- **`enqueue(value, delay)`** — the item is written under `delayed/` keyed by its ready timestamp and stays invisible until it matures (zero/negative delay = immediate). Consumers promote matured items via a mod-revision-guarded CAS move — one winner per item — and the delayed key's basename becomes the item key, so promoted items sort by ready time among themselves, interleave correctly with immediate items, and then flow through the normal claim/ack/redelivery/DLQ lifecycle from #56.
- Promotion runs before every claim pass and in the periodic sweep, and **empty-queue waits wake exactly when the earliest delayed item matures** — prompt delivery without busy polling; immediate items are never blocked behind delayed ones.
- Maturity rides on client clocks (documented on the API): producer/consumer skew shifts delivery by the skew, tolerable at visibility-timeout scale.

## Testing

5 tests, test-first, real etcd: invisibility before maturity + delivery after (with timing bounds), ready-time ordering regardless of enqueue order, immediate-item non-blocking, bounded receive returning null while the only item is still delayed, zero-delay passthrough. `make lint` clean; full `make tests-tc`: **244 tests, 0 failures**.

This completes idea #4: bounded/non-blocking consumption (#55), at-least-once claims + DLQ (#56), and delayed delivery (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP