### PR TITLE
Add DistributedReadWriteLock: fair shared/exclusive lock with lock-lost awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (locks: read-write lock)
+
+- `DistributedReadWriteLock` — fair (FIFO by create revision) shared/exclusive
+  lock: readers share, writers exclude, queued writers cannot be starved by
+  later readers. Lease-bound `read-`/`write-` entries with herd-free
+  wait-on-nearest-conflicting-predecessor; write→read downgrade supported,
+  read→write upgrade throws. Same thread-owned holds, reentrancy, leak-free
+  `tryLock(timeout)`, and cooperative lock-lost semantics as `DistributedMutex`
+  (both sides expose the shared `EtcdLock` surface).
+
 ### Added (locks: mutex)
 
 - `DistributedMutex` — reentrant distributed lock on etcd's native lock service

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ what [Curator](https://curator.apache.org) provides for [ZooKeeper](https://zook
 | `io.etcd.recipes.discovery` | `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`, `ServiceProvider` |
 | `io.etcd.recipes.election` | `LeaderSelector`, `LeaderSelectorListener`, `Participant` |
 | `io.etcd.recipes.keyvalue` | `TransientKeyValue` (lease-backed key/value) |
-| `io.etcd.recipes.lock` | `DistributedMutex` (reentrant, on etcd's native lock service) |
+| `io.etcd.recipes.lock` | `DistributedMutex`, `DistributedReadWriteLock` |
 | `io.etcd.recipes.queue` | `DistributedQueue`, `DistributedPriorityQueue`, `DistributedWorkQueue` (at-least-once) |
 | `io.etcd.recipes.common` | Kotlin extensions over jetcd `Client`, `KV`, `Lease`, `Watch`, `Txn` |
 
@@ -102,6 +102,12 @@ waiter and the dispossessed holder observes it **cooperatively**:
 `isHeldByCurrentThread` turns false, its `LockLostListener` fires, connection
 state reports `LOST`, and `unlock()` returns false (interruption is opt-in via
 `interruptOnLockLoss`). The lock is deliberately never auto-reclaimed.
+
+`DistributedReadWriteLock` adds shared/exclusive semantics with the same lock
+surface (`rw.readLock` / `rw.writeLock`, both `EtcdLock`s): readers share,
+writers exclude, and grants are **fair** — FIFO by arrival revision, so a queued
+writer is never starved by later readers. Write→read downgrade is supported;
+read→write upgrade throws (it would self-deadlock).
 
 ## Reliable work queue
 

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/lock/ReadWriteLockExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/lock/ReadWriteLockExample.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.lock
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.lock.DistributedReadWriteLock
+import io.etcd.recipes.lock.withLock
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.concurrent.thread
+
+/**
+ * Demonstrates the fair read-write lock: readers share the lock concurrently,
+ * a writer excludes everyone, and arrivals are honored in order — a queued
+ * writer is never starved by later readers.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val lockPath = "/locks/rw-example"
+  var document = "v0"
+
+  val workers =
+    (1..6).map { worker ->
+      thread {
+        connectToEtcd(urls) { client ->
+          DistributedReadWriteLock(client, lockPath).use { rw ->
+            if (worker % 3 == 0) {
+              rw.writeLock.withLock {
+                document = "v$worker"
+                logger.info { "Writer $worker updated the document to $document" }
+                Thread.sleep(300)
+              }
+            } else {
+              rw.readLock.withLock {
+                logger.info { "Reader $worker sees $document (shared with other readers)" }
+                Thread.sleep(300)
+              }
+            }
+          }
+        }
+      }
+    }
+  workers.forEach { it.join() }
+  logger.info { "Final document: $document" }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
@@ -1,0 +1,398 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import com.pambrose.common.time.timeUnitToDuration
+import com.pambrose.common.util.randomId
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KeyValue
+import io.etcd.jetcd.options.GetOption
+import io.etcd.recipes.common.EtcdConnector
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.doesNotExist
+import io.etcd.recipes.common.getChildrenKeys
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.putOption
+import io.etcd.recipes.common.setTo
+import io.etcd.recipes.common.transaction
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.time.ComparableTimeMark
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/**
+ * A fair (FIFO by create revision) distributed read-write lock. Readers share;
+ * writers exclude everyone; arrivals are honored in revision order, so a queued
+ * writer cannot be starved by later readers — Curator-parity semantics (the
+ * "writer-priority" of the product doc).
+ *
+ * Hand-rolled key scheme (etcd's native lock service cannot express shared
+ * holds): each acquisition creates a lease-bound `read-`/`write-` entry under the
+ * lock path and waits on the DELETE of its *nearest conflicting predecessor* —
+ * herd-free, and correct because the conflict predicate is set-emptiness over
+ * earlier entries: the watched key is always in the set, so the set cannot empty
+ * without a wakeup, and new arrivals always rank later.
+ *
+ * Thread-per-acquisition holds, per-side reentrancy, cooperative lock-lost, and
+ * write→read downgrade are as in [DistributedMutex]; read→write upgrade throws
+ * (it would self-deadlock).
+ */
+class DistributedReadWriteLock
+  @JvmOverloads
+  constructor(
+    client: Client,
+    val lockPath: String,
+    val leaseTtlSecs: Long = DEFAULT_TTL_SECS,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+    val clientId: String = defaultClientId(DistributedReadWriteLock::class.simpleName!!),
+    private val interruptOnLockLoss: Boolean = false,
+  ) : EtcdConnector(client, resilience) {
+  internal enum class Side(
+    val entryPrefix: String,
+  ) {
+    READ("read-"),
+    WRITE("write-"),
+  }
+
+  private enum class Phase { WAITING, HOLDING, DEAD }
+
+  private class EntryData(
+    val lease: AcquisitionLease,
+    val entryKey: String,
+  ) {
+    var holdCount = 1 // owner-thread confined
+  }
+
+  // One in-flight acquisition; the phase machine arbitrates fatal-vs-win exactly
+  // like DistributedMutex's.
+  private class Attempt(
+    val owner: Thread,
+    val entryKey: String,
+  ) {
+    val phase = AtomicReference(Phase.WAITING)
+    val wake = java.util.concurrent.atomic.AtomicReference<CountDownLatch?>(null)
+  }
+
+  private val readHolds = ConcurrentHashMap<Thread, EntryData>()
+  private val writeHolds = ConcurrentHashMap<Thread, EntryData>()
+  private val readDispossessed = ConcurrentHashMap<Thread, Int>()
+  private val writeDispossessed = ConcurrentHashMap<Thread, Int>()
+  private val readLostListeners = CopyOnWriteArrayList<LockLostListener>()
+  private val writeLostListeners = CopyOnWriteArrayList<LockLostListener>()
+  private val attempts = CopyOnWriteArrayList<Attempt>()
+
+  init {
+    require(lockPath.isNotEmpty()) { "Lock path cannot be empty" }
+    require(leaseTtlSecs > 0) { "Lease TTL must be > 0" }
+  }
+
+  val readLock: EtcdLock = LockView(Side.READ)
+  val writeLock: EtcdLock = LockView(Side.WRITE)
+
+  private fun holdsFor(side: Side) = if (side == Side.READ) readHolds else writeHolds
+
+  private fun dispossessedFor(side: Side) = if (side == Side.READ) readDispossessed else writeDispossessed
+
+  private fun listenersFor(side: Side) = if (side == Side.READ) readLostListeners else writeLostListeners
+
+  private inner class LockView(
+    private val side: Side,
+  ) : EtcdLock {
+    override fun lock() {
+      check(acquire(side, null)) { "unbounded acquisition returned without the lock" }
+    }
+
+    override fun tryLock(timeout: Duration): Boolean {
+      require(timeout > Duration.ZERO) { "Timeout must be positive: $timeout" }
+      return acquire(side, TimeSource.Monotonic.markNow() + timeout)
+    }
+
+    override fun tryLock(
+      timeout: Long,
+      timeUnit: TimeUnit,
+    ): Boolean = tryLock(timeUnitToDuration(timeout, timeUnit))
+
+    override fun unlock(): Boolean = release(side)
+
+    override val isHeldByCurrentThread: Boolean get() = holdsFor(side).containsKey(Thread.currentThread())
+
+    override val isLocked: Boolean
+      get() {
+        checkCloseNotCalled()
+        return client.getChildrenKeys(lockPath, rpc = resilience.rpc)
+          .any { it.substringAfterLast('/').startsWith(side.entryPrefix) }
+      }
+
+    override val holdCount: Int get() = holdsFor(side)[Thread.currentThread()]?.holdCount ?: 0
+
+    override fun addLockLostListener(listener: LockLostListener) {
+      listenersFor(side) += listener
+    }
+
+    override fun removeLockLostListener(listener: LockLostListener) {
+      listenersFor(side) -= listener
+    }
+  }
+
+  @Suppress("ReturnCount")
+  private fun release(side: Side): Boolean {
+    val me = Thread.currentThread()
+    val holds = holdsFor(side)
+    val data = holds[me]
+    if (data != null) {
+      if (data.holdCount > 1) {
+        data.holdCount -= 1
+        return true
+      }
+      holds.remove(me)
+      data.lease.close() // revoke deletes the entry, waking successors
+      return true
+    }
+
+    val disposs = dispossessedFor(side)
+    val lostHolds = disposs[me]
+    if (lostHolds != null) {
+      if (lostHolds > 1) disposs[me] = lostHolds - 1 else disposs.remove(me)
+      logger.debug { "unlock() on $lockPath (${side.entryPrefix}) after the hold was lost or released by close()" }
+      return false
+    }
+
+    throw IllegalMonitorStateException("Current thread does not hold the ${side.entryPrefix} lock on $lockPath")
+  }
+
+  @Suppress(
+    "ReturnCount",
+    "LoopWithTooManyJumpStatements",
+    "LongMethod",
+    "CyclomaticComplexMethod",
+    "NestedBlockDepth",
+  )
+  private fun acquire(
+    side: Side,
+    deadline: ComparableTimeMark?,
+  ): Boolean {
+    checkCloseNotCalled()
+    val me = Thread.currentThread()
+    holdsFor(side)[me]?.let { data ->
+      data.holdCount += 1
+      return true
+    }
+    if (side == Side.WRITE && readHolds.containsKey(me)) {
+      throw EtcdRecipeRuntimeException(
+        "Read-to-write upgrade is not supported on $lockPath (it would self-deadlock)",
+      )
+    }
+
+    outer@ while (true) {
+      checkCloseNotCalled()
+      if (deadline != null && deadline.hasPassedNow()) return false
+
+      val entryKey = "$lockPath/${side.entryPrefix}$clientId:${randomId(TOKEN_LENGTH)}"
+      val attempt = Attempt(me, entryKey)
+      val lease =
+        AcquisitionLease(
+          client,
+          leaseTtlSecs,
+          resilience.rpc,
+          onTransient = { e ->
+            exceptionList.value += e
+            reportLeaseEvent(LeaseEvent.Suspended(-1L, e))
+          },
+          onFatal = { cause -> onEntryFatal(side, attempt, cause) },
+        )
+      attempts += attempt
+      var acquired = false
+      try {
+        val txn =
+          client.transaction(resilience.rpc) {
+            If(entryKey.doesNotExist)
+            Then(entryKey.setTo(clientId, putOption { withLeaseId(lease.leaseId) }))
+          }
+        if (!txn.isSucceeded) {
+          // Random-suffix collision: effectively impossible; pace and retry
+          Thread.sleep(LEASE_HEAL_PAUSE_MS)
+          continue@outer
+        }
+        val ownCreateRevision =
+          client.getResponse(entryKey, rpc = resilience.rpc).kvs.firstOrNull()?.createRevision
+            ?: run {
+              // Entry already gone: the lease died in the creation window
+              Thread.sleep(LEASE_HEAL_PAUSE_MS)
+              continue@outer
+            }
+
+        while (true) {
+          if (attempt.phase.load() == Phase.DEAD) {
+            Thread.sleep(LEASE_HEAL_PAUSE_MS)
+            continue@outer // fresh entry at the tail
+          }
+          if (deadline != null && deadline.hasPassedNow()) return false
+
+          val conflict = nearestConflict(side, me, entryKey, ownCreateRevision)
+            ?: run {
+              // Admitted: publish the hold BEFORE claiming the phase (a fatal in
+              // the win window must always find the hold — or the CAS failure
+              // below rolls it back).
+              holdsFor(side)[me] = EntryData(lease, entryKey)
+              if (attempt.phase.compareAndSet(Phase.WAITING, Phase.HOLDING)) {
+                dispossessedFor(side).remove(me)
+                acquired = true
+                return true
+              }
+              holdsFor(side).remove(me)
+              Thread.sleep(LEASE_HEAL_PAUSE_MS)
+              continue@outer
+            }
+
+          val latch = CountDownLatch(1)
+          attempt.wake.set(latch)
+          if (attempt.phase.load() == Phase.DEAD) latch.countDown() // fatal raced the install
+          WaiterSupport.awaitKeyDeletion(
+            client,
+            conflict.key.asString,
+            resilience,
+            latch,
+            deadline,
+            reportRecovery = { event -> reportRecoveryEvent(event) },
+            recordException = { e -> exceptionList.value += e },
+          )
+          attempt.wake.set(null)
+          // Loop: re-evaluate the conflict set (it only shrinks)
+        }
+      } finally {
+        attempts -= attempt
+        if (!acquired) {
+          // Revoke deletes the entry (safe on an already-dead lease), waking successors
+          lease.close()
+        }
+      }
+      @Suppress("UNREACHABLE_CODE")
+      error("unreachable")
+    }
+  }
+
+  // One consistent snapshot (a single ranged read), sorted by create revision.
+  // The nearest EARLIER conflicting entry is the wait target; the calling
+  // thread's own write entry is excluded so write→read downgrade admits.
+  private fun nearestConflict(
+    side: Side,
+    thread: Thread,
+    ownEntryKey: String,
+    ownCreateRevision: Long,
+  ): KeyValue? {
+    val snapshot =
+      client.getResponse(
+        lockPath,
+        getOption {
+          isPrefix(true)
+          withSortField(GetOption.SortTarget.CREATE)
+          withSortOrder(GetOption.SortOrder.ASCEND)
+        },
+        resilience.rpc,
+      )
+    val ownWriteEntry = writeHolds[thread]?.entryKey
+    return snapshot.kvs
+      .asSequence()
+      .filter { it.createRevision < ownCreateRevision }
+      .filter { kv ->
+        val basename = kv.key.asString.substringAfterLast('/')
+        when (side) {
+          Side.WRITE -> true
+
+          // any earlier entry conflicts with a writer
+          Side.READ -> basename.startsWith(Side.WRITE.entryPrefix)
+        }
+      }
+      .filter { it.key.asString != ownEntryKey && it.key.asString != ownWriteEntry }
+      .maxByOrNull { it.createRevision }
+  }
+
+  // Runs on jetcd's lease callback thread — no blocking RPCs here. The phase
+  // machine guarantees exactly one of {waiter-abort, lockLost} runs.
+  private fun onEntryFatal(
+    side: Side,
+    attempt: Attempt,
+    cause: Throwable?,
+  ) {
+    if (attempt.phase.compareAndSet(Phase.WAITING, Phase.DEAD)) {
+      exceptionList.value += (
+        cause ?: EtcdRecipeRuntimeException("Lock entry lease expired while waiting on $lockPath")
+      )
+      attempt.wake.get()?.countDown()
+    } else if (attempt.phase.load() == Phase.HOLDING) {
+      lockLost(side, attempt.owner, cause)
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun lockLost(
+    side: Side,
+    thread: Thread,
+    cause: Throwable?,
+  ) {
+    val data = holdsFor(side).remove(thread) ?: return
+    dispossessedFor(side)[thread] = data.holdCount
+    logger.warn(cause) { "${side.entryPrefix} lock on $lockPath lost by $clientId (lease expired)" }
+    exceptionList.value += (cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
+    reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
+    listenersFor(side).forEach { listener ->
+      try {
+        listener.onLockLost(cause)
+      } catch (e: Throwable) {
+        logger.error(e) { "Exception in lock-lost listener" }
+        exceptionList.value += e
+      }
+    }
+    if (interruptOnLockLoss) thread.interrupt()
+    data.lease.closeWithoutRevoke() // lease already gone; no RPC on this thread
+  }
+
+  override fun doClose() {
+    listOf(Side.READ, Side.WRITE).forEach { side ->
+      val holds = holdsFor(side)
+      holds.keys.toList().forEach { thread ->
+        holds.remove(thread)?.let { data ->
+          dispossessedFor(side)[thread] = data.holdCount
+          data.lease.close()
+        }
+      }
+    }
+    attempts.toList().forEach { attempt ->
+      if (attempt.phase.compareAndSet(Phase.WAITING, Phase.DEAD)) {
+        attempt.wake.get()?.countDown()
+      }
+    }
+    readLostListeners.clear()
+    writeLostListeners.clear()
+  }
+
+  companion object {
+    private val logger = KotlinLogging.logger {}
+    private const val LEASE_HEAL_PAUSE_MS = 250L
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/WaiterSupport.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/WaiterSupport.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.watch.WatchEvent
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
+import io.etcd.recipes.common.isKeyNotPresent
+import io.etcd.recipes.common.watchOption
+import io.etcd.recipes.common.withWatcher
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.ComparableTimeMark
+import kotlin.time.Duration
+
+/**
+ * Shared wait-on-predecessor machinery for the hand-rolled locks (read-write lock,
+ * semaphore): parks on [latch] until [key] is DELETEd (or found already absent —
+ * the pre-live gap and every recovery are re-checked), someone else counts the
+ * latch down (lease-fatal, close), or the deadline passes. Watch failures unpark
+ * and throw. Follows the queue/barrier watcher discipline: recheck RPCs run on
+ * the watch dispatcher thread, never on jetcd's event loop.
+ */
+internal object WaiterSupport {
+  fun awaitKeyDeletion(
+    client: Client,
+    key: String,
+    resilience: ResilienceConfig,
+    latch: CountDownLatch,
+    deadline: ComparableTimeMark?,
+    reportRecovery: (WatchRecoveryEvent) -> Unit,
+    recordException: (Throwable) -> Unit,
+  ) {
+    val failure = AtomicReference<Throwable?>()
+    val recoveryListener =
+      WatchRecoveryListener { event ->
+        reportRecovery(event)
+        when (event) {
+          is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+            // The DELETE may have been lost while the stream was dead
+            if (client.isKeyNotPresent(key, resilience.rpc)) latch.countDown()
+          }
+
+          is WatchRecoveryEvent.Failed -> {
+            val cause = event.cause ?: EtcdRecipeRuntimeException("Watch on $key abandoned while waiting")
+            failure.set(cause)
+            recordException(cause)
+            latch.countDown()
+          }
+
+          is WatchRecoveryEvent.Suspended -> {
+            // jetcd (transient) or the recovery loop (fatal) is already on it
+          }
+        }
+      }
+
+    client.withWatcher(
+      key,
+      watchOption { withNoPut(true) },
+      resilience.watch,
+      recoveryListener,
+      resyncWith = null,
+      { watchResponse ->
+        if (watchResponse.events.any { it.eventType == WatchEvent.EventType.DELETE }) latch.countDown()
+      },
+    ) {
+      // Pre-live gap: the key may have been deleted before the watch went live
+      if (latch.count > 0 && client.isKeyNotPresent(key, resilience.rpc)) latch.countDown()
+      if (deadline == null) {
+        latch.await()
+      } else {
+        val remaining = -deadline.elapsedNow()
+        if (remaining > Duration.ZERO) {
+          latch.await(remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        }
+      }
+      failure.get()?.let { cause ->
+        throw EtcdRecipeRuntimeException("Lock watch on $key failed while waiting", cause)
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdTestContainer.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdTestContainer.kt
@@ -34,45 +34,65 @@ internal object EtcdTestContainer {
   private const val ETCD_IMAGE = "gcr.io/etcd-development/etcd:v3.5.17"
   private const val CLIENT_PORT = 2379
 
-  // The client port is bound to a FIXED host port chosen once per JVM: Docker does
-  // NOT preserve randomly-assigned host ports across `docker restart` (verified:
-  // the port changes), and the fault tests restart the container while jetcd
-  // clients keep dialing the original endpoint. A fixed binding lives in the
-  // container's HostConfig and survives restarts. Probing a free port and then
-  // binding it is racy in principle; with one container per forked test JVM the
-  // window is negligible.
-  private val fixedClientHostPort: Int by lazy {
-    ServerSocket(0).use { it.localPort }
-  }
+  // The client port is bound to a FIXED host port: Docker does NOT preserve
+  // randomly-assigned host ports across `docker restart` (verified: the port
+  // changes), and the fault tests restart the container while jetcd clients keep
+  // dialing the original endpoint. A fixed binding lives in the container's
+  // HostConfig and survives restarts. Probing a free port and then binding it is
+  // racy across parallel test forks (observed: "port is already allocated" under
+  // a full-suite run), so startup retries with a fresh port on bind conflicts.
+  private const val START_ATTEMPTS = 5
+
+  private class RunningContainer(
+    val container: GenericContainer<*>,
+    val hostPort: Int,
+  )
 
   // Lazy: the container is only started when a test in this JVM actually
   // asks for the endpoint. With forkEvery=1 each test class is its own JVM,
   // so this gives one container per test class. Testcontainers' Ryuk reaper
   // handles cleanup; the explicit shutdown hook is belt-and-suspenders that
   // stops the container promptly when the test JVM exits.
-  private val container: GenericContainer<*> by lazy {
-    // Only the client port is exposed: the peer port is unused on a single node, and
-    // the fixed-binding modifier below replaces ALL host-port bindings — an exposed
-    // port without a binding would stall Testcontainers' startup port check.
-    val c = GenericContainer(DockerImageName.parse(ETCD_IMAGE))
-      .withExposedPorts(CLIENT_PORT)
-      .withCreateContainerCmdModifier { cmd ->
-        cmd.hostConfig?.withPortBindings(
-          PortBinding(Ports.Binding.bindPort(fixedClientHostPort), ExposedPort.tcp(CLIENT_PORT)),
+  private val running: RunningContainer by lazy {
+    var lastFailure: Exception? = null
+    repeat(START_ATTEMPTS) {
+      val hostPort = ServerSocket(0).use { it.localPort }
+      // Only the client port is exposed: the peer port is unused on a single node,
+      // and the fixed-binding modifier below replaces ALL host-port bindings — an
+      // exposed port without a binding would stall Testcontainers' startup check.
+      val c = GenericContainer(DockerImageName.parse(ETCD_IMAGE))
+        .withExposedPorts(CLIENT_PORT)
+        .withCreateContainerCmdModifier { cmd ->
+          cmd.hostConfig?.withPortBindings(
+            PortBinding(Ports.Binding.bindPort(hostPort), ExposedPort.tcp(CLIENT_PORT)),
+          )
+        }
+        .withCommand(
+          "etcd",
+          "--listen-client-urls=http://0.0.0.0:$CLIENT_PORT",
+          "--advertise-client-urls=http://0.0.0.0:$CLIENT_PORT",
         )
+        .waitingFor(Wait.forLogMessage(".*ready to serve client requests.*\\n", 1))
+      try {
+        c.start()
+        Runtime.getRuntime().addShutdownHook(Thread { runCatching { c.stop() } })
+        return@lazy RunningContainer(c, hostPort)
+      } catch (e: Exception) {
+        lastFailure = e
+        runCatching { c.stop() }
+        val portConflict =
+          generateSequence<Throwable>(e) { t -> t.cause?.takeIf { it !== t } }
+            .any { it.message?.contains("port is already allocated") == true }
+        if (!portConflict) throw e
+        // Another fork (or process) won the probed port; retry with a fresh one
       }
-      .withCommand(
-        "etcd",
-        "--listen-client-urls=http://0.0.0.0:$CLIENT_PORT",
-        "--advertise-client-urls=http://0.0.0.0:$CLIENT_PORT",
-      )
-      .waitingFor(Wait.forLogMessage(".*ready to serve client requests.*\\n", 1))
-    c.start()
-    Runtime.getRuntime().addShutdownHook(Thread { runCatching { c.stop() } })
-    c
+    }
+    throw IllegalStateException("etcd container failed to start after $START_ATTEMPTS attempts", lastFailure)
   }
 
-  fun endpoint(): String = "http://${container.host}:$fixedClientHostPort"
+  private val container: GenericContainer<*> get() = running.container
+
+  fun endpoint(): String = "http://${container.host}:${running.hostPort}"
 
   // ---- Fault-injection controls (used by io.etcd.recipes.fault tests) ----
   // These mutate the private container; they are only meaningful under

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/ReadWriteLockFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/ReadWriteLockFaultTests.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.common.EtcdTestContainer
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.lock.DistributedReadWriteLock
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Real partition: a writer paused longer than its lease TTL loses the write lock,
+ * and queued readers acquire once the cluster is reachable again.
+ */
+class ReadWriteLockFaultTests : StringSpec() {
+  private val path = "/fault/${javaClass.simpleName}"
+
+  init {
+    "a partitioned writer loses the lock and queued readers acquire" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        val lockPath = "$path/partition"
+        connectToEtcd(urls) { client2 ->
+          DistributedReadWriteLock(client, lockPath, leaseTtlSecs = 2).use { doomed ->
+            DistributedReadWriteLock(client2, lockPath, leaseTtlSecs = 2).use { readerSide ->
+              val held = BooleanMonitor(false)
+              val writerThread =
+                thread {
+                  doomed.writeLock.lock()
+                  held.set(true)
+                  Thread.sleep(60_000)
+                }
+              held.waitUntilTrue(15.seconds) shouldBe true
+
+              val readerAcquired = BooleanMonitor(false)
+              val readerThread =
+                thread {
+                  readerSide.readLock.lock()
+                  readerAcquired.set(true)
+                  readerSide.readLock.unlock()
+                }
+              Thread.sleep(1_000) // let the reader queue behind the writer
+
+              EtcdTestContainer.pause()
+              try {
+                Thread.sleep(7_000) // well past the 2s TTL
+              } finally {
+                EtcdTestContainer.unpause()
+              }
+              EtcdTestContainer.awaitReady()
+
+              readerAcquired.waitUntilTrue(60.seconds) shouldBe true
+              pollUntil(30.seconds) { !doomed.writeLock.isHeldByCurrentThread } shouldBe true
+              writerThread.interrupt()
+              writerThread.join(10_000)
+              readerThread.join(10_000)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedReadWriteLockTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedReadWriteLockTests.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.common.blockingThreads
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getChildCount
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Fair (FIFO by create revision) read-write lock semantics: readers share, writers
+ * exclude, arrivals are honored in revision order (so writers cannot starve), and
+ * write-to-read downgrade works while read-to-write upgrade is rejected.
+ */
+class DistributedReadWriteLockTests : StringSpec() {
+  private val base = "/rwlock/${javaClass.simpleName}"
+
+  init {
+    "multiple readers hold concurrently" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/shared-readers"
+        val concurrent = AtomicInteger(0)
+        val maxConcurrent = AtomicInteger(0)
+
+        blockingThreads(4) {
+          connectToEtcd(urls) { c ->
+            DistributedReadWriteLock(c, path).use { rw ->
+              rw.readLock.withLock {
+                val now = concurrent.incrementAndGet()
+                maxConcurrent.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                Thread.sleep(500)
+                concurrent.decrementAndGet()
+              }
+            }
+          }
+        }
+        maxConcurrent.get() shouldBe 4
+      }
+    }
+
+    "a writer excludes readers and other writers" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/writer-excludes"
+        val inCritical = AtomicInteger(0)
+        val maxInCritical = AtomicInteger(0)
+        var unguarded = 0
+
+        blockingThreads(4) { i ->
+          connectToEtcd(urls) { c ->
+            DistributedReadWriteLock(c, path).use { rw ->
+              val lock = if (i % 2 == 0) rw.writeLock else rw.readLock
+              repeat(5) {
+                lock.withLock {
+                  if (i % 2 == 0) {
+                    val now = inCritical.incrementAndGet()
+                    maxInCritical.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                    unguarded += 1
+                    inCritical.decrementAndGet()
+                  } else {
+                    inCritical.get() shouldBe 0 // no writer while a reader holds
+                  }
+                }
+              }
+            }
+          }
+        }
+        maxInCritical.get() shouldBeLessThanOrEqual 1
+        unguarded shouldBe 10
+      }
+    }
+
+    "grants honor revision order: readers share, a queued writer splits them" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/fifo"
+        val grants = CopyOnWriteArrayList<String>()
+
+        DistributedReadWriteLock(client, path).use { gate ->
+          // An initial writer holds the lock while we stage arrivals behind it
+          val release = BooleanMonitor(false)
+          val gateHeld = BooleanMonitor(false)
+          val gateThread =
+            thread {
+              gate.writeLock.lock()
+              gateHeld.set(true)
+              release.waitUntilTrue()
+              gate.writeLock.unlock()
+            }
+          gateHeld.waitUntilTrue(15.seconds) shouldBe true
+
+          fun arrival(
+            name: String,
+            write: Boolean,
+            expectedEntries: Long,
+          ): Thread {
+            val t =
+              thread(name = name) {
+                connectToEtcd(urls) { c ->
+                  DistributedReadWriteLock(c, path).use { rw ->
+                    val lock = if (write) rw.writeLock else rw.readLock
+                    lock.withLock {
+                      grants += name
+                      Thread.sleep(400) // overlap window so concurrent readers interleave
+                    }
+                  }
+                }
+              }
+            // Stage deterministically: each arrival's entry appears under the prefix
+            pollUntil(15.seconds) { client.getChildCount(path) >= expectedEntries } shouldBe true
+            return t
+          }
+
+          val r1 = arrival("R1", write = false, expectedEntries = 2)
+          val r2 = arrival("R2", write = false, expectedEntries = 3)
+          val w1 = arrival("W1", write = true, expectedEntries = 4)
+          val r3 = arrival("R3", write = false, expectedEntries = 5)
+
+          release.set(true)
+          listOf(r1, r2, w1, r3).forEach { it.join(60_000) }
+          gateThread.join(10_000)
+
+          grants.size shouldBe 4
+          // R1 and R2 (both ahead of W1) share and finish before W1; R3 waits for W1
+          grants.subList(0, 2).toSet() shouldBe setOf("R1", "R2")
+          grants[2] shouldBe "W1"
+          grants[3] shouldBe "R3"
+        }
+      }
+    }
+
+    "read and write locks are reentrant per thread" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        DistributedReadWriteLock(client, "$base/reentrant").use { rw ->
+          rw.readLock.lock()
+          rw.readLock.lock()
+          rw.readLock.holdCount shouldBe 2
+          rw.readLock.unlock() shouldBe true
+          rw.readLock.unlock() shouldBe true
+          rw.readLock.holdCount shouldBe 0
+
+          rw.writeLock.lock()
+          rw.writeLock.lock()
+          rw.writeLock.holdCount shouldBe 2
+          rw.writeLock.unlock() shouldBe true
+          rw.writeLock.unlock() shouldBe true
+        }
+      }
+    }
+
+    "read to write upgrade throws; write to read downgrade is allowed" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        DistributedReadWriteLock(client, "$base/up-down").use { rw ->
+          rw.readLock.lock()
+          shouldThrow<io.etcd.recipes.common.EtcdRecipeRuntimeException> { rw.writeLock.lock() }
+          rw.readLock.unlock() shouldBe true
+
+          rw.writeLock.lock()
+          rw.readLock.tryLock(10.seconds) shouldBe true // downgrade: own write hold is excluded
+          rw.readLock.unlock() shouldBe true
+          rw.writeLock.unlock() shouldBe true
+        }
+      }
+    }
+
+    "tryLock times out promptly on both sides and leaves no entries behind" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/try-timeout"
+        connectToEtcd(urls) { client2 ->
+          DistributedReadWriteLock(client, path).use { holder ->
+            DistributedReadWriteLock(client2, path).use { contender ->
+              val release = BooleanMonitor(false)
+              val held = BooleanMonitor(false)
+              val holderThread =
+                thread {
+                  holder.writeLock.lock()
+                  held.set(true)
+                  release.waitUntilTrue()
+                  holder.writeLock.unlock()
+                }
+              held.waitUntilTrue(15.seconds) shouldBe true
+
+              contender.readLock.tryLock(2.seconds) shouldBe false
+              contender.writeLock.tryLock(2.seconds) shouldBe false
+              // Timed-out attempts must leave nothing: only the holder's entry remains
+              pollUntil(10.seconds) { client.getChildCount(path) == 1L } shouldBe true
+
+              release.set(true)
+              holderThread.join(10_000)
+              contender.writeLock.tryLock(10.seconds) shouldBe true
+              contender.writeLock.unlock() shouldBe true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/ReadWriteLockLostTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/ReadWriteLockLostTests.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Lock-lost semantics for the read-write lock, driven by revoking entry leases
+ * out-of-band: a lost holder unblocks its queued conflicts, and a lost waiter
+ * re-queues with a fresh entry.
+ */
+class ReadWriteLockLostTests : StringSpec() {
+  private val base = "/rwlock/${javaClass.simpleName}"
+
+  private fun revokeEntryLease(
+    client: Client,
+    lockPath: String,
+    basenamePrefix: String,
+  ) {
+    val kvs = client.getResponse(lockPath, getOption { isPrefix(true) }).kvs
+    val entry = kvs.first { it.key.asString.substringAfterLast('/').startsWith(basenamePrefix) }
+    (entry.lease > 0L) shouldBe true
+    client.leaseClient.revoke(entry.lease).get()
+  }
+
+  init {
+    "a lost writer hold unblocks queued readers and fires the listener" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/writer-lost"
+        val lost = CopyOnWriteArrayList<Throwable?>()
+
+        connectToEtcd(urls) { client2 ->
+          DistributedReadWriteLock(client, path).use { doomed ->
+            DistributedReadWriteLock(client2, path).use { readerSide ->
+              doomed.writeLock.addLockLostListener { cause -> lost += cause }
+              val held = BooleanMonitor(false)
+              val writerThread =
+                thread {
+                  doomed.writeLock.lock()
+                  held.set(true)
+                  Thread.sleep(30_000)
+                }
+              held.waitUntilTrue(15.seconds) shouldBe true
+
+              val readerAcquired = BooleanMonitor(false)
+              val readerThread =
+                thread {
+                  readerSide.readLock.lock()
+                  readerAcquired.set(true)
+                  readerSide.readLock.unlock()
+                }
+              // reader queued behind the writer
+              pollUntil(15.seconds) {
+                client.getResponse(path, getOption { isPrefix(true) }).kvs.size == 2
+              } shouldBe true
+              readerAcquired.get() shouldBe false
+
+              revokeEntryLease(client, path, "write-")
+
+              readerAcquired.waitUntilTrue(20.seconds) shouldBe true
+              pollUntil(10.seconds) { lost.size == 1 } shouldBe true
+              writerThread.interrupt()
+              writerThread.join(10_000)
+              readerThread.join(10_000)
+            }
+          }
+        }
+      }
+    }
+
+    "a waiter revoked mid-wait re-queues and still acquires" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/waiter-revoked"
+        connectToEtcd(urls) { client2 ->
+          DistributedReadWriteLock(client, path).use { holder ->
+            DistributedReadWriteLock(client2, path).use { waiterSide ->
+              val release = BooleanMonitor(false)
+              val held = BooleanMonitor(false)
+              val holderThread =
+                thread {
+                  holder.writeLock.lock()
+                  held.set(true)
+                  release.waitUntilTrue()
+                  holder.writeLock.unlock()
+                }
+              held.waitUntilTrue(15.seconds) shouldBe true
+
+              val acquired = BooleanMonitor(false)
+              val waiterThread =
+                thread {
+                  waiterSide.writeLock.lock()
+                  acquired.set(true)
+                  waiterSide.writeLock.unlock()
+                }
+              pollUntil(15.seconds) {
+                client.getResponse(path, getOption { isPrefix(true) }).kvs.size == 2
+              } shouldBe true
+
+              // Kill the WAITER's entry lease (the later create revision)
+              val waiterKv =
+                client.getResponse(path, getOption { isPrefix(true) })
+                  .kvs.maxByOrNull { it.createRevision }!!
+              client.leaseClient.revoke(waiterKv.lease).get()
+
+              // The waiter recovers: a fresh entry appears
+              pollUntil(20.seconds) {
+                client.getResponse(path, getOption { isPrefix(true) }).kvs.size == 2
+              } shouldBe true
+
+              release.set(true)
+              acquired.waitUntilTrue(30.seconds) shouldBe true
+              holderThread.join(10_000)
+              waiterThread.join(10_000)
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Second PR of the distributed lock suite ([product idea #1](https://github.com/pambrose/etcd-recipes/pull/58)); builds on the `EtcdLock` / `AcquisitionLease` foundation from #58.

## What's new

**`DistributedReadWriteLock`** — a fair (FIFO by create revision) shared/exclusive lock:

- `rw.readLock` / `rw.writeLock` both implement the `EtcdLock` surface from #58: `lock()`, `tryLock(timeout)`, `unlock()`, reentrancy via per-thread hold counts, `withLock { }`, and `LockLostListener`.
- Each acquisition places a lease-bound `read-`/`write-` entry under the lock prefix. Readers are admitted when no earlier live `write-` entry exists (excluding the calling thread's own write hold, so **write→read downgrade** works); writers require no earlier entry at all. Grants are FIFO — a queued writer is never starved by later readers.
- Waiters watch only their **nearest conflicting predecessor's** key for deletion (herd-free), with pre-live gap recheck and watch-recovery rechecks via the new internal `WaiterSupport` helper (reused by the upcoming semaphore PR).
- **Read→write upgrade throws** (it would self-deadlock). `tryLock` timeouts revoke the waiter's own entry, so no stale queue entries leak.
- Lost holds are cooperative, matching the mutex: bookkeeping, listener callbacks, `ConnectionState.LOST`, `unlock() == false`, opt-in `interruptOnLockLoss`.

## Test infrastructure fix

`EtcdTestContainer` now retries container startup with a freshly probed host port when Docker reports `port is already allocated` — the probe-then-bind fixed-port scheme (needed for restart-stable endpoints in fault tests) raced under parallel test forks.

## Testing

- `DistributedReadWriteLockTests` — concurrent readers share (max-concurrency tracker), writer excludes, staged R,R,W,R grants honor revision order, per-side reentrancy, upgrade throws / downgrade works, `tryLock` timeout leaves no entries.
- `ReadWriteLockLostTests` — lost writer hold unblocks queued readers and fires the listener; a waiter revoked mid-wait re-queues and still acquires (out-of-band lease revocation).
- `ReadWriteLockFaultTests` — a partitioned writer (container pause > TTL) loses the lock and queued readers acquire.
- Full Testcontainers gate: **269 passed, 0 failed**; lint/detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP