### PR TITLE
Add DistributedMutex: reentrant distributed lock on etcd's lock service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (locks: mutex)
+
+- `DistributedMutex` — reentrant distributed lock on etcd's native lock service
+  (server-side FIFO queuing, requireLeader applied by jetcd). Thread-per-acquisition
+  holds (Curator parity), `tryLock(timeout)` whose timed-out attempts leak nothing
+  (the per-acquisition lease revoke authoritatively aborts the server-side wait),
+  `withLock { }`, and cooperative lock-lost handling: listener + state flip +
+  `LOST` connection state, with interruption opt-in (`interruptOnLockLoss`). The
+  raw `Client.lock`/`unlock` extensions gained rpc-resilience parameters
+  (`lock` defaults to an unbounded wait by design).
+
 ### Added (queues: delayed delivery)
 
 - `DistributedWorkQueue.enqueue(value, delay)` — the item stays invisible under

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ what [Curator](https://curator.apache.org) provides for [ZooKeeper](https://zook
 | `io.etcd.recipes.discovery` | `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`, `ServiceProvider` |
 | `io.etcd.recipes.election` | `LeaderSelector`, `LeaderSelectorListener`, `Participant` |
 | `io.etcd.recipes.keyvalue` | `TransientKeyValue` (lease-backed key/value) |
-| `io.etcd.recipes.queue` | `DistributedQueue`, `DistributedPriorityQueue` |
+| `io.etcd.recipes.lock` | `DistributedMutex` (reentrant, on etcd's native lock service) |
+| `io.etcd.recipes.queue` | `DistributedQueue`, `DistributedPriorityQueue`, `DistributedWorkQueue` (at-least-once) |
 | `io.etcd.recipes.common` | Kotlin extensions over jetcd `Client`, `KV`, `Lease`, `Watch`, `Txn` |
 
 ## Usage
@@ -71,6 +72,36 @@ See the `etcd-recipes-examples/` module for runnable
 [Java](https://github.com/pambrose/etcd-recipes/tree/master/etcd-recipes-examples/src/main/java/io/etcd/recipes/examples)
 and [Kotlin](https://github.com/pambrose/etcd-recipes/tree/master/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples)
 demos of every recipe.
+
+## Distributed locks
+
+`DistributedMutex` is a reentrant distributed lock on etcd's **native lock
+service** — waiters queue server-side (FIFO by revision), and jetcd applies
+`requireLeader`, so a waiter never blocks silently against a partitioned server:
+
+```kotlin
+import io.etcd.recipes.lock.DistributedMutex
+import io.etcd.recipes.lock.withLock
+
+DistributedMutex(client, "/locks/inventory").use { mutex ->
+    mutex.withLock {
+        // exactly one holder across all processes and threads
+    }
+
+    if (mutex.tryLock(5.seconds)) {          // bounded acquisition; nothing leaks on timeout
+        try { /* ... */ } finally { mutex.unlock() }
+    }
+}
+```
+
+Holds are **per-thread** (Curator parity): a second thread on the same instance
+queues in etcd like a second process, and `unlock()` from a non-owner throws.
+Each acquisition owns a lease that is renewed through the wait and the hold. If
+a holder is partitioned longer than the TTL, etcd grants the lock to the next
+waiter and the dispossessed holder observes it **cooperatively**:
+`isHeldByCurrentThread` turns false, its `LockLostListener` fires, connection
+state reports `LOST`, and `unlock()` returns false (interruption is opt-in via
+`interruptOnLockLoss`). The lock is deliberately never auto-reclaimed.
 
 ## Reliable work queue
 

--- a/docs/superpowers/specs/2026-07-11-distributed-locks-design.md
+++ b/docs/superpowers/specs/2026-07-11-distributed-locks-design.md
@@ -1,0 +1,70 @@
+# Distributed Lock Suite — Design (product idea #1)
+
+Approved 2026-07-11. Three sequential PRs, each merged before the next:
+DistributedMutex → DistributedReadWriteLock → DistributedSemaphore. All in a new
+`io.etcd.recipes.lock` package.
+
+## Decisions (user-approved)
+
+- **Cooperative lock-lost**: mark not-held + `LockLostListener` + `ConnectionState.LOST`;
+  thread interrupt is opt-in (`interruptOnLockLoss`, default false) — critical sections
+  are inline user code, unlike LeaderSelector's framework-owned callback.
+- **Semaphore is single-permit** (`acquire()/tryAcquire(timeout)/release()`).
+- **Thread-per-acquisition** (Curator parity): each non-reentrant acquisition grants a
+  fresh lease and queues in etcd; a second thread on one instance queues like a second
+  process. Reentrancy is per-thread hold counts. A thread that dies holding never
+  unlocks until `close()` (documented, same as Curator).
+
+## Cross-cutting mechanics
+
+- `AcquisitionLease` (internal): lease grant + immediate keep-alive with a
+  discriminating observer (transient → Suspended/exceptions; fatal = onCompleted or
+  lease-not-found → the attempt's fatal hook). **Never self-healed** — an expired lock
+  lease means etcd already promoted the next waiter. `close()` revokes; revoke is the
+  sole authoritative abort (jetcd's lock RPC internally retries on safe-redo failures
+  and `future.cancel` is best-effort).
+- `EtcdLock` interface (ships in PR 1): `lock()`, `tryLock(timeout)`, `unlock(): Boolean`
+  (owner → true; dispossessed → false; non-owner → IllegalMonitorStateException),
+  `isHeldByCurrentThread`, `isLocked` (advisory), `holdCount`, lock-lost listeners,
+  `withLock { }`. Deliberately not `java.util.concurrent.locks.Lock`.
+- Wait strategies: mutex — none (etcd's native lock service queues server-side, FIFO,
+  requireLeader applied by jetcd); RW lock — watch nearest *conflicting* predecessor
+  (set-emptiness predicate ⇒ no missed wakeups, herd-free); semaphore — prefix DELETE
+  watch + full recheck (nearest-predecessor is provably wrong for rank admission).
+
+## PR 1 — DistributedMutex
+
+etcd's native lock RPC does the queuing. Acquisition: fresh `AcquisitionLease`
+(keep-alive through the wait and the hold) → `lockClient.lock(path, leaseId)` →
+deadline-bounded `get`. Attempt phase machine (WAITING/HOLDING/DEAD CAS) resolves the
+fatal-vs-win race; timeout = cancel + **lease revoke** (deletes any just-granted key,
+aborts the server-side wait); lease death mid-wait = fresh-lease retry after a 250 ms
+pace (re-queues at the tail — documented fairness caveat). Lock-lost: once-guarded
+dispossession, exceptions list, `LeaseEvent.Expired` → LOST, listeners, optional
+interrupt.
+
+## PR 2 — DistributedReadWriteLock
+
+Hand-rolled: `read-`/`write-` entries under the lock path, each on its own
+`AcquisitionLease`, ranked by createRevision (one sorted prefix GET = consistent
+snapshot). Reader admitted iff no live earlier write entry (excluding the calling
+thread's own write hold ⇒ write→read downgrade works); writer admitted iff no earlier
+entry. Read→write upgrade throws (self-deadlock). **Fair/FIFO** semantics (prevents
+writer starvation; Curator parity). Shared `WaiterSupport` wait-on-watch helper
+(pre-live recheck + recovery recheck + Failed → throw + deadline), reused by PR 3.
+
+## PR 3 — DistributedSemaphore
+
+Canonical permit count CAS-created at `<path>/permits`, validated lazily on first use
+(mismatch → typed error). Holder/waiter entries under `<path>/holders/`; admission =
+createRevision rank ≤ permits (rank monotone while an entry lives ⇒ capacity provably
+never exceeded). Counter-style API (any thread may release; LIFO among the instance's
+holds), `PermitLostListener`, `withPermit { }`. Timeout/loss/release all funnel
+through lease revoke.
+
+## Testing
+
+TDD; MockK for the lease observer + win-race unit tests; real-etcd suites with
+out-of-band lease revocation for deterministic crash simulation; fault tests
+(container pause > TTL) gated by `-PuseTestcontainers`. Per PR: `make lint` + full
+`make tests-tc` before merge.

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/lock/LockExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/lock/LockExample.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.lock
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.lock.DistributedMutex
+import io.etcd.recipes.lock.withLock
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.concurrent.thread
+
+/**
+ * Demonstrates mutual exclusion: five workers increment an unguarded counter
+ * 100 times each under the mutex — the total is exact because etcd's native
+ * lock service serializes them (FIFO). Lock-lost events are printed.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val lockPath = "/locks/example"
+  var unguarded = 0
+
+  val workers =
+    (1..5).map { worker ->
+      thread {
+        connectToEtcd(urls) { client ->
+          DistributedMutex(client, lockPath).use { mutex ->
+            mutex.addLockLostListener { cause -> logger.warn { "Worker $worker lost the lock: $cause" } }
+            repeat(100) {
+              mutex.withLock { unguarded += 1 }
+            }
+          }
+        }
+      }
+    }
+  workers.forEach { it.join() }
+  logger.info { "Final count: $unguarded (expected 500)" }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LockExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LockExtensions.kt
@@ -23,9 +23,24 @@ import io.etcd.jetcd.Client
 import io.etcd.jetcd.lock.LockResponse
 import io.etcd.jetcd.lock.UnlockResponse
 
+/**
+ * Raw pass-through to etcd's lock service; prefer [io.etcd.recipes.lock.DistributedMutex].
+ *
+ * The default rpc config is [RpcResilience.DISABLED] — unlike every other
+ * extension — because a lock call legitimately WAITS server-side for the current
+ * holder; a 30s operation timeout would abort valid waits. Pass a bounded config
+ * only when a bounded wait is what you mean. (jetcd already retries this RPC
+ * internally on safe-redo failures, idempotently per lease.)
+ */
+@JvmOverloads
 fun Client.lock(
   keyName: String,
   leaseId: Long,
-): LockResponse = lockClient.lock(keyName.asByteSequence, leaseId).get()
+  rpc: RpcResilience = RpcResilience.DISABLED,
+): LockResponse = awaitRpc(rpc, "lock($keyName)", lockClient.lock(keyName.asByteSequence, leaseId))
 
-fun Client.unlock(keyName: String): UnlockResponse = lockClient.unlock(keyName.asByteSequence).get()
+@JvmOverloads
+fun Client.unlock(
+  keyName: String,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): UnlockResponse = retryRpc(rpc, "unlock($keyName)") { lockClient.unlock(keyName.asByteSequence) }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/AcquisitionLease.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/AcquisitionLease.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse
+import io.etcd.jetcd.support.CloseableClient
+import io.etcd.jetcd.support.Observers
+import io.etcd.recipes.common.RpcResilience
+import io.etcd.recipes.common.isLeaseNotFound
+import io.etcd.recipes.common.leaseGrant
+import io.etcd.recipes.common.leaseRevoke
+import java.io.Closeable
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The lease behind one lock/permit acquisition: granted eagerly, kept alive from
+ * the moment of grant (a queued waiter's lease must stay renewed — etcd aborts a
+ * waiter whose lease dies), and **never self-healed**: an expired lock lease means
+ * etcd has already promoted the next waiter, and reclaiming would race the new
+ * holder — the same rationale as leadership step-down.
+ *
+ * The observer discriminates jetcd's signals: `onCompleted` (lease outlived its
+ * TTL unrenewed) or a lease-not-found error mean the lease is gone → [onFatal];
+ * any other stream error is transient (jetcd restarts the stream itself) →
+ * [onTransient]. Neither callback fires on our own close.
+ *
+ * [close] revokes — revocation is the sole authoritative abort of a server-side
+ * lock wait (jetcd internally retries the lock RPC on safe-redo failures, and
+ * future cancellation is best-effort only). [closeWithoutRevoke] is for the
+ * already-lost path, where the lease is gone and callbacks run on jetcd's
+ * threads (no blocking revoke RPC there).
+ */
+internal class AcquisitionLease(
+  private val client: Client,
+  ttlSecs: Long,
+  private val rpc: RpcResilience,
+  onTransient: (Throwable) -> Unit,
+  onFatal: (Throwable?) -> Unit,
+) : Closeable {
+  private val lease = client.leaseGrant(ttlSecs.seconds, rpc)
+  private val closed = AtomicBoolean(false)
+
+  val leaseId: Long get() = lease.id
+
+  private val registration: CloseableClient =
+    client.leaseClient.keepAlive(
+      lease.id,
+      Observers.builder<LeaseKeepAliveResponse>()
+        .onNext { }
+        .onError { e ->
+          if (!closed.load()) {
+            if (e.isLeaseNotFound()) onFatal(e) else onTransient(e)
+          }
+        }
+        .onCompleted {
+          if (!closed.load()) onFatal(null)
+        }
+        .build(),
+    )
+
+  /** Stops renewal without a revoke RPC — for when the lease is already gone. */
+  fun closeWithoutRevoke() {
+    if (closed.compareAndSet(false, true)) {
+      registration.close()
+    }
+  }
+
+  override fun close() {
+    if (closed.compareAndSet(false, true)) {
+      registration.close()
+      client.leaseRevoke(lease, rpc) // best-effort; deletes the entry / aborts the wait
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedMutex.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedMutex.kt
@@ -1,0 +1,326 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import com.pambrose.common.time.timeUnitToDuration
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.lock.LockResponse
+import io.etcd.recipes.common.EtcdConnector
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.getChildCount
+import io.etcd.recipes.common.unlock
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.time.ComparableTimeMark
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/**
+ * A distributed, reentrant mutex on etcd's native lock service (which queues
+ * waiters server-side, FIFO by revision, with requireLeader applied by jetcd —
+ * a waiter never blocks silently against a partitioned server).
+ *
+ * Thread-per-acquisition (Curator parity): every non-reentrant acquisition grants
+ * its own lease and queues in etcd, so a second thread on this instance waits in
+ * the same FIFO as a second process. The acquisition lease is kept alive through
+ * the wait and the hold; it is deliberately NOT self-healed — an expired lease
+ * means etcd already promoted the next waiter, so the dispossessed thread's hold
+ * is *lost* (see [EtcdLock] and [addLockLostListener]) rather than reclaimed.
+ *
+ * A thread that dies while holding never unlocks; its hold persists until
+ * [close] (documented Curator-parity caveat).
+ */
+class DistributedMutex
+  @JvmOverloads
+  constructor(
+    client: Client,
+    val lockPath: String,
+    val leaseTtlSecs: Long = DEFAULT_TTL_SECS,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+    val clientId: String = defaultClientId(DistributedMutex::class.simpleName!!),
+    private val interruptOnLockLoss: Boolean = false,
+  ) : EtcdConnector(client, resilience),
+    EtcdLock {
+  private class LockData(
+    val acquisitionLease: AcquisitionLease,
+    val ownershipKey: ByteSequence,
+  ) {
+    var holdCount = 1 // guarded by owner-thread confinement
+  }
+
+  private enum class Phase { WAITING, HOLDING, DEAD }
+
+  // One in-flight acquisition: the phase machine resolves the race between the
+  // keep-alive's fatal callback and the acquirer's win. Exactly one of
+  // {retry-as-loser, lockLost} runs.
+  private inner class Attempt(
+    val owner: Thread,
+  ) {
+    val phase = AtomicReference(Phase.WAITING)
+
+    @Volatile
+    var future: CompletableFuture<LockResponse>? = null
+  }
+
+  private val threadData = ConcurrentHashMap<Thread, LockData>()
+  private val dispossessed = ConcurrentHashMap<Thread, Int>()
+  private val attempts = CopyOnWriteArrayList<Attempt>()
+  private val lockLostListeners = CopyOnWriteArrayList<LockLostListener>()
+
+  init {
+    require(lockPath.isNotEmpty()) { "Lock path cannot be empty" }
+    require(leaseTtlSecs > 0) { "Lease TTL must be > 0" }
+  }
+
+  override fun lock() {
+    check(acquire(null)) { "unbounded acquisition returned without the lock" }
+  }
+
+  override fun tryLock(timeout: Duration): Boolean {
+    require(timeout > Duration.ZERO) { "Timeout must be positive: $timeout" }
+    return acquire(TimeSource.Monotonic.markNow() + timeout)
+  }
+
+  override fun tryLock(
+    timeout: Long,
+    timeUnit: TimeUnit,
+  ): Boolean = tryLock(timeUnitToDuration(timeout, timeUnit))
+
+  override val isHeldByCurrentThread: Boolean get() = threadData.containsKey(Thread.currentThread())
+
+  override val isLocked: Boolean
+    get() {
+      checkCloseNotCalled()
+      // Advisory: any entry under the prefix implies a granted holder (waiters
+      // included transiently for the ms until a timed-out attempt's revoke lands).
+      return client.getChildCount(lockPath, resilience.rpc) > 0L
+    }
+
+  override val holdCount: Int get() = threadData[Thread.currentThread()]?.holdCount ?: 0
+
+  override fun addLockLostListener(listener: LockLostListener) {
+    lockLostListeners += listener
+  }
+
+  override fun removeLockLostListener(listener: LockLostListener) {
+    lockLostListeners -= listener
+  }
+
+  // No checkCloseNotCalled: unlocking after close() is legitimate cleanup — the
+  // hold was released by close(), so the caller gets false, not a throw.
+  @Suppress("ReturnCount")
+  override fun unlock(): Boolean {
+    val me = Thread.currentThread()
+    val data = threadData[me]
+    if (data != null) {
+      if (data.holdCount > 1) {
+        data.holdCount -= 1
+        return true
+      }
+      threadData.remove(me)
+      releaseHold(data)
+      return true
+    }
+
+    val lostHolds = dispossessed[me]
+    if (lostHolds != null) {
+      if (lostHolds > 1) dispossessed[me] = lostHolds - 1 else dispossessed.remove(me)
+      logger.debug { "unlock() on $lockPath after the hold was lost or released by close()" }
+      return false
+    }
+
+    throw IllegalMonitorStateException("Current thread does not hold the lock on $lockPath")
+  }
+
+  @Suppress("ReturnCount", "ThrowsCount", "LoopWithTooManyJumpStatements", "TooGenericExceptionCaught", "LongMethod")
+  private fun acquire(deadline: ComparableTimeMark?): Boolean {
+    checkCloseNotCalled()
+    val me = Thread.currentThread()
+    threadData[me]?.let { data ->
+      data.holdCount += 1
+      return true
+    }
+
+    while (true) {
+      checkCloseNotCalled()
+      if (deadline != null && deadline.hasPassedNow()) return false
+
+      val attempt = Attempt(me)
+      // The lease is kept alive from grant, through the server-side wait, and
+      // across the hold; its fatal callback drives both mid-wait aborts and
+      // lock-lost while holding.
+      val lease =
+        AcquisitionLease(
+          client,
+          leaseTtlSecs,
+          resilience.rpc,
+          onTransient = { e ->
+            exceptionList.value += e
+            reportLeaseEvent(LeaseEvent.Suspended(-1L, e))
+          },
+          onFatal = { cause -> onAttemptFatal(attempt, cause) },
+        )
+      attempts += attempt
+      var acquired = false
+      try {
+        val future = client.lockClient.lock(lockPath.asByteSequence, lease.leaseId)
+        attempt.future = future
+
+        val response =
+          try {
+            awaitLock(future, deadline)
+          } catch (
+            @Suppress("SwallowedException") e: TimeoutException,
+          ) {
+            // The timeout IS the outcome; the finally's revoke is the authoritative abort
+            future.cancel(true)
+            return false
+          } catch (e: InterruptedException) {
+            future.cancel(true)
+            throw e
+          } catch (e: Exception) {
+            // Lease death mid-wait, "no leader", or a close() abort. Retry with a
+            // fresh lease (paced); tryLock stays bounded by the loop's deadline check.
+            exceptionList.value += e
+            if (closeCalled.load()) {
+              throw EtcdRecipeRuntimeException("Lock attempt on $lockPath aborted by close()", e)
+            }
+            Thread.sleep(LEASE_HEAL_PAUSE_MS)
+            continue
+          }
+
+        // Publish the hold BEFORE claiming the phase, so a fatal that lands in the
+        // win window always finds the hold to dispossess (or the CAS failure below
+        // rolls it back) — never a silently-dead "held" lock.
+        threadData[me] = LockData(lease, response.key)
+        if (attempt.phase.compareAndSet(Phase.WAITING, Phase.HOLDING)) {
+          dispossessed.remove(me)
+          acquired = true
+          return true
+        }
+        // The lease died in the win window: roll back and retry as a loser
+        threadData.remove(me)
+        continue
+      } finally {
+        attempts -= attempt
+        if (!acquired) {
+          // Revoke is idempotent and safe on an already-dead lease; it deletes any
+          // just-granted ownership key and aborts the server-side wait.
+          lease.close()
+        }
+      }
+    }
+  }
+
+  private fun awaitLock(
+    future: CompletableFuture<LockResponse>,
+    deadline: ComparableTimeMark?,
+  ): LockResponse =
+    if (deadline == null) {
+      future.get()
+    } else {
+      val remaining = -deadline.elapsedNow()
+      if (remaining <= Duration.ZERO) throw TimeoutException()
+      future.get(remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+    }
+
+  // Runs on jetcd's lease callback thread: no blocking RPCs here.
+  private fun onAttemptFatal(
+    attempt: Attempt,
+    cause: Throwable?,
+  ) {
+    if (attempt.phase.compareAndSet(Phase.WAITING, Phase.DEAD)) {
+      // Unbind the waiter even when the server is unreachable and the RPC would
+      // otherwise never return.
+      attempt.future?.completeExceptionally(
+        cause ?: EtcdRecipeRuntimeException("Lock lease expired while waiting on $lockPath"),
+      )
+    } else if (attempt.phase.load() == Phase.HOLDING) {
+      lockLost(attempt.owner, cause)
+    }
+  }
+
+  // Cooperative dispossession (once-guarded by the map removal): state flips,
+  // listeners fire, LOST is reported; interruption is opt-in because critical
+  // sections are inline user code.
+  @Suppress("TooGenericExceptionCaught")
+  private fun lockLost(
+    thread: Thread,
+    cause: Throwable?,
+  ) {
+    val data = threadData.remove(thread) ?: return
+    dispossessed[thread] = data.holdCount
+    logger.warn(cause) { "Lock on $lockPath lost by $clientId (lease expired)" }
+    exceptionList.value += (cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
+    reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
+    lockLostListeners.forEach { listener ->
+      try {
+        listener.onLockLost(cause)
+      } catch (e: Throwable) {
+        logger.error(e) { "Exception in lock-lost listener" }
+        exceptionList.value += e
+      }
+    }
+    if (interruptOnLockLoss) thread.interrupt()
+    data.acquisitionLease.closeWithoutRevoke() // lease already gone; no RPC on this thread
+  }
+
+  private fun releaseHold(data: LockData) {
+    // Prompt FIFO handoff via the unlock RPC; the revoke below is belt-and-braces
+    // (it deletes the ownership key even if the unlock RPC failed).
+    runCatching { client.unlock(data.ownershipKey.asString, resilience.rpc) }
+      .onFailure { e -> logger.debug(e) { "unlock RPC failed for $lockPath; revoke will release" } }
+    data.acquisitionLease.close()
+  }
+
+  override fun doClose() {
+    // Release every thread's hold; owners become dispossessed so their later
+    // unlock() returns false instead of throwing. Never blocks on user threads.
+    threadData.keys.toList().forEach { thread ->
+      threadData.remove(thread)?.let { data ->
+        dispossessed[thread] = data.holdCount
+        releaseHold(data)
+      }
+    }
+    // Abort in-flight waits; each attempt's finally revokes its lease.
+    attempts.toList().forEach { attempt ->
+      if (attempt.phase.compareAndSet(Phase.WAITING, Phase.DEAD)) {
+        attempt.future?.completeExceptionally(
+          EtcdRecipeRuntimeException("Lock attempt on $lockPath aborted by close()"),
+        )
+      }
+    }
+    lockLostListeners.clear()
+  }
+
+  companion object {
+    private val logger = KotlinLogging.logger {}
+    private const val LEASE_HEAL_PAUSE_MS = 250L
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/EtcdLock.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/EtcdLock.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.lock
+
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+
+/**
+ * A distributed, reentrant, per-thread-owned lock.
+ *
+ * Deliberately NOT [java.util.concurrent.locks.Lock]: `newCondition()` is not
+ * implementable on etcd, a no-argument `tryLock()` invites non-distributed
+ * assumptions, and lock ownership here can be *lost* (lease expiry during a
+ * partition) — see [addLockLostListener]. Ownership is cooperative after a loss:
+ * the dispossessed thread keeps running until it observes [isHeldByCurrentThread]
+ * turn false, its listener firing, or (opt-in) an interrupt.
+ */
+interface EtcdLock {
+  /** Acquires the lock, waiting as long as it takes. Interruptible. */
+  @Throws(InterruptedException::class)
+  fun lock()
+
+  /** Acquires within [timeout]: true when acquired, false when time ran out. */
+  @Throws(InterruptedException::class)
+  fun tryLock(timeout: Duration): Boolean
+
+  @Throws(InterruptedException::class)
+  fun tryLock(
+    timeout: Long,
+    timeUnit: TimeUnit,
+  ): Boolean
+
+  /**
+   * Releases one hold. Returns true when a hold was released or decremented;
+   * false when this thread's hold had already been lost (lease expiry) or was
+   * released by `close()`. Throws [IllegalMonitorStateException] when the calling
+   * thread never held the lock.
+   */
+  fun unlock(): Boolean
+
+  val isHeldByCurrentThread: Boolean
+
+  /** Advisory: whether any holder (any thread, any process) currently holds it. */
+  val isLocked: Boolean
+
+  /** The calling thread's reentrant hold count (0 when it is not the owner). */
+  val holdCount: Int
+
+  fun addLockLostListener(listener: LockLostListener)
+
+  fun removeLockLostListener(listener: LockLostListener)
+}
+
+fun interface LockLostListener {
+  fun onLockLost(cause: Throwable?)
+}
+
+/** Runs [block] under the lock, releasing on every exit path. */
+inline fun <T> EtcdLock.withLock(block: () -> T): T {
+  lock()
+  try {
+    return block()
+  } finally {
+    unlock()
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/MutexFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/MutexFaultTests.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import io.etcd.recipes.common.EtcdTestContainer
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.lock.DistributedMutex
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Real partition: a lock holder paused longer than its lease TTL loses the lock,
+ * and another instance acquires once the cluster is reachable again.
+ */
+class MutexFaultTests : StringSpec() {
+  private val path = "/fault/${javaClass.simpleName}"
+
+  init {
+    "a partitioned holder loses the lock and another instance acquires" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        val lockPath = "$path/partition"
+        val lost = CopyOnWriteArrayList<Throwable?>()
+
+        connectToEtcd(urls) { client2 ->
+          DistributedMutex(client, lockPath, leaseTtlSecs = 2).use { holder ->
+            DistributedMutex(client2, lockPath, leaseTtlSecs = 2).use { successor ->
+              holder.addLockLostListener { cause -> lost += cause }
+              holder.lock()
+
+              EtcdTestContainer.pause()
+              try {
+                Thread.sleep(7_000) // well past the 2s TTL
+              } finally {
+                EtcdTestContainer.unpause()
+              }
+              EtcdTestContainer.awaitReady()
+
+              pollUntil(60.seconds) { !holder.isHeldByCurrentThread } shouldBe true
+              pollUntil(30.seconds) { lost.size == 1 } shouldBe true
+              successor.tryLock(30.seconds) shouldBe true
+              successor.unlock() shouldBe true
+              holder.unlock() shouldBe false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedMutexTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedMutexTests.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.urls
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Single-thread semantics of [DistributedMutex]: reentrancy, ownership rules,
+ * withLock, and lifecycle (product idea #1, PR 1).
+ */
+class DistributedMutexTests : StringSpec() {
+  private val base = "/mutex/${javaClass.simpleName}"
+
+  init {
+    "lock is reentrant and holdCount tracks per-thread holds" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        DistributedMutex(client, "$base/reentrant").use { mutex ->
+          mutex.holdCount shouldBe 0
+          mutex.lock()
+          mutex.isHeldByCurrentThread shouldBe true
+          mutex.holdCount shouldBe 1
+          mutex.lock()
+          mutex.holdCount shouldBe 2
+          mutex.unlock() shouldBe true
+          mutex.holdCount shouldBe 1
+          mutex.isHeldByCurrentThread shouldBe true
+          mutex.unlock() shouldBe true
+          mutex.holdCount shouldBe 0
+          mutex.isHeldByCurrentThread shouldBe false
+        }
+      }
+    }
+
+    "unlock by a thread that never held the lock throws IllegalMonitorStateException" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        DistributedMutex(client, "$base/non-owner").use { mutex ->
+          mutex.lock()
+          val thrown = AtomicReference<Throwable?>()
+          thread {
+            try {
+              mutex.unlock()
+            } catch (e: Throwable) {
+              thrown.set(e)
+            }
+          }.join(10_000)
+          (thrown.get() is IllegalMonitorStateException) shouldBe true
+          mutex.unlock() shouldBe true
+        }
+      }
+    }
+
+    "withLock releases on exception" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        DistributedMutex(client, "$base/with-lock").use { mutex ->
+          shouldThrow<IllegalStateException> {
+            mutex.withLock { throw IllegalStateException("inside") }
+          }
+          mutex.isHeldByCurrentThread shouldBe false
+          mutex.isLocked shouldBe false
+        }
+      }
+    }
+
+    "isLocked reflects a holder from another instance" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        connectToEtcd(urls) { client2 ->
+          DistributedMutex(client, "$base/is-locked").use { holder ->
+            DistributedMutex(client2, "$base/is-locked").use { observer ->
+              observer.isLocked shouldBe false
+              holder.lock()
+              observer.isLocked shouldBe true
+              observer.isHeldByCurrentThread shouldBe false
+              holder.unlock() shouldBe true
+              observer.isLocked shouldBe false
+            }
+          }
+        }
+      }
+    }
+
+    "close releases a held lock and later unlock returns false" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        connectToEtcd(urls) { client2 ->
+          val mutex = DistributedMutex(client, "$base/close")
+          mutex.lock()
+          mutex.close()
+
+          DistributedMutex(client2, "$base/close").use { next ->
+            next.tryLock(10.seconds) shouldBe true
+            next.unlock() shouldBe true
+          }
+          mutex.unlock() shouldBe false // released by close(), not by this thread
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/MutexLockLostTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/MutexLockLostTests.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.ConnectionState
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Lock-lost semantics, driven for real by revoking leases out-of-band (etcd
+ * exposes each entry's lease id) — what a partition longer than the TTL produces.
+ * Loss handling is cooperative: state flips, listener fires, LOST is reported;
+ * interruption is opt-in.
+ */
+class MutexLockLostTests : StringSpec() {
+  private val base = "/mutex/${javaClass.simpleName}"
+
+  /** Revokes the lease behind the earliest (holder) entry under the lock prefix. */
+  private fun revokeHolderLease(
+    client: Client,
+    lockPath: String,
+  ) {
+    val kvs = client.getResponse(lockPath, io.etcd.recipes.common.getOption { isPrefix(true) }).kvs
+    (kvs.isNotEmpty()) shouldBe true
+    val holder = kvs.minByOrNull { it.createRevision }
+    holder.shouldNotBeNull()
+    (holder.lease > 0L) shouldBe true
+    client.leaseClient.revoke(holder.lease).get()
+  }
+
+  init {
+    "holder observes lock loss when its lease is revoked" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/lost"
+        val lost = CopyOnWriteArrayList<Throwable?>()
+
+        DistributedMutex(client, path).use { mutex ->
+          mutex.addLockLostListener { cause -> lost += cause }
+          mutex.lock()
+          mutex.isHeldByCurrentThread shouldBe true
+
+          revokeHolderLease(client, path)
+
+          pollUntil(15.seconds) { !mutex.isHeldByCurrentThread } shouldBe true
+          pollUntil(10.seconds) { lost.size == 1 } shouldBe true
+          mutex.connectionState shouldBe ConnectionState.LOST
+          mutex.hasExceptions shouldBe true
+          mutex.unlock() shouldBe false // dispossessed, not an error
+        }
+      }
+    }
+
+    "another instance acquires after the holder's lease is revoked" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/succession"
+        connectToEtcd(urls) { client2 ->
+          DistributedMutex(client, path).use { doomed ->
+            DistributedMutex(client2, path).use { successor ->
+              doomed.lock()
+              revokeHolderLease(client, path)
+              successor.tryLock(15.seconds) shouldBe true
+              successor.unlock() shouldBe true
+            }
+          }
+        }
+      }
+    }
+
+    "interruptOnLockLoss interrupts a parked holder; the default does not" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+
+        // Opt-in: the parked holder is interrupted
+        val interruptedPath = "$base/interrupt-on"
+        val wasInterrupted = BooleanMonitor(false)
+        val heldOn = BooleanMonitor(false)
+        DistributedMutex(client, interruptedPath, interruptOnLockLoss = true).use { mutex ->
+          val holder =
+            thread {
+              mutex.lock()
+              heldOn.set(true)
+              try {
+                Thread.sleep(60_000)
+              } catch (e: InterruptedException) {
+                wasInterrupted.set(true)
+              }
+            }
+          heldOn.waitUntilTrue(15.seconds) shouldBe true
+          revokeHolderLease(client, interruptedPath)
+          wasInterrupted.waitUntilTrue(15.seconds) shouldBe true
+          holder.join(10_000)
+        }
+
+        // Default: cooperative only — no interrupt lands
+        val cooperativePath = "$base/interrupt-off"
+        val interrupted = AtomicBoolean(false)
+        val heldOff = BooleanMonitor(false)
+        val finished = BooleanMonitor(false)
+        DistributedMutex(client, cooperativePath).use { mutex ->
+          val holder =
+            thread {
+              mutex.lock()
+              heldOff.set(true)
+              try {
+                Thread.sleep(4_000)
+              } catch (e: InterruptedException) {
+                interrupted.set(true)
+              }
+              finished.set(true)
+            }
+          heldOff.waitUntilTrue(15.seconds) shouldBe true
+          revokeHolderLease(client, cooperativePath)
+          finished.waitUntilTrue(20.seconds) shouldBe true
+          interrupted.get() shouldBe false
+          pollUntil(10.seconds) { !mutex.isHeldByCurrentThread } shouldBe true
+          holder.join(10_000)
+        }
+      }
+    }
+
+    "a waiter whose lease is revoked mid-wait re-queues and still acquires" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/waiter-revoked"
+        connectToEtcd(urls) { client2 ->
+          DistributedMutex(client, path).use { holder ->
+            DistributedMutex(client2, path).use { waiter ->
+              holder.lock()
+
+              val acquired = BooleanMonitor(false)
+              val releaseWaiter = BooleanMonitor(false)
+              val waiterThread =
+                thread {
+                  waiter.lock()
+                  acquired.set(true)
+                  releaseWaiter.waitUntilTrue() // holds are thread-owned: unlock here
+                  waiter.unlock()
+                }
+              // The waiter's queue entry is the SECOND entry by create revision
+              pollUntil(15.seconds) {
+                client.getResponse(path, io.etcd.recipes.common.getOption { isPrefix(true) }).kvs.size == 2
+              } shouldBe true
+              val waiterKv =
+                client.getResponse(path, io.etcd.recipes.common.getOption { isPrefix(true) })
+                  .kvs.maxByOrNull { it.createRevision }!!
+              client.leaseClient.revoke(waiterKv.lease).get()
+
+              // The waiter recovers with a fresh lease and re-queues
+              pollUntil(20.seconds) {
+                client.getResponse(path, io.etcd.recipes.common.getOption { isPrefix(true) }).kvs.size == 2
+              } shouldBe true
+
+              holder.unlock() shouldBe true
+              acquired.waitUntilTrue(20.seconds) shouldBe true
+              releaseWaiter.set(true)
+              waiterThread.join(10_000)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/MutexTryLockTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/MutexTryLockTests.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getChildCount
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Bounded acquisition: tryLock must time out promptly and — critically — leave no
+ * waiter key or lease behind (the timed-out attempt's lease revoke is the sole
+ * authoritative abort of the server-side wait).
+ */
+class MutexTryLockTests : StringSpec() {
+  private val base = "/mutex/${javaClass.simpleName}"
+
+  init {
+    "tryLock times out promptly while held elsewhere and leaks nothing" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/timeout"
+        connectToEtcd(urls) { client2 ->
+          DistributedMutex(client, path).use { holder ->
+            DistributedMutex(client2, path).use { contender ->
+              holder.lock()
+              client.getChildCount(path) shouldBe 1L
+
+              val start = TimeSource.Monotonic.markNow()
+              contender.tryLock(2.seconds) shouldBe false
+              (start.elapsedNow() >= 1.5.seconds) shouldBe true
+              (start.elapsedNow() < 20.seconds) shouldBe true
+
+              // No leaked waiter entry: the timed-out attempt's key must vanish
+              pollUntil(10.seconds) { client.getChildCount(path) == 1L } shouldBe true
+
+              // And the holder's release must promote nobody stale: a fresh lock()
+              // succeeds immediately afterwards
+              holder.unlock() shouldBe true
+              contender.tryLock(5.seconds) shouldBe true
+              contender.unlock() shouldBe true
+            }
+          }
+        }
+      }
+    }
+
+    "tryLock succeeds when the lock frees within the timeout" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/frees-in-time"
+        connectToEtcd(urls) { client2 ->
+          DistributedMutex(client, path).use { holder ->
+            DistributedMutex(client2, path).use { contender ->
+              // Holds are thread-owned: lock and unlock must run on the same thread
+              val held = com.pambrose.common.concurrent.BooleanMonitor(false)
+              val holderThread =
+                thread {
+                  holder.lock()
+                  held.set(true)
+                  Thread.sleep(1_000)
+                  holder.unlock()
+                }
+              held.waitUntilTrue(10.seconds) shouldBe true
+
+              contender.tryLock(20.seconds) shouldBe true
+              contender.isHeldByCurrentThread shouldBe true
+              contender.unlock() shouldBe true
+              holderThread.join(10_000)
+            }
+          }
+        }
+      }
+    }
+
+    "reentrant tryLock returns immediately" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        DistributedMutex(client, "$base/reentrant-try").use { mutex ->
+          mutex.lock()
+          val start = TimeSource.Monotonic.markNow()
+          mutex.tryLock(30.seconds) shouldBe true
+          (start.elapsedNow() < 5.seconds) shouldBe true
+          mutex.holdCount shouldBe 2
+          mutex.unlock() shouldBe true
+          mutex.unlock() shouldBe true
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/ThreadedMutexTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/ThreadedMutexTests.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import io.etcd.recipes.common.blockingThreads
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getChildCount
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Contention semantics of [DistributedMutex]: mutual exclusion across instances and
+ * threads, and FIFO fairness (etcd's native lock service queues by revision).
+ */
+class ThreadedMutexTests : StringSpec() {
+  private val base = "/mutex/${javaClass.simpleName}"
+
+  init {
+    "mutual exclusion across instances under contention" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val threadCount = 5
+        val iterations = 20
+        var unguarded = 0 // deliberately unsynchronized; the mutex is the only guard
+
+        blockingThreads(threadCount) {
+          connectToEtcd(urls) { c ->
+            DistributedMutex(c, "$base/exclusion").use { mutex ->
+              repeat(iterations) {
+                mutex.withLock { unguarded += 1 }
+              }
+            }
+          }
+        }
+        unguarded shouldBe threadCount * iterations
+      }
+    }
+
+    "two threads sharing one instance exclude each other through etcd" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        DistributedMutex(client, "$base/shared-instance").use { mutex ->
+          var unguarded = 0
+          blockingThreads(2) {
+            repeat(25) {
+              mutex.withLock { unguarded += 1 }
+            }
+          }
+          unguarded shouldBe 50
+        }
+      }
+    }
+
+    "waiters acquire in FIFO order" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/fifo"
+        val order = CopyOnWriteArrayList<Int>()
+
+        DistributedMutex(client, path).use { holder ->
+          holder.lock()
+
+          // Stage three waiters deterministically: each waiter's queue entry appears
+          // under the lock prefix the moment its Lock RPC lands, so poll the child
+          // count instead of sleeping.
+          val waiters =
+            (1..3).map { i ->
+              val t =
+                thread(name = "waiter-$i") {
+                  connectToEtcd(urls) { c ->
+                    DistributedMutex(c, path).use { m ->
+                      m.withLock { order += i }
+                    }
+                  }
+                }
+              pollUntil(15.seconds) { client.getChildCount(path) >= 1L + i } shouldBe true
+              t
+            }
+
+          holder.unlock() shouldBe true
+          waiters.forEach { it.join(30_000) }
+          order shouldBe listOf(1, 2, 3)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
PR 1 of 3 for product idea #1 (distributed lock suite) — design spec in `docs/superpowers/specs/2026-07-11-distributed-locks-design.md`.

## Problem

The README promises Curator parity, but there was no lock recipe: `LockExtensions` exposed two raw pass-throughs with caller-managed leases, no reentrancy, no `tryLock(timeout)`, and no lost-lock awareness.

## Design

- **etcd's native lock service does the queuing** (server-side FIFO by revision; jetcd auto-applies `requireLeader`, so waiters never block silently against a partitioned server).
- **Thread-per-acquisition holds** (Curator parity): each non-reentrant acquisition grants its own lease — renewed through the wait and the hold, deliberately never self-healed — and a second thread on one instance queues in etcd like a second process. Per-thread reentrancy; `unlock()` from a non-owner throws `IllegalMonitorStateException`.
- **Leak-free `tryLock(timeout)`**: cancellation of the lock future is best-effort (jetcd internally retries the RPC on safe-redo failures), so the timed-out attempt **revokes its acquisition lease** — the authoritative abort that deletes any just-granted ownership key and aborts the server-side wait. A test pins "no leaked waiter key" after timeouts.
- **WAITING/HOLDING/DEAD phase machine** resolves the fatal-vs-win race: the hold is published before the phase CAS (a loss in the win window always finds it), and mid-wait lease death completes the future exceptionally — waiters unbind even when the server is unreachable — followed by a paced fresh-lease retry.
- **Cooperative lock-lost** (per the approved design): `isHeldByCurrentThread` flips, `LockLostListener` fires, connection state reports `LOST`, `unlock()` returns false; interruption is opt-in (`interruptOnLockLoss`), unlike `LeaderSelector`'s default-on interrupt — critical sections are inline user code.
- `EtcdLock` interface + `withLock { }` ship now for reuse by PR 2's read/write locks.

## Testing

15 tests (test-first) + 1 fault test: reentrancy/hold counts, non-owner and post-close unlock semantics, `withLock` exception safety, cross-instance `isLocked`, exact-count mutual exclusion under contention (5 instances × 20 unguarded increments), two-threads-one-instance exclusion, FIFO across 3 deterministically staged waiters, leak-free timeout, lease-revocation loss simulation (state/listener/LOST/succession), both interrupt modes, waiter-revoked-mid-wait requeue, and a container-pause partition test. `make lint` clean; full `make tests-tc`: **260 tests, 0 failures**.

Next: PR 2 `DistributedReadWriteLock`, PR 3 `DistributedSemaphore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP