### PR TITLE
Add DistributedSemaphore: distributed counting semaphore with permit-lost awareness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (locks: semaphore)
+
+- `DistributedSemaphore` — distributed counting semaphore: the canonical permit
+  count is CAS-created at the semaphore path and validated by every instance
+  (mismatch throws `SemaphorePermitMismatchException` naming both values);
+  lease-bound holder entries are admitted by create-revision rank, so capacity
+  is provably never exceeded and grants are FIFO. Java-`Semaphore`-style
+  instance-level holds: any thread may `release()` (LIFO among the instance's
+  holds), acquisitions are never reentrant, and `withPermit { }` scopes a
+  permit. Cooperative permit-lost semantics (`PermitLostListener`,
+  `ConnectionState.LOST`, `release()` returns false, opt-in
+  `interruptOnPermitLoss`) and leak-free `tryAcquire(timeout)` match the rest
+  of the lock suite.
+- `EtcdRecipeRuntimeException` is now `open`, so library exception subtypes
+  (like `SemaphorePermitMismatchException`) stay catchable as the base type.
+
 ### Added (locks: read-write lock)
 
 - `DistributedReadWriteLock` — fair (FIFO by create revision) shared/exclusive

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ what [Curator](https://curator.apache.org) provides for [ZooKeeper](https://zook
 | `io.etcd.recipes.discovery` | `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`, `ServiceProvider` |
 | `io.etcd.recipes.election` | `LeaderSelector`, `LeaderSelectorListener`, `Participant` |
 | `io.etcd.recipes.keyvalue` | `TransientKeyValue` (lease-backed key/value) |
-| `io.etcd.recipes.lock` | `DistributedMutex`, `DistributedReadWriteLock` |
+| `io.etcd.recipes.lock` | `DistributedMutex`, `DistributedReadWriteLock`, `DistributedSemaphore` |
 | `io.etcd.recipes.queue` | `DistributedQueue`, `DistributedPriorityQueue`, `DistributedWorkQueue` (at-least-once) |
 | `io.etcd.recipes.common` | Kotlin extensions over jetcd `Client`, `KV`, `Lease`, `Watch`, `Txn` |
 
@@ -108,6 +108,15 @@ surface (`rw.readLock` / `rw.writeLock`, both `EtcdLock`s): readers share,
 writers exclude, and grants are **fair** — FIFO by arrival revision, so a queued
 writer is never starved by later readers. Write→read downgrade is supported;
 read→write upgrade throws (it would self-deadlock).
+
+`DistributedSemaphore` caps concurrency across processes with a counting
+semaphore (`acquire()` / `tryAcquire(timeout)` / `release()` /
+`withPermit { }`). The permit count is stored once at the semaphore path and
+validated by every instance, grants are FIFO, and capacity is never exceeded.
+Holds are instance-level, Java-`Semaphore`-style: any thread may release
+(releases are LIFO among the instance's holds), and a permit whose lease
+expires is lost cooperatively — a `PermitLostListener` fires and the matching
+`release()` returns false.
 
 ## Reliable work queue
 

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/lock/SemaphoreExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/lock/SemaphoreExample.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.lock
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.lock.DistributedSemaphore
+import io.etcd.recipes.lock.withPermit
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+
+/**
+ * Demonstrates the counting semaphore: six workers contend for two permits, so
+ * at most two are ever inside the guarded section at once, admitted in arrival
+ * order.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val semaphorePath = "/semaphores/example"
+  val inFlight = AtomicInteger(0)
+
+  val workers =
+    (1..6).map { worker ->
+      thread {
+        connectToEtcd(urls) { client ->
+          DistributedSemaphore(client, semaphorePath, permits = 2).use { semaphore ->
+            semaphore.withPermit {
+              val now = inFlight.incrementAndGet()
+              logger.info { "Worker $worker holds a permit ($now of 2 in flight)" }
+              Thread.sleep(500)
+              inFlight.decrementAndGet()
+            }
+          }
+        }
+      }
+    }
+  workers.forEach { it.join() }
+  logger.info { "All workers finished" }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdRecipeRuntimeException.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdRecipeRuntimeException.kt
@@ -18,7 +18,7 @@
 
 package io.etcd.recipes.common
 
-class EtcdRecipeRuntimeException
+open class EtcdRecipeRuntimeException
   @JvmOverloads
   constructor(
     msg: String,

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
@@ -1,0 +1,393 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import com.pambrose.common.time.timeUnitToDuration
+import com.pambrose.common.util.randomId
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.options.GetOption
+import io.etcd.recipes.common.EtcdConnector
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.doesNotExist
+import io.etcd.recipes.common.getChildCount
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.getValue
+import io.etcd.recipes.common.putOption
+import io.etcd.recipes.common.setTo
+import io.etcd.recipes.common.transaction
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.time.ComparableTimeMark
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/** Notified when a held permit's lease expires (crash/partition) and the permit is lost. */
+fun interface PermitLostListener {
+  fun onPermitLost(cause: Throwable?)
+}
+
+/**
+ * Thrown on first use when the canonical permit count stored at the semaphore
+ * path disagrees with the count this instance was constructed with.
+ */
+class SemaphorePermitMismatchException(
+  val semaphorePath: String,
+  val requestedPermits: Int,
+  val canonicalPermits: Int,
+) : EtcdRecipeRuntimeException(
+    "Semaphore at $semaphorePath already exists with $canonicalPermits permits; " +
+      "this instance requested $requestedPermits",
+  )
+
+/**
+ * A distributed counting semaphore. The canonical permit count is CAS-created at
+ * `<semaphorePath>/permits` on first use and validated by every later instance
+ * (mismatch throws [SemaphorePermitMismatchException]). Each acquisition places a
+ * lease-bound entry under `<semaphorePath>/holders/`; an entry holds a permit iff
+ * its create-revision rank is below the permit count — rank only shrinks while an
+ * entry lives, so capacity is provably never exceeded and grants are FIFO.
+ *
+ * Unlike [EtcdLock], holds are instance-level, Java-`Semaphore`-style: any thread
+ * may [release], releases are LIFO among this instance's holds, and acquisitions
+ * are never reentrant (each [acquire] consumes a fresh permit). A permit whose
+ * lease expires is lost **cooperatively**: capacity frees server-side, listeners
+ * fire, connection state reports LOST, and the matching [release] returns false
+ * (interruption of the acquiring thread is opt-in via `interruptOnPermitLoss`).
+ *
+ * Waiters watch the holders prefix for any DELETE and re-evaluate their rank —
+ * rank admission has no single predecessor key, so a prefix watch is the only
+ * sound wakeup (a nearest-predecessor watch can miss multi-departure windows).
+ */
+class DistributedSemaphore
+  @JvmOverloads
+  constructor(
+    client: Client,
+    val semaphorePath: String,
+    val permits: Int,
+    val leaseTtlSecs: Long = DEFAULT_TTL_SECS,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+    val clientId: String = defaultClientId(DistributedSemaphore::class.simpleName!!),
+    private val interruptOnPermitLoss: Boolean = false,
+  ) : EtcdConnector(client, resilience) {
+  private enum class Phase { WAITING, HOLDING, DEAD }
+
+  private class PermitData(
+    val lease: AcquisitionLease,
+    val entryKey: String,
+    val owner: Thread,
+  )
+
+  // One in-flight acquisition; the phase machine arbitrates fatal-vs-win exactly
+  // like DistributedMutex's.
+  private class Attempt(
+    val owner: Thread,
+    val entryKey: String,
+  ) {
+    val phase = AtomicReference(Phase.WAITING)
+    val wake = java.util.concurrent.atomic.AtomicReference<CountDownLatch?>(null)
+
+    @Volatile
+    var holdData: PermitData? = null
+  }
+
+  private val holds = ConcurrentLinkedDeque<PermitData>()
+  private val dispossessedCount = AtomicInteger(0)
+  private val lostListeners = CopyOnWriteArrayList<PermitLostListener>()
+  private val attempts = CopyOnWriteArrayList<Attempt>()
+  private val permitsValidated = AtomicBoolean(false)
+
+  private val permitsKey = "$semaphorePath/permits"
+  private val holdersPath = "$semaphorePath/holders"
+
+  init {
+    require(semaphorePath.isNotEmpty()) { "Semaphore path cannot be empty" }
+    require(permits >= 1) { "Permits must be >= 1: $permits" }
+    require(leaseTtlSecs > 0) { "Lease TTL must be > 0" }
+  }
+
+  fun acquire() {
+    check(acquireInternal(null)) { "unbounded acquisition returned without a permit" }
+  }
+
+  fun tryAcquire(timeout: Duration): Boolean {
+    require(timeout > Duration.ZERO) { "Timeout must be positive: $timeout" }
+    return acquireInternal(TimeSource.Monotonic.markNow() + timeout)
+  }
+
+  fun tryAcquire(
+    timeout: Long,
+    timeUnit: TimeUnit,
+  ): Boolean = tryAcquire(timeUnitToDuration(timeout, timeUnit))
+
+  /**
+   * Releases this instance's most recently acquired live permit (LIFO). Returns
+   * false when the consumed hold had already been lost or released by close();
+   * throws [IllegalStateException] when this instance holds nothing at all.
+   */
+  fun release(): Boolean {
+    val data = holds.pollFirst()
+    if (data != null) {
+      data.lease.close() // revoke deletes the entry, waking waiters
+      return true
+    }
+    while (true) {
+      val slots = dispossessedCount.get()
+      if (slots <= 0) break
+      if (dispossessedCount.compareAndSet(slots, slots - 1)) {
+        logger.debug { "release() on $semaphorePath after the permit was lost or released by close()" }
+        return false
+      }
+    }
+    throw IllegalStateException("No permit is held on $semaphorePath by this instance")
+  }
+
+  /** Advisory: permits minus live holder/waiter entries, floored at zero. */
+  fun availablePermits(): Int {
+    checkCloseNotCalled()
+    validatePermits()
+    val entries = client.getChildCount(holdersPath, resilience.rpc).toInt()
+    return (permits - entries).coerceAtLeast(0)
+  }
+
+  fun addPermitLostListener(listener: PermitLostListener) {
+    lostListeners += listener
+  }
+
+  fun removePermitLostListener(listener: PermitLostListener) {
+    lostListeners -= listener
+  }
+
+  // CAS-create the canonical count, or verify it matches; once per instance.
+  // The ctor stays RPC-free like every recipe, so this runs lazily on first use.
+  private fun validatePermits() {
+    if (permitsValidated.load()) return
+    var canonical = -1
+    while (canonical == -1) {
+      // -1 = key deleted between the failed CAS and the read; CAS again
+      val txn =
+        client.transaction(resilience.rpc) {
+          If(permitsKey.doesNotExist)
+          Then(permitsKey setTo permits)
+        }
+      canonical = if (txn.isSucceeded) permits else client.getValue(permitsKey, -1, resilience.rpc)
+    }
+    if (canonical != permits) {
+      throw SemaphorePermitMismatchException(semaphorePath, permits, canonical)
+    }
+    permitsValidated.store(true)
+  }
+
+  @Suppress(
+    "ReturnCount",
+    "LoopWithTooManyJumpStatements",
+    "LongMethod",
+    "CyclomaticComplexMethod",
+    "NestedBlockDepth",
+  )
+  private fun acquireInternal(deadline: ComparableTimeMark?): Boolean {
+    checkCloseNotCalled()
+    validatePermits()
+    val me = Thread.currentThread()
+
+    outer@ while (true) {
+      checkCloseNotCalled()
+      if (deadline != null && deadline.hasPassedNow()) return false
+
+      val entryKey = "$holdersPath/$clientId:${randomId(TOKEN_LENGTH)}"
+      val attempt = Attempt(me, entryKey)
+      val lease =
+        AcquisitionLease(
+          client,
+          leaseTtlSecs,
+          resilience.rpc,
+          onTransient = { e ->
+            exceptionList.value += e
+            reportLeaseEvent(LeaseEvent.Suspended(-1L, e))
+          },
+          onFatal = { cause -> onEntryFatal(attempt, cause) },
+        )
+      attempts += attempt
+      var acquired = false
+      try {
+        val txn =
+          client.transaction(resilience.rpc) {
+            If(entryKey.doesNotExist)
+            Then(entryKey.setTo(clientId, putOption { withLeaseId(lease.leaseId) }))
+          }
+        if (!txn.isSucceeded) {
+          // Random-suffix collision: effectively impossible; pace and retry
+          Thread.sleep(LEASE_HEAL_PAUSE_MS)
+          continue@outer
+        }
+
+        while (true) {
+          if (attempt.phase.load() == Phase.DEAD) {
+            Thread.sleep(LEASE_HEAL_PAUSE_MS)
+            continue@outer // fresh entry at the tail
+          }
+          if (deadline != null && deadline.hasPassedNow()) return false
+
+          val rank = rankOf(entryKey)
+            ?: run {
+              // Own entry gone: the lease died in the window
+              Thread.sleep(LEASE_HEAL_PAUSE_MS)
+              continue@outer
+            }
+          if (rank < permits) {
+            // Admitted: publish the hold BEFORE claiming the phase (a fatal in
+            // the win window must always find the hold — or the CAS failure
+            // below rolls it back).
+            val data = PermitData(lease, entryKey, me)
+            attempt.holdData = data
+            holds.addFirst(data)
+            if (attempt.phase.compareAndSet(Phase.WAITING, Phase.HOLDING)) {
+              acquired = true
+              return true
+            }
+            holds.remove(data)
+            Thread.sleep(LEASE_HEAL_PAUSE_MS)
+            continue@outer
+          }
+
+          val latch = CountDownLatch(1)
+          attempt.wake.set(latch)
+          if (attempt.phase.load() == Phase.DEAD) latch.countDown() // fatal raced the install
+          WaiterSupport.awaitPrefixDeletion(
+            client,
+            "$holdersPath/",
+            resilience,
+            latch,
+            deadline,
+            shouldWake = {
+              val now = rankOf(entryKey)
+              now == null || now < permits
+            },
+            reportRecovery = { event -> reportRecoveryEvent(event) },
+            recordException = { e -> exceptionList.value += e },
+          )
+          attempt.wake.set(null)
+          // Loop: re-evaluate the rank (it only shrinks while the entry lives)
+        }
+      } finally {
+        attempts -= attempt
+        if (!acquired) {
+          // Revoke deletes the entry (safe on an already-dead lease), waking waiters
+          lease.close()
+        }
+      }
+      @Suppress("UNREACHABLE_CODE")
+      error("unreachable")
+    }
+  }
+
+  // Create-revision rank of the entry within one consistent prefix snapshot;
+  // null once the entry no longer exists (its lease died).
+  private fun rankOf(entryKey: String): Int? {
+    val snapshot =
+      client.getResponse(
+        "$holdersPath/",
+        getOption {
+          isPrefix(true)
+          withSortField(GetOption.SortTarget.CREATE)
+          withSortOrder(GetOption.SortOrder.ASCEND)
+        },
+        resilience.rpc,
+      )
+    val idx = snapshot.kvs.indexOfFirst { it.key.asString == entryKey }
+    return if (idx < 0) null else idx
+  }
+
+  // Runs on jetcd's lease callback thread — no blocking RPCs here. The phase
+  // machine guarantees exactly one of {waiter-abort, permitLost} runs.
+  private fun onEntryFatal(
+    attempt: Attempt,
+    cause: Throwable?,
+  ) {
+    if (attempt.phase.compareAndSet(Phase.WAITING, Phase.DEAD)) {
+      exceptionList.value += (
+        cause ?: EtcdRecipeRuntimeException("Semaphore entry lease expired while waiting on $semaphorePath")
+      )
+      attempt.wake.get()?.countDown()
+    } else if (attempt.phase.load() == Phase.HOLDING) {
+      permitLost(attempt, cause)
+    }
+  }
+
+  @Suppress("TooGenericExceptionCaught")
+  private fun permitLost(
+    attempt: Attempt,
+    cause: Throwable?,
+  ) {
+    val data = attempt.holdData ?: return
+    if (!holds.remove(data)) return // already released, or close() took it
+    dispossessedCount.incrementAndGet()
+    logger.warn(cause) { "Permit on $semaphorePath lost by $clientId (lease expired)" }
+    exceptionList.value += (cause ?: EtcdRecipeRuntimeException("Permit lease for $semaphorePath expired; permit lost"))
+    reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
+    lostListeners.forEach { listener ->
+      try {
+        listener.onPermitLost(cause)
+      } catch (e: Throwable) {
+        logger.error(e) { "Exception in permit-lost listener" }
+        exceptionList.value += e
+      }
+    }
+    if (interruptOnPermitLoss) attempt.owner.interrupt()
+    data.lease.closeWithoutRevoke() // lease already gone; no RPC on this thread
+  }
+
+  override fun doClose() {
+    while (true) {
+      val data = holds.pollFirst() ?: break
+      dispossessedCount.incrementAndGet()
+      data.lease.close()
+    }
+    attempts.toList().forEach { attempt ->
+      if (attempt.phase.compareAndSet(Phase.WAITING, Phase.DEAD)) {
+        attempt.wake.get()?.countDown()
+      }
+    }
+    lostListeners.clear()
+  }
+
+  companion object {
+    private val logger = KotlinLogging.logger {}
+    private const val LEASE_HEAL_PAUSE_MS = 250L
+  }
+}
+
+/** Runs [block] while holding a permit, releasing it on every exit path. */
+inline fun <T> DistributedSemaphore.withPermit(block: () -> T): T {
+  acquire()
+  try {
+    return block()
+  } finally {
+    release()
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/WaiterSupport.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/WaiterSupport.kt
@@ -19,6 +19,7 @@
 package io.etcd.recipes.lock
 
 import io.etcd.jetcd.Client
+import io.etcd.jetcd.options.WatchOption
 import io.etcd.jetcd.watch.WatchEvent
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
 import io.etcd.recipes.common.ResilienceConfig
@@ -34,20 +35,73 @@ import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
 
 /**
- * Shared wait-on-predecessor machinery for the hand-rolled locks (read-write lock,
- * semaphore): parks on [latch] until [key] is DELETEd (or found already absent —
- * the pre-live gap and every recovery are re-checked), someone else counts the
- * latch down (lease-fatal, close), or the deadline passes. Watch failures unpark
- * and throw. Follows the queue/barrier watcher discipline: recheck RPCs run on
- * the watch dispatcher thread, never on jetcd's event loop.
+ * Shared wait-on-DELETE machinery for the hand-rolled locks (read-write lock,
+ * semaphore): parks on [CountDownLatch] until a DELETE fires (or [shouldWake]
+ * says the predicate already holds — the pre-live gap and every recovery are
+ * re-checked), someone else counts the latch down (lease-fatal, close), or the
+ * deadline passes. Watch failures unpark and throw. Follows the queue/barrier
+ * watcher discipline: recheck RPCs run on the watch dispatcher thread, never on
+ * jetcd's event loop.
  */
 internal object WaiterSupport {
+  /** Waits for the DELETE of exactly [key]; the wake predicate is key absence. */
   fun awaitKeyDeletion(
     client: Client,
     key: String,
     resilience: ResilienceConfig,
     latch: CountDownLatch,
     deadline: ComparableTimeMark?,
+    reportRecovery: (WatchRecoveryEvent) -> Unit,
+    recordException: (Throwable) -> Unit,
+  ) = await(
+    client,
+    key,
+    watchOption { withNoPut(true) },
+    resilience,
+    latch,
+    deadline,
+    shouldWake = { client.isKeyNotPresent(key, resilience.rpc) },
+    reportRecovery,
+    recordException,
+  )
+
+  /**
+   * Waits for ANY DELETE under [prefix] — rank-based admission (the semaphore)
+   * cannot watch a single predecessor, so every deletion wakes the waiter and
+   * [shouldWake] re-evaluates the full predicate on the pre-live gap and after
+   * each recovery. Spurious wakes are safe: callers loop and re-check.
+   */
+  @Suppress("LongParameterList")
+  fun awaitPrefixDeletion(
+    client: Client,
+    prefix: String,
+    resilience: ResilienceConfig,
+    latch: CountDownLatch,
+    deadline: ComparableTimeMark?,
+    shouldWake: () -> Boolean,
+    reportRecovery: (WatchRecoveryEvent) -> Unit,
+    recordException: (Throwable) -> Unit,
+  ) = await(
+    client,
+    prefix,
+    watchOption { withNoPut(true).isPrefix(true) },
+    resilience,
+    latch,
+    deadline,
+    shouldWake,
+    reportRecovery,
+    recordException,
+  )
+
+  @Suppress("LongParameterList")
+  private fun await(
+    client: Client,
+    watchKey: String,
+    option: WatchOption,
+    resilience: ResilienceConfig,
+    latch: CountDownLatch,
+    deadline: ComparableTimeMark?,
+    shouldWake: () -> Boolean,
     reportRecovery: (WatchRecoveryEvent) -> Unit,
     recordException: (Throwable) -> Unit,
   ) {
@@ -57,12 +111,12 @@ internal object WaiterSupport {
         reportRecovery(event)
         when (event) {
           is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
-            // The DELETE may have been lost while the stream was dead
-            if (client.isKeyNotPresent(key, resilience.rpc)) latch.countDown()
+            // A DELETE may have been lost while the stream was dead
+            if (shouldWake()) latch.countDown()
           }
 
           is WatchRecoveryEvent.Failed -> {
-            val cause = event.cause ?: EtcdRecipeRuntimeException("Watch on $key abandoned while waiting")
+            val cause = event.cause ?: EtcdRecipeRuntimeException("Watch on $watchKey abandoned while waiting")
             failure.set(cause)
             recordException(cause)
             latch.countDown()
@@ -75,8 +129,8 @@ internal object WaiterSupport {
       }
 
     client.withWatcher(
-      key,
-      watchOption { withNoPut(true) },
+      watchKey,
+      option,
       resilience.watch,
       recoveryListener,
       resyncWith = null,
@@ -84,8 +138,8 @@ internal object WaiterSupport {
         if (watchResponse.events.any { it.eventType == WatchEvent.EventType.DELETE }) latch.countDown()
       },
     ) {
-      // Pre-live gap: the key may have been deleted before the watch went live
-      if (latch.count > 0 && client.isKeyNotPresent(key, resilience.rpc)) latch.countDown()
+      // Pre-live gap: the awaited DELETE may have landed before the watch went live
+      if (latch.count > 0 && shouldWake()) latch.countDown()
       if (deadline == null) {
         latch.await()
       } else {
@@ -95,7 +149,7 @@ internal object WaiterSupport {
         }
       }
       failure.get()?.let { cause ->
-        throw EtcdRecipeRuntimeException("Lock watch on $key failed while waiting", cause)
+        throw EtcdRecipeRuntimeException("Lock watch on $watchKey failed while waiting", cause)
       }
     }
   }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/SemaphoreFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/SemaphoreFaultTests.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.common.EtcdTestContainer
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.lock.DistributedSemaphore
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Real partition: a permit holder paused longer than its lease TTL loses the
+ * permit, and a queued waiter acquires once the cluster is reachable again.
+ */
+class SemaphoreFaultTests : StringSpec() {
+  private val path = "/fault/${javaClass.simpleName}"
+
+  init {
+    "a partitioned holder loses its permit and a queued waiter acquires" {
+      assumeFaultInjection()
+      connectToEtcd(urls) { client ->
+        val semPath = "$path/partition"
+        connectToEtcd(urls) { client2 ->
+          DistributedSemaphore(client, semPath, 1, leaseTtlSecs = 2).use { doomed ->
+            DistributedSemaphore(client2, semPath, 1, leaseTtlSecs = 2).use { successor ->
+              doomed.acquire()
+
+              val acquired = BooleanMonitor(false)
+              val waiter =
+                thread {
+                  successor.acquire()
+                  acquired.set(true)
+                  successor.release()
+                }
+              Thread.sleep(1_000) // let the waiter queue behind the holder
+
+              EtcdTestContainer.pause()
+              try {
+                Thread.sleep(7_000) // well past the 2s TTL
+              } finally {
+                EtcdTestContainer.unpause()
+              }
+              EtcdTestContainer.awaitReady()
+
+              acquired.waitUntilTrue(60.seconds) shouldBe true
+              waiter.join(10_000)
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedSemaphoreTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedSemaphoreTests.kt
@@ -1,0 +1,284 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.common.blockingThreads
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getChildCount
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Counting-semaphore semantics: capacity is never exceeded, grants are FIFO by
+ * arrival revision, releases are LIFO among this instance's holds, timeouts leak
+ * no queue entries, and the canonical permit count is validated on first use.
+ */
+class DistributedSemaphoreTests : StringSpec() {
+  private val base = "/semaphore/${javaClass.simpleName}"
+
+  init {
+    "capacity is never exceeded under contention" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/capacity"
+        val inFlight = AtomicInteger(0)
+        val maxInFlight = AtomicInteger(0)
+        val completions = AtomicInteger(0)
+
+        blockingThreads(8) {
+          connectToEtcd(urls) { c ->
+            DistributedSemaphore(c, path, 3).use { sem ->
+              sem.withPermit {
+                val now = inFlight.incrementAndGet()
+                maxInFlight.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                Thread.sleep(300)
+                inFlight.decrementAndGet()
+                completions.incrementAndGet()
+              }
+            }
+          }
+        }
+        maxInFlight.get() shouldBeLessThanOrEqual 3
+        completions.get() shouldBe 8
+      }
+    }
+
+    "grants are FIFO by arrival order" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/fifo"
+        val holdersPath = "$path/holders"
+        val grants = CopyOnWriteArrayList<String>()
+
+        DistributedSemaphore(client, path, 1).use { gate ->
+          val release = BooleanMonitor(false)
+          val gateHeld = BooleanMonitor(false)
+          val gateThread =
+            thread {
+              gate.acquire()
+              gateHeld.set(true)
+              release.waitUntilTrue()
+              gate.release()
+            }
+          gateHeld.waitUntilTrue(15.seconds) shouldBe true
+
+          // Stage each waiter deterministically: its queue entry must exist
+          // before the next arrival is launched
+          fun arrival(
+            name: String,
+            expectedCount: Long,
+          ): Thread {
+            val t =
+              thread {
+                connectToEtcd(urls) { c ->
+                  DistributedSemaphore(c, path, 1).use { sem ->
+                    sem.acquire()
+                    grants += name
+                    Thread.sleep(200)
+                    sem.release()
+                  }
+                }
+              }
+            pollUntil(15.seconds) { client.getChildCount(holdersPath) == expectedCount } shouldBe true
+            return t
+          }
+
+          val w1 = arrival("w1", 2)
+          val w2 = arrival("w2", 3)
+
+          release.set(true)
+          gateThread.join(10_000)
+          w1.join(15_000)
+          w2.join(15_000)
+          grants.toList() shouldBe listOf("w1", "w2")
+        }
+      }
+    }
+
+    "release frees the most recently acquired permit first" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/lifo"
+        val holdersPath = "$path/holders"
+
+        DistributedSemaphore(client, path, 2).use { sem ->
+          sem.acquire()
+          val firstRev =
+            client.getResponse(holdersPath, getOption { isPrefix(true) }).kvs.single().createRevision
+          sem.acquire()
+          client.getChildCount(holdersPath) shouldBe 2L
+
+          sem.release() shouldBe true
+          val remaining = client.getResponse(holdersPath, getOption { isPrefix(true) }).kvs.single()
+          remaining.createRevision shouldBe firstRev
+          sem.release() shouldBe true
+        }
+      }
+    }
+
+    "tryAcquire times out promptly and leaves no waiter entry" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/timeout"
+        val holdersPath = "$path/holders"
+
+        DistributedSemaphore(client, path, 1).use { holder ->
+          holder.acquire()
+          connectToEtcd(urls) { client2 ->
+            DistributedSemaphore(client2, path, 1).use { contender ->
+              contender.tryAcquire(2.seconds) shouldBe false
+              client.getChildCount(holdersPath) shouldBe 1L
+
+              holder.release() shouldBe true
+              contender.tryAcquire(10.seconds) shouldBe true
+              contender.release() shouldBe true
+            }
+          }
+        }
+      }
+    }
+
+    "tryAcquire succeeds when a permit frees within the timeout" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/timely"
+
+        DistributedSemaphore(client, path, 1).use { holder ->
+          holder.acquire()
+          val releaser =
+            thread {
+              Thread.sleep(1_000)
+              holder.release()
+            }
+          connectToEtcd(urls) { client2 ->
+            DistributedSemaphore(client2, path, 1).use { contender ->
+              contender.tryAcquire(15.seconds) shouldBe true
+              contender.release() shouldBe true
+            }
+          }
+          releaser.join(10_000)
+        }
+      }
+    }
+
+    "release without a hold throws IllegalStateException" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        DistributedSemaphore(client, "$base/none", 1).use { sem ->
+          shouldThrow<IllegalStateException> { sem.release() }
+        }
+      }
+    }
+
+    "withPermit releases the permit when the block throws" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/with-permit"
+        val holdersPath = "$path/holders"
+
+        DistributedSemaphore(client, path, 1).use { sem ->
+          shouldThrow<IllegalArgumentException> {
+            sem.withPermit { throw IllegalArgumentException("boom") }
+          }
+          client.getChildCount(holdersPath) shouldBe 0L
+          sem.availablePermits() shouldBe 1
+        }
+      }
+    }
+
+    "mismatched permit counts fail on first use naming both values" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/mismatch"
+
+        DistributedSemaphore(client, path, 2).use { first ->
+          first.acquire()
+          connectToEtcd(urls) { client2 ->
+            DistributedSemaphore(client2, path, 3).use { second ->
+              val e = shouldThrow<SemaphorePermitMismatchException> { second.acquire() }
+              e.requestedPermits shouldBe 3
+              e.canonicalPermits shouldBe 2
+            }
+          }
+          first.release() shouldBe true
+        }
+      }
+    }
+
+    "availablePermits tracks holds" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/available"
+
+        DistributedSemaphore(client, path, 2).use { sem ->
+          sem.availablePermits() shouldBe 2
+          sem.acquire()
+          sem.availablePermits() shouldBe 1
+          sem.acquire()
+          sem.availablePermits() shouldBe 0
+          sem.release() shouldBe true
+          sem.availablePermits() shouldBe 1
+          sem.release() shouldBe true
+          sem.availablePermits() shouldBe 2
+        }
+      }
+    }
+
+    "close releases all held permits and later release returns false" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/close"
+        val holdersPath = "$path/holders"
+
+        val holder = DistributedSemaphore(client, path, 1)
+        holder.acquire()
+        connectToEtcd(urls) { client2 ->
+          DistributedSemaphore(client2, path, 1).use { successor ->
+            val acquired = BooleanMonitor(false)
+            val waiter =
+              thread {
+                successor.acquire()
+                acquired.set(true)
+                successor.release()
+              }
+            pollUntil(15.seconds) { client.getChildCount(holdersPath) == 2L } shouldBe true
+
+            holder.close()
+
+            acquired.waitUntilTrue(20.seconds) shouldBe true
+            waiter.join(10_000)
+          }
+        }
+        holder.release() shouldBe false
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/SemaphorePermitLostTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/SemaphorePermitLostTests.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getChildCount
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Permit-lost semantics driven by revoking entry leases out-of-band: a lost
+ * holder frees capacity and fires the listener, and a lost waiter re-queues
+ * with a fresh entry.
+ */
+class SemaphorePermitLostTests : StringSpec() {
+  private val base = "/semaphore/${javaClass.simpleName}"
+
+  private fun revokeLease(
+    client: Client,
+    holdersPath: String,
+    newest: Boolean,
+  ) {
+    val kvs = client.getResponse(holdersPath, getOption { isPrefix(true) }).kvs
+    val entry =
+      if (newest) kvs.maxByOrNull { it.createRevision }!! else kvs.minByOrNull { it.createRevision }!!
+    (entry.lease > 0L) shouldBe true
+    client.leaseClient.revoke(entry.lease).get()
+  }
+
+  init {
+    "a lost permit frees capacity, fires the listener, and release returns false" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/holder-lost"
+        val holdersPath = "$path/holders"
+        val lost = CopyOnWriteArrayList<Throwable?>()
+
+        connectToEtcd(urls) { client2 ->
+          DistributedSemaphore(client, path, 1).use { doomed ->
+            DistributedSemaphore(client2, path, 1).use { successor ->
+              doomed.addPermitLostListener { cause -> lost += cause }
+              doomed.acquire()
+
+              val acquired = BooleanMonitor(false)
+              val waiter =
+                thread {
+                  successor.acquire()
+                  acquired.set(true)
+                  successor.release()
+                }
+              pollUntil(15.seconds) { client.getChildCount(holdersPath) == 2L } shouldBe true
+              acquired.get() shouldBe false
+
+              revokeLease(client, holdersPath, newest = false)
+
+              acquired.waitUntilTrue(20.seconds) shouldBe true
+              pollUntil(10.seconds) { lost.size == 1 } shouldBe true
+              doomed.release() shouldBe false
+              waiter.join(10_000)
+            }
+          }
+        }
+      }
+    }
+
+    "a waiter revoked mid-wait re-queues and still acquires" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val path = "$base/waiter-revoked"
+        val holdersPath = "$path/holders"
+
+        connectToEtcd(urls) { client2 ->
+          DistributedSemaphore(client, path, 1).use { holder ->
+            DistributedSemaphore(client2, path, 1).use { waiterSide ->
+              holder.acquire()
+
+              val acquired = BooleanMonitor(false)
+              val waiter =
+                thread {
+                  waiterSide.acquire()
+                  acquired.set(true)
+                  waiterSide.release()
+                }
+              pollUntil(15.seconds) { client.getChildCount(holdersPath) == 2L } shouldBe true
+
+              // Kill the WAITER's entry lease (the later create revision)
+              revokeLease(client, holdersPath, newest = true)
+
+              // The waiter recovers: a fresh entry appears
+              pollUntil(20.seconds) { client.getChildCount(holdersPath) == 2L } shouldBe true
+
+              holder.release() shouldBe true
+              acquired.waitUntilTrue(30.seconds) shouldBe true
+              waiter.join(10_000)
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Third and final PR of the distributed lock suite (product idea #1), completing the trio started with `DistributedMutex` (#58) and `DistributedReadWriteLock` (#59).

## What's new

**`DistributedSemaphore`** — caps concurrency across processes:

- The canonical permit count is CAS-created at `<path>/permits` on first use and validated by every later instance; a mismatch throws `SemaphorePermitMismatchException` naming both values.
- Each acquisition places a lease-bound entry under `<path>/holders/`; an entry holds a permit iff its create-revision rank is below the permit count. Rank only shrinks while an entry lives, so **capacity is provably never exceeded** and grants are FIFO.
- Waiters watch the holders prefix for any DELETE and re-evaluate their rank — rank admission has no single predecessor key, so a prefix watch is the only sound wakeup (a nearest-predecessor watch can miss multi-departure windows). `tryAcquire` timeouts revoke the waiter's own entry, so nothing leaks.
- Holds are instance-level, Java-`Semaphore`-style: any thread may `release()` (LIFO among the instance's holds), acquisitions are never reentrant, and `withPermit { }` scopes a permit.
- Permit loss is cooperative like the rest of the suite: capacity frees server-side, `PermitLostListener` fires, connection state reports `LOST`, the matching `release()` returns false, and interruption is opt-in via `interruptOnPermitLoss`.

Supporting changes: `WaiterSupport` gains an `awaitPrefixDeletion` variant sharing the existing watch/recheck/deadline machinery with the read-write lock's exact-key wait, and `EtcdRecipeRuntimeException` is now `open` so library exception subtypes stay catchable as the base type.

## Testing

- `DistributedSemaphoreTests` — capacity never exceeded under contention (8 threads, 3 permits, max-in-flight tracker), FIFO grants (staged arrivals), LIFO release order, `tryAcquire` timeout leaves no entry, release-without-hold throws, `withPermit` releases on exception, permit-count mismatch detection, `availablePermits`, close releases all holds.
- `SemaphorePermitLostTests` — a lost holder frees capacity and fires the listener; a waiter revoked mid-wait re-queues and still acquires (out-of-band lease revocation).
- `SemaphoreFaultTests` — a partitioned holder (container pause > TTL) loses its permit and a queued waiter acquires.
- Full Testcontainers gate: **282 passed, 0 failed**; lint/detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP