### PR TITLE
Add coroutines foundation: suspend RPC twins and Flow-based watches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (coroutines: suspend KV/lease/txn + Flow watches)
+
+- New `io.etcd.recipes.coroutines` package: a Kotlin-first async surface alongside
+  the unchanged blocking API. Suspending twins of the `common` extensions
+  (`awaitPutValue`, `awaitGetValue`, `awaitGetChildren`, `awaitTransaction`,
+  `awaitLeaseGrant`, `awaitLock`, ...) share the blocking engine's retry policies
+  and operation timeouts, backing off with `delay` instead of `Thread.sleep`;
+  coroutine cancellation cancels the in-flight RPC future and is never retried.
+- `Client.watchAsFlow(...)`: etcd watches as `Flow<WatchFlowEvent>`, backed by the
+  existing resilient watcher — recovery transitions (`Suspended` / `Resubscribed` /
+  `Resynced` / `Failed`) arrive in-band, compaction resync works through
+  `resyncWith`, cancelling the collector closes the watcher, and the default
+  unlimited buffer keeps a slow collector from ever stalling the watch dispatcher.
+  `Client.watchEventsAsFlow(...)` flattens to `Flow<WatchEvent>`.
+- `kotlinx-coroutines-core` is now an `api` dependency (Flow and suspend appear in
+  public signatures).
+
 ### Added (locks: semaphore)
 
 - `DistributedSemaphore` — distributed counting semaphore: the canonical permit

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ what [Curator](https://curator.apache.org) provides for [ZooKeeper](https://zook
 | `io.etcd.recipes.lock` | `DistributedMutex`, `DistributedReadWriteLock`, `DistributedSemaphore` |
 | `io.etcd.recipes.queue` | `DistributedQueue`, `DistributedPriorityQueue`, `DistributedWorkQueue` (at-least-once) |
 | `io.etcd.recipes.common` | Kotlin extensions over jetcd `Client`, `KV`, `Lease`, `Watch`, `Txn` |
+| `io.etcd.recipes.coroutines` | Suspending twins of the `common` extensions, `Flow`-based watches |
 
 ## Usage
 
@@ -72,6 +73,42 @@ See the `etcd-recipes-examples/` module for runnable
 [Java](https://github.com/pambrose/etcd-recipes/tree/master/etcd-recipes-examples/src/main/java/io/etcd/recipes/examples)
 and [Kotlin](https://github.com/pambrose/etcd-recipes/tree/master/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples)
 demos of every recipe.
+
+## Coroutines API
+
+Every blocking operation stays as-is (Java parity); a Kotlin-first async surface
+lives alongside it in `io.etcd.recipes.coroutines`. Suspending twins of the
+`common` extensions take the `await` prefix (`awaitPutValue`, `awaitGetValue`,
+`awaitTransaction`, ...) and share the same retry policies and operation
+timeouts — backing off with `delay` instead of parking a thread, and treating
+coroutine cancellation as authoritative (the in-flight RPC future is cancelled,
+never retried).
+
+Watches become `Flow`s:
+
+```kotlin
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.watchOption
+import io.etcd.recipes.coroutines.WatchFlowEvent
+import io.etcd.recipes.coroutines.watchAsFlow
+
+connectToEtcd(urls).use { client ->
+    client.watchAsFlow("/config", watchOption { isPrefix(true) }).collect { element ->
+        when (element) {
+            is WatchFlowEvent.Response -> element.response.events.forEach { /* react */ }
+            is WatchFlowEvent.Recovery -> { /* Suspended / Resubscribed / Resynced / Failed */ }
+        }
+    }
+}
+```
+
+`watchAsFlow` rides the same resilient watcher as the blocking API: fatal stream
+deaths recover automatically, and compaction resyncs surface in-band as
+`WatchFlowEvent.Recovery` so collectors with derived state can rebuild. The
+default unlimited buffer means a slow collector can never stall the watch
+dispatcher; cancelling the collector closes the watcher. Use
+`watchEventsAsFlow` for a flattened `Flow<WatchEvent>` when no derived state is
+kept.
 
 ## Distributed locks
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,8 @@ subprojects {
 
     dependencies {
         "implementation"(rootProject.libs.kotlinx.serialization.json)
-        "implementation"(rootProject.libs.kotlinx.coroutines.core)
+        // api: Flow and suspend modifiers appear in the io.etcd.recipes.coroutines public surface
+        "api"(rootProject.libs.kotlinx.coroutines.core)
 
         "implementation"(rootProject.libs.jetcd.core)
 

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/WatchAsFlowExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/WatchAsFlowExample.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.coroutines
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.keyAsString
+import io.etcd.recipes.common.valueAsString
+import io.etcd.recipes.common.watchOption
+import io.etcd.recipes.coroutines.WatchFlowEvent
+import io.etcd.recipes.coroutines.awaitDeleteChildren
+import io.etcd.recipes.coroutines.awaitPutValue
+import io.etcd.recipes.coroutines.watchAsFlow
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Consumes etcd watch events as a Flow: the collector sees puts and deletes in
+ * order, resilience transitions arrive in-band, and cancelling the collector
+ * closes the underlying watcher.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val prefix = "/examples/watchflow"
+
+  runBlocking {
+    connectToEtcd(urls).use { client ->
+      client.awaitDeleteChildren(prefix)
+
+      val collector =
+        launch {
+          client.watchAsFlow(prefix, watchOption { isPrefix(true) }).collect { element ->
+            when (element) {
+              is WatchFlowEvent.Response -> {
+                element.response.events.forEach { event ->
+                  logger.info { "${event.eventType} ${event.keyAsString} = ${event.valueAsString}" }
+                }
+              }
+
+              is WatchFlowEvent.Recovery -> {
+                logger.info { "Watch recovery: ${element.event}" }
+              }
+            }
+          }
+        }
+      delay(500) // let the watch subscribe
+
+      repeat(5) { i -> client.awaitPutValue("$prefix/key$i", "value$i") }
+      client.awaitDeleteChildren(prefix)
+      delay(1_000) // let the events arrive
+
+      collector.cancel() // closes the watcher
+      logger.info { "Collector cancelled; done" }
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/RpcRetry.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/RpcRetry.kt
@@ -73,7 +73,8 @@ internal fun <T> retryRpc(
   }
 }
 
-private fun Throwable.isRetriableRpcFailure(): Boolean =
+// internal: the suspend RPC engine in io.etcd.recipes.coroutines shares this predicate
+internal fun Throwable.isRetriableRpcFailure(): Boolean =
   generateSequence(this) { it.cause.takeIf { c -> c !== it } }
     .any { t -> t is TimeoutException || (t is EtcdException && t.errorCode in RETRIABLE_CODES) }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/ChildrenSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/ChildrenSuspend.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import com.pambrose.common.util.ensureSuffix
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.options.GetOption
+import io.etcd.jetcd.options.GetOption.SortOrder
+import io.etcd.recipes.common.RpcResilience
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.deleteOption
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.keys
+import io.etcd.recipes.common.values
+
+/** Suspending twin of `getChildren`: all key/value pairs under [keyName]. */
+suspend fun Client.awaitGetChildren(
+  keyName: String,
+  target: GetOption.SortTarget = GetOption.SortTarget.KEY,
+  order: SortOrder = SortOrder.ASCEND,
+  keysOnly: Boolean = false,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): List<Pair<String, ByteSequence>> {
+  val trailingKey = keyName.ensureSuffix("/")
+  val getOption =
+    getOption {
+      isPrefix(true)
+      withSortField(target)
+      withSortOrder(order)
+      withKeysOnly(keysOnly)
+    }
+  return awaitGetKeyValuePairs(trailingKey, getOption, rpc)
+}
+
+private suspend fun Client.awaitGetSingleChild(
+  keyName: String,
+  target: GetOption.SortTarget,
+  order: SortOrder,
+  rpc: RpcResilience,
+): GetResponse {
+  val trailingKey = keyName.ensureSuffix("/")
+  val getOption =
+    getOption {
+      isPrefix(true)
+      withSortField(target)
+      withSortOrder(order)
+      withLimit(1)
+    }
+  return awaitGetResponse(trailingKey, getOption, rpc)
+}
+
+/** Suspending twin of `getFirstChild`. */
+suspend fun Client.awaitGetFirstChild(
+  keyName: String,
+  target: GetOption.SortTarget,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): GetResponse = awaitGetSingleChild(keyName, target, SortOrder.ASCEND, rpc)
+
+/** Suspending twin of `getLastChild`. */
+suspend fun Client.awaitGetLastChild(
+  keyName: String,
+  target: GetOption.SortTarget,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): GetResponse = awaitGetSingleChild(keyName, target, SortOrder.DESCEND, rpc)
+
+/** Suspending twin of `getChildrenKeys`. */
+suspend fun Client.awaitGetChildrenKeys(
+  keyName: String,
+  target: GetOption.SortTarget = GetOption.SortTarget.KEY,
+  order: SortOrder = SortOrder.ASCEND,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): List<String> = awaitGetChildren(keyName, target, order, true, rpc).keys
+
+/** Suspending twin of `getChildrenValues`. */
+suspend fun Client.awaitGetChildrenValues(
+  keyName: String,
+  target: GetOption.SortTarget = GetOption.SortTarget.KEY,
+  order: SortOrder = SortOrder.ASCEND,
+): List<ByteSequence> = awaitGetChildren(keyName, target, order).values
+
+/** Suspending twin of `getChildCount`. */
+suspend fun Client.awaitGetChildCount(
+  keyName: String,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): Long {
+  val trailingKey = keyName.ensureSuffix("/")
+  val getOption =
+    getOption {
+      isPrefix(true)
+      withCountOnly(true)
+    }
+  return awaitGetResponse(trailingKey.asByteSequence, getOption, 0, rpc).count
+}
+
+/** Suspending twin of `deleteChildren`: deletes everything under [keyName], returning the deleted keys. */
+suspend fun Client.awaitDeleteChildren(
+  keyName: String,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): List<String> {
+  val trailingKey = keyName.ensureSuffix("/")
+  val deleteOption =
+    deleteOption {
+      isPrefix(true)
+      withPrevKV(true)
+    }
+  return suspendRetryRpc(rpc, "deleteChildren($keyName)") { kvClient.delete(trailingKey.asByteSequence, deleteOption) }
+    .prevKvs.map { it.key.asString }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/KVSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/KVSuspend.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.kv.CompactResponse
+import io.etcd.jetcd.kv.DeleteResponse
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.kv.PutResponse
+import io.etcd.jetcd.options.CompactOption
+import io.etcd.jetcd.options.GetOption
+import io.etcd.jetcd.options.PutOption
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.RpcResilience
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.asInt
+import io.etcd.recipes.common.asLong
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.doesExist
+import io.etcd.recipes.common.getOption
+
+private const val MAX_GET_ATTEMPTS = 10 // mirrors KVExtensions
+
+/**
+ * Suspending twin of `putValue`: last-writer-wins puts, retried on retriable
+ * statuses (a duplicate apply from an ambiguous first attempt is harmless).
+ * CAS puts go through [awaitTransaction], which is never retried.
+ */
+suspend fun Client.awaitPutValue(
+  keyName: String,
+  keyval: ByteSequence,
+  option: PutOption = PutOption.DEFAULT,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): PutResponse = suspendRetryRpc(rpc, "putValue($keyName)") { kvClient.put(keyName.asByteSequence, keyval, option) }
+
+/** Suspending twin of `putValue` for String values. */
+suspend fun Client.awaitPutValue(
+  keyName: String,
+  keyval: String,
+  option: PutOption = PutOption.DEFAULT,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): PutResponse = awaitPutValue(keyName, keyval.asByteSequence, option, rpc)
+
+/** Suspending twin of `putValue` for Int values. */
+suspend fun Client.awaitPutValue(
+  keyName: String,
+  keyval: Int,
+  option: PutOption = PutOption.DEFAULT,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): PutResponse = awaitPutValue(keyName, keyval.asByteSequence, option, rpc)
+
+/** Suspending twin of `putValue` for Long values. */
+suspend fun Client.awaitPutValue(
+  keyName: String,
+  keyval: Long,
+  option: PutOption = PutOption.DEFAULT,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): PutResponse = awaitPutValue(keyName, keyval.asByteSequence, option, rpc)
+
+/** Suspending twin of `deleteKeys`. */
+suspend fun Client.awaitDeleteKeys(vararg keyNames: String) {
+  keyNames.forEach { awaitDeleteKey(it) }
+}
+
+/** Suspending twin of `deleteKey`. */
+suspend fun Client.awaitDeleteKey(
+  keyName: String,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): DeleteResponse = suspendRetryRpc(rpc, "deleteKey($keyName)") { kvClient.delete(keyName.asByteSequence) }
+
+// Mirrors the blocking internal getResponse: re-fetches while etcd reports more
+// data pending but returns no kvs.
+internal suspend fun Client.awaitGetResponse(
+  keyName: ByteSequence,
+  option: GetOption = GetOption.DEFAULT,
+  iteration: Int = 0,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): GetResponse {
+  val response = suspendRetryRpc(rpc, "getResponse(${keyName.asString})") { kvClient.get(keyName, option) }
+  return if (response.kvs.isEmpty() && response.isMore) {
+    if (iteration >= MAX_GET_ATTEMPTS)
+      throw EtcdRecipeRuntimeException(
+        "Unable to fulfill call to getResponse for key ${keyName.asString} after $iteration attempts",
+      )
+    awaitGetResponse(keyName, option, iteration + 1, rpc)
+  } else {
+    response
+  }
+}
+
+/** Suspending twin of `getResponse`. */
+suspend fun Client.awaitGetResponse(
+  keyName: String,
+  option: GetOption = GetOption.DEFAULT,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): GetResponse = awaitGetResponse(keyName.asByteSequence, option, 0, rpc)
+
+/** Suspending twin of `getKeyValuePairs`. */
+suspend fun Client.awaitGetKeyValuePairs(
+  keyName: String,
+  getOption: GetOption,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): List<Pair<String, ByteSequence>> =
+  awaitGetResponse(keyName.asByteSequence, getOption, 0, rpc).kvs.map { it.key.asString to it.value }
+
+/** Suspending twin of `getValue`. */
+suspend fun Client.awaitGetValue(
+  keyName: String,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): ByteSequence? {
+  val getOption = getOption { withLimit(1) }
+  return awaitGetResponse(keyName, getOption, rpc).kvs.takeIf { it.isNotEmpty() }?.get(0)?.value
+}
+
+/** Suspending twin of `getValue` with a String default. */
+suspend fun Client.awaitGetValue(
+  keyName: String,
+  default: String,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): String = awaitGetValue(keyName, rpc)?.asString ?: default
+
+/** Suspending twin of `getValue` with an Int default. */
+suspend fun Client.awaitGetValue(
+  keyName: String,
+  default: Int,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): Int = awaitGetValue(keyName, rpc)?.asInt ?: default
+
+/** Suspending twin of `getValue` with a Long default. */
+suspend fun Client.awaitGetValue(
+  keyName: String,
+  default: Long,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): Long = awaitGetValue(keyName, rpc)?.asLong ?: default
+
+/** Suspending twin of `compact`. */
+suspend fun Client.awaitCompact(
+  revision: Long,
+  option: CompactOption = CompactOption.DEFAULT,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): CompactResponse = suspendRetryRpc(rpc, "compact($revision)") { kvClient.compact(revision, option) }
+
+/** Suspending twin of `isKeyPresent`. */
+suspend fun Client.awaitIsKeyPresent(
+  keyName: String,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): Boolean = awaitTransaction(rpc) { If(keyName.doesExist) }.isSucceeded
+
+/** Suspending twin of `isKeyNotPresent`. */
+suspend fun Client.awaitIsKeyNotPresent(
+  keyName: String,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): Boolean = !awaitIsKeyPresent(keyName, rpc)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LeaseSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LeaseSuspend.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.lease.LeaseGrantResponse
+import io.etcd.recipes.common.RpcResilience
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.CancellationException
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * Suspending twin of `leaseGrant`. Retried on retriable statuses: a duplicate grant
+ * from an ambiguous first attempt orphans a lease that dies at its TTL — harmless.
+ */
+suspend fun Client.awaitLeaseGrant(
+  ttl: Duration,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): LeaseGrantResponse =
+  suspendRetryRpc(rpc, "leaseGrant($ttl)") { leaseClient.grant(ttl.toDouble(DurationUnit.SECONDS).toLong()) }
+
+/**
+ * Suspending twin of `leaseRevoke`: best-effort, failures are logged and swallowed
+ * (callers use this on cleanup paths where a secondary failure would mask the
+ * original problem; the TTL bounds resource retention if the revoke fails) — but
+ * cancellation always propagates.
+ */
+@Suppress("TooGenericExceptionCaught")
+suspend fun Client.awaitLeaseRevoke(
+  lease: LeaseGrantResponse,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+) {
+  try {
+    suspendAwaitRpc(rpc, "leaseRevoke(${lease.id})", leaseClient.revoke(lease.id))
+  } catch (e: CancellationException) {
+    throw e
+  } catch (e: Throwable) {
+    logger.debug(e) { "leaseRevoke(${lease.id}) failed; lease will expire on TTL" }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LockSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LockSuspend.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.lock.LockResponse
+import io.etcd.jetcd.lock.UnlockResponse
+import io.etcd.recipes.common.RpcResilience
+import io.etcd.recipes.common.asByteSequence
+
+/**
+ * Suspending twin of the raw `lock` pass-through; prefer
+ * [io.etcd.recipes.lock.DistributedMutex]. The default rpc config is
+ * [RpcResilience.DISABLED] — unlike every other suspend twin — because a lock call
+ * legitimately WAITS server-side for the current holder; a 30s operation timeout
+ * would abort valid waits. Pass a bounded config only when a bounded wait is what
+ * you mean.
+ */
+suspend fun Client.awaitLock(
+  keyName: String,
+  leaseId: Long,
+  rpc: RpcResilience = RpcResilience.DISABLED,
+): LockResponse = suspendAwaitRpc(rpc, "lock($keyName)", lockClient.lock(keyName.asByteSequence, leaseId))
+
+/** Suspending twin of the raw `unlock` pass-through. */
+suspend fun Client.awaitUnlock(
+  keyName: String,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): UnlockResponse = suspendRetryRpc(rpc, "unlock($keyName)") { lockClient.unlock(keyName.asByteSequence) }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/RpcSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/RpcSuspend.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.RpcResilience
+import io.etcd.recipes.common.isRetriableRpcFailure
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeoutException
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+// Marker box so withTimeoutOrNull's null unambiguously means "timed out" even for
+// futures that could complete with null.
+private class Boxed<T>(
+  val value: T,
+)
+
+/**
+ * Suspending twin of the blocking retry engine in `common/RpcRetry.kt`: awaits the
+ * future produced by [op], bounding each attempt with [RpcResilience.operationTimeout]
+ * and retrying retriable failures under [RpcResilience.retryPolicy], backing off with
+ * `delay` instead of `Thread.sleep`. External cancellation is never retried: it cancels
+ * the in-flight future and propagates immediately.
+ */
+@Suppress("TooGenericExceptionCaught", "ThrowsCount")
+internal suspend fun <T> suspendRetryRpc(
+  rpc: RpcResilience,
+  opName: String,
+  op: () -> CompletableFuture<T>,
+): T {
+  val start = TimeSource.Monotonic.markNow()
+  var attempt = 0
+  var lastFailure: Throwable
+  while (true) {
+    attempt += 1
+    val future = op()
+    try {
+      val boxed =
+        if (rpc.operationTimeout.isFinite()) {
+          // withTimeoutOrNull instead of withTimeout: an enclosing withTimeout's
+          // TimeoutCancellationException must never be mistaken for our attempt
+          // timeout — here any CancellationException reaching the catch is external.
+          withTimeoutOrNull(rpc.operationTimeout) { Boxed(future.await()) }
+        } else {
+          Boxed(future.await())
+        }
+      if (boxed != null) return boxed.value
+      future.cancel(true)
+      lastFailure = TimeoutException("$opName attempt timed out after ${rpc.operationTimeout}")
+    } catch (e: CancellationException) {
+      future.cancel(true)
+      throw e
+    } catch (e: Throwable) {
+      if (!e.isRetriableRpcFailure()) throw e
+      lastFailure = e
+    }
+    val delay = rpc.retryPolicy.nextDelay(attempt, start.elapsedNow())
+      ?: throw EtcdRecipeRuntimeException("$opName failed after $attempt attempts", lastFailure)
+    if (delay > Duration.ZERO) delay(delay)
+  }
+}
+
+/**
+ * Suspending twin of `awaitRpc`: awaits [future] with the operation timeout applied but
+ * NO retry — for transactions, whose failed commits are ambiguous and whose retry
+ * decisions belong to the recipes' own CAS loops.
+ */
+internal suspend fun <T> suspendAwaitRpc(
+  rpc: RpcResilience,
+  opName: String,
+  future: CompletableFuture<T>,
+): T =
+  try {
+    if (rpc.operationTimeout.isFinite()) {
+      val boxed = withTimeoutOrNull(rpc.operationTimeout) { Boxed(future.await()) }
+      if (boxed == null) {
+        future.cancel(true)
+        throw EtcdRecipeRuntimeException("$opName timed out after ${rpc.operationTimeout}")
+      }
+      boxed.value
+    } else {
+      future.await()
+    }
+  } catch (e: CancellationException) {
+    future.cancel(true)
+    throw e
+  }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/TxnSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/TxnSuspend.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.Txn
+import io.etcd.jetcd.kv.TxnResponse
+import io.etcd.recipes.common.RpcResilience
+
+/**
+ * Suspending twin of `transaction`: commits the transaction built by [receiver] with
+ * the operation timeout applied but NEVER retried — a failed commit is ambiguous (it
+ * may have been applied), and CAS retry decisions belong to the callers' own loops.
+ */
+suspend fun Client.awaitTransaction(
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+  receiver: Txn.() -> Txn,
+): TxnResponse =
+  suspendAwaitRpc(
+    rpc,
+    "transaction",
+    kvClient.txn().run {
+      receiver()
+      commit()
+    },
+  )

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/WatchFlowEvent.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/WatchFlowEvent.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.jetcd.watch.WatchEvent
+import io.etcd.jetcd.watch.WatchResponse
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
+import io.etcd.recipes.common.WatchResilience
+import io.etcd.recipes.common.watcher
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.transform
+
+/**
+ * An element of a [watchAsFlow] stream: either a watch response from etcd or a
+ * resilience transition of the underlying watcher. Recovery events are surfaced
+ * in-band because a resilient watch that silently hides suspension, resubscription,
+ * or a compaction resync invites derived-state corruption in the collector.
+ */
+sealed interface WatchFlowEvent {
+  /** A watch response from the stream (events + header). */
+  data class Response(
+    val response: WatchResponse,
+  ) : WatchFlowEvent
+
+  /** A resilience transition: Suspended / Resubscribed / Resynced / Failed. */
+  data class Recovery(
+    val event: WatchRecoveryEvent,
+  ) : WatchFlowEvent
+}
+
+/**
+ * Watches [keyName] as a [Flow], backed by the same resilient watcher as the blocking
+ * API: fatal stream deaths are recovered per [resilience], and after a compaction
+ * [resyncWith] is invoked so the caller can re-read its world and return the new
+ * anchor revision. Watch responses and recovery transitions arrive in-band as
+ * [WatchFlowEvent]s, in order.
+ *
+ * Cancelling the collector closes the watcher (bounded by its ≤5s close contract).
+ * The default [capacity] of [Channel.UNLIMITED] guarantees the watcher's dispatcher
+ * thread — which also runs recovery and resync — is never stalled by a slow
+ * collector; a bounded capacity opts into backpressure that pauses THIS watch's
+ * delivery and recovery while the buffer is full.
+ */
+fun Client.watchAsFlow(
+  keyName: String,
+  option: WatchOption = WatchOption.DEFAULT,
+  resilience: WatchResilience = WatchResilience.DEFAULT,
+  resyncWith: (() -> Long)? = null,
+  capacity: Int = Channel.UNLIMITED,
+): Flow<WatchFlowEvent> =
+  callbackFlow {
+    // trySendBlocking: never blocks under the UNLIMITED default; on a bounded
+    // buffer it parks the watcher's own dispatcher thread (opt-in backpressure);
+    // on an already-cancelled collector it reports closed instead of throwing.
+    val watcher =
+      watcher(
+        keyName,
+        option,
+        resilience,
+        recoveryListener = WatchRecoveryListener { event -> trySendBlocking(WatchFlowEvent.Recovery(event)) },
+        resyncWith = resyncWith,
+      ) { response -> trySendBlocking(WatchFlowEvent.Response(response)) }
+    awaitClose { watcher.close() }
+  }.buffer(capacity)
+
+/**
+ * Convenience over [watchAsFlow]: flattens responses into their [WatchEvent]s and
+ * drops recovery transitions. Use [watchAsFlow] instead when the collector keeps
+ * derived state — after a compaction resync this flow silently skips the gap.
+ */
+fun Client.watchEventsAsFlow(
+  keyName: String,
+  option: WatchOption = WatchOption.DEFAULT,
+  resilience: WatchResilience = WatchResilience.DEFAULT,
+  capacity: Int = Channel.UNLIMITED,
+): Flow<WatchEvent> =
+  watchAsFlow(keyName, option, resilience, resyncWith = null, capacity = capacity)
+    .transform { element ->
+      if (element is WatchFlowEvent.Response) {
+        element.response.events.forEach { emit(it) }
+      }
+    }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendKVTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendKVTests.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.options.GetOption
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.doesNotExist
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.setTo
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Integration round-trips for the suspending twins of the common/ extension surface,
+ * called directly from the suspend test context — no threads, no latches.
+ */
+class SuspendKVTests : StringSpec() {
+  private val base = "/coroutines/${javaClass.simpleName}"
+
+  init {
+    "typed put and get round-trip through the suspend twins" {
+      connectToEtcd(urls).use { client ->
+        client.awaitDeleteChildren(base)
+        val path = "$base/typed"
+
+        client.awaitPutValue("$path/str", "hello")
+        client.awaitGetValue("$path/str", "none") shouldBe "hello"
+
+        client.awaitPutValue("$path/int", 42)
+        client.awaitGetValue("$path/int", -1) shouldBe 42
+
+        client.awaitPutValue("$path/long", 42_000_000_000L)
+        client.awaitGetValue("$path/long", -1L) shouldBe 42_000_000_000L
+
+        client.awaitGetValue("$path/missing", "fallback") shouldBe "fallback"
+        client.awaitGetValue("$path/missing") shouldBe null
+      }
+    }
+
+    "children twins list, count, and delete" {
+      connectToEtcd(urls).use { client ->
+        client.awaitDeleteChildren(base)
+        val path = "$base/children"
+
+        client.awaitPutValue("$path/a", "1")
+        client.awaitPutValue("$path/b", "2")
+        client.awaitPutValue("$path/c", "3")
+
+        client.awaitGetChildCount(path) shouldBe 3L
+        client.awaitGetChildrenKeys(path).map { it.substringAfterLast('/') } shouldContainExactly
+          listOf("a", "b", "c")
+        client.awaitGetChildrenValues(path).map { it.asString } shouldContainExactly listOf("1", "2", "3")
+        client.awaitGetChildren(path).map { it.second.asString } shouldContainExactly listOf("1", "2", "3")
+
+        client.awaitGetFirstChild(path, GetOption.SortTarget.KEY)
+          .kvs.single().key.asString.substringAfterLast('/') shouldBe "a"
+        client.awaitGetLastChild(path, GetOption.SortTarget.KEY)
+          .kvs.single().key.asString.substringAfterLast('/') shouldBe "c"
+
+        client.awaitDeleteChildren(path).size shouldBe 3
+        client.awaitGetChildCount(path) shouldBe 0L
+      }
+    }
+
+    "getResponse, key presence, and single-key delete" {
+      connectToEtcd(urls).use { client ->
+        client.awaitDeleteChildren(base)
+        val key = "$base/presence/key"
+
+        client.awaitIsKeyNotPresent(key) shouldBe true
+        client.awaitPutValue(key, "here")
+        client.awaitIsKeyPresent(key) shouldBe true
+        client.awaitGetResponse(key).kvs.single().value.asString shouldBe "here"
+        client.awaitGetKeyValuePairs(key, getOption { isPrefix(true) }).single().second.asString shouldBe "here"
+
+        client.awaitDeleteKey(key)
+        client.awaitIsKeyNotPresent(key) shouldBe true
+      }
+    }
+
+    "awaitTransaction executes a CAS create exactly once" {
+      connectToEtcd(urls).use { client ->
+        client.awaitDeleteChildren(base)
+        val key = "$base/txn/key"
+
+        val first =
+          client.awaitTransaction {
+            If(key.doesNotExist)
+            Then(key setTo "claimed")
+          }
+        first.isSucceeded shouldBe true
+
+        val second =
+          client.awaitTransaction {
+            If(key.doesNotExist)
+            Then(key setTo "stolen")
+          }
+        second.isSucceeded shouldBe false
+        client.awaitGetValue(key, "none") shouldBe "claimed"
+      }
+    }
+
+    "lease grant, raw lock, unlock, and revoke sequence" {
+      connectToEtcd(urls).use { client ->
+        client.awaitDeleteChildren(base)
+        val lockName = "$base/rawlock"
+
+        val lease = client.awaitLeaseGrant(10.seconds)
+        val lock = client.awaitLock(lockName, lease.id)
+        lock.key.asString.startsWith(lockName) shouldBe true
+
+        client.awaitUnlock(lock.key.asString)
+        client.awaitLeaseRevoke(lease)
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendRpcRetryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendRpcRetryTests.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.common.exception.ErrorCode
+import io.etcd.jetcd.common.exception.EtcdException
+import io.etcd.jetcd.common.exception.EtcdExceptionFactory
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.RetryPolicy
+import io.etcd.recipes.common.RpcResilience
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Unit tests for the suspending RPC retry/timeout engine — the coroutine twin of
+ * RpcRetryTests. Virtual time via runTest: backoff delays and operation timeouts
+ * cost no wall-clock. No etcd needed.
+ */
+class SuspendRpcRetryTests : StringSpec() {
+  private fun unavailable() = EtcdExceptionFactory.newEtcdException(ErrorCode.UNAVAILABLE, "etcd unavailable")
+
+  private fun quick() = RpcResilience(RetryPolicy.bounded(maxAttempts = 5, delay = 10.milliseconds), 5.seconds)
+
+  init {
+    "retries retriable failures until success" {
+      runTest {
+        val calls = AtomicInteger(0)
+        val result =
+          suspendRetryRpc(quick(), "test-op") {
+            if (calls.incrementAndGet() <= 2) {
+              CompletableFuture.failedFuture(unavailable())
+            } else {
+              CompletableFuture.completedFuture("ok")
+            }
+          }
+        result shouldBe "ok"
+        calls.get() shouldBe 3
+      }
+    }
+
+    "retriable causes are found through the exception chain" {
+      runTest {
+        val calls = AtomicInteger(0)
+        val result =
+          suspendRetryRpc(quick(), "wrapped-op") {
+            if (calls.incrementAndGet() <= 1) {
+              CompletableFuture.failedFuture(RuntimeException("wrapper", unavailable()))
+            } else {
+              CompletableFuture.completedFuture("ok")
+            }
+          }
+        result shouldBe "ok"
+        calls.get() shouldBe 2
+      }
+    }
+
+    "gives up after policy exhaustion and wraps the cause with attempt context" {
+      runTest {
+        val calls = AtomicInteger(0)
+        val rpc = RpcResilience(RetryPolicy.bounded(maxAttempts = 2, delay = 10.milliseconds), 5.seconds)
+        val thrown =
+          shouldThrow<EtcdRecipeRuntimeException> {
+            suspendRetryRpc<String>(rpc, "doomed-op") {
+              calls.incrementAndGet()
+              CompletableFuture.failedFuture(unavailable())
+            }
+          }
+        calls.get() shouldBe 3 // initial + 2 retries
+        thrown.message!! shouldContain "doomed-op"
+        thrown.message!! shouldContain "3"
+        generateSequence(thrown as Throwable) { it.cause.takeIf { c -> c !== it } }
+          .any { it.message?.contains("unavailable") == true } shouldBe true
+      }
+    }
+
+    "a hung call fails at operationTimeout and cancels the in-flight future" {
+      runTest {
+        val futures = mutableListOf<CompletableFuture<String>>()
+        val rpc = RpcResilience(RetryPolicy.never, operationTimeout = 200.milliseconds)
+        shouldThrow<EtcdRecipeRuntimeException> {
+          suspendRetryRpc(rpc, "hung-op") {
+            CompletableFuture<String>().also { futures += it } // never completes
+          }
+        }
+        futures.size shouldBe 1
+        futures.single().isCancelled shouldBe true
+      }
+    }
+
+    "an attempt timeout is retriable under the policy" {
+      runTest {
+        val calls = AtomicInteger(0)
+        val rpc = RpcResilience(RetryPolicy.bounded(maxAttempts = 3, delay = 10.milliseconds), 100.milliseconds)
+        val result =
+          suspendRetryRpc(rpc, "slow-then-ok") {
+            if (calls.incrementAndGet() <= 1) {
+              CompletableFuture() // hangs; times out at 100ms virtual
+            } else {
+              CompletableFuture.completedFuture("ok")
+            }
+          }
+        result shouldBe "ok"
+        calls.get() shouldBe 2
+      }
+    }
+
+    "non-retriable failures propagate without retry" {
+      runTest {
+        val calls = AtomicInteger(0)
+        shouldThrow<IllegalArgumentException> {
+          suspendRetryRpc<String>(quick(), "bad-request") {
+            calls.incrementAndGet()
+            CompletableFuture.failedFuture(IllegalArgumentException("bad key"))
+          }
+        }
+        calls.get() shouldBe 1
+      }
+    }
+
+    "external cancellation during the await propagates promptly without retry" {
+      runTest {
+        val calls = AtomicInteger(0)
+        val futures = mutableListOf<CompletableFuture<String>>()
+        val rpc = RpcResilience(RetryPolicy.bounded(maxAttempts = 5, delay = 10.milliseconds), Duration.INFINITE)
+        val job =
+          launch {
+            suspendRetryRpc<String>(rpc, "cancelled-op") {
+              calls.incrementAndGet()
+              CompletableFuture<String>().also { futures += it } // hangs; no timeout configured
+            }
+          }
+        testScheduler.runCurrent() // let the launch reach the await
+        job.cancel()
+        job.join()
+        job.isCancelled shouldBe true
+        calls.get() shouldBe 1
+        futures.single().isCancelled shouldBe true
+      }
+    }
+
+    "external cancellation during backoff is prompt: no further attempt" {
+      runTest {
+        val calls = AtomicInteger(0)
+        val rpc = RpcResilience(RetryPolicy.bounded(maxAttempts = 5, delay = 60.seconds), 5.seconds)
+        val job =
+          launch {
+            suspendRetryRpc<String>(rpc, "backoff-op") {
+              calls.incrementAndGet()
+              CompletableFuture.failedFuture(unavailable())
+            }
+          }
+        testScheduler.runCurrent() // first attempt fails; coroutine parks in the 60s backoff delay
+        calls.get() shouldBe 1
+        job.cancel()
+        job.join()
+        job.isCancelled shouldBe true
+        calls.get() shouldBe 1
+      }
+    }
+
+    "suspendAwaitRpc returns a completed value" {
+      runTest {
+        suspendAwaitRpc(quick(), "done-op", CompletableFuture.completedFuture("ok")) shouldBe "ok"
+      }
+    }
+
+    "suspendAwaitRpc never retries, even on retriable failures" {
+      runTest {
+        shouldThrow<EtcdException> {
+          suspendAwaitRpc<String>(quick(), "one-shot", CompletableFuture.failedFuture(unavailable()))
+        }
+      }
+    }
+
+    "suspendAwaitRpc wraps a timeout and cancels the future" {
+      runTest {
+        val future = CompletableFuture<String>()
+        val rpc = RpcResilience(RetryPolicy.never, operationTimeout = 200.milliseconds)
+        val thrown =
+          shouldThrow<EtcdRecipeRuntimeException> {
+            suspendAwaitRpc(rpc, "hung-txn", future)
+          }
+        thrown.message!! shouldContain "timed out"
+        future.isCancelled shouldBe true
+      }
+    }
+
+    "suspendAwaitRpc external cancellation cancels the future and propagates" {
+      runTest {
+        val future = CompletableFuture<String>()
+        val rpc = RpcResilience(RetryPolicy.never, operationTimeout = Duration.INFINITE)
+        val job = launch { suspendAwaitRpc(rpc, "cancelled-txn", future) }
+        testScheduler.runCurrent()
+        job.cancel()
+        job.join()
+        job.isCancelled shouldBe true
+        future.isCancelled shouldBe true
+      }
+    }
+
+    "cancellation exceptions are never swallowed as retriable" {
+      runTest {
+        val calls = AtomicInteger(0)
+        shouldThrow<CancellationException> {
+          suspendRetryRpc<String>(quick(), "cancel-inside") {
+            calls.incrementAndGet()
+            CompletableFuture.failedFuture(CancellationException("externally cancelled future"))
+          }
+        }
+        calls.get() shouldBe 1
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/WatchAsFlowTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/WatchAsFlowTests.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.watch.WatchEvent
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.keyAsString
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.common.valueAsString
+import io.etcd.recipes.common.watchOption
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Flow-based watch semantics: ordered delivery, flattening, cancellation closing the
+ * watcher, collector independence, and lossless buffering under a slow collector.
+ */
+class WatchAsFlowTests : StringSpec() {
+  private val base = "/coroutines/${javaClass.simpleName}"
+
+  private suspend fun untilTrue(
+    timeout: Duration,
+    predicate: () -> Boolean,
+  ): Boolean {
+    val start = TimeSource.Monotonic.markNow()
+    while (start.elapsedNow() < timeout) {
+      if (predicate()) return true
+      delay(50)
+    }
+    return predicate()
+  }
+
+  // Collectors run on their own scope: the kotest test context must stay free to
+  // drive puts and assertions while collection is live. The settle delay lets the
+  // watch subscription go live before the test starts writing.
+  private suspend fun <T> withCollector(
+    collect: suspend CoroutineScope.() -> Job,
+    body: suspend (Job) -> T,
+  ): T {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    try {
+      val job = collect(scope)
+      delay(1_000)
+      return body(job)
+    } finally {
+      scope.coroutineContext[Job]!!.cancelAndJoin()
+    }
+  }
+
+  init {
+    "watchAsFlow delivers responses in order" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val key = "$base/ordered/key"
+        val seen = CopyOnWriteArrayList<Pair<WatchEvent.EventType, String>>()
+
+        withCollector(
+          collect = {
+            launch {
+              client.watchAsFlow(key).filterIsInstance<WatchFlowEvent.Response>().collect { r ->
+                r.response.events.forEach { seen += it.eventType to it.valueAsString }
+              }
+            }
+          },
+        ) {
+          client.putValue(key, "v1")
+          client.putValue(key, "v2")
+          client.deleteChildren("$base/ordered")
+          untilTrue(15.seconds) { seen.size == 3 } shouldBe true
+          seen.map { it.first } shouldContainExactly
+            listOf(WatchEvent.EventType.PUT, WatchEvent.EventType.PUT, WatchEvent.EventType.DELETE)
+          seen.take(2).map { it.second } shouldContainExactly listOf("v1", "v2")
+        }
+      }
+    }
+
+    "watchEventsAsFlow flattens responses to events across a prefix" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val prefix = "$base/flat"
+        val seen = CopyOnWriteArrayList<String>()
+
+        withCollector(
+          collect = {
+            launch {
+              client.watchEventsAsFlow(prefix, watchOption { isPrefix(true) }).collect { event ->
+                seen += event.keyAsString.substringAfterLast('/')
+              }
+            }
+          },
+        ) {
+          client.putValue("$prefix/a", "1")
+          client.putValue("$prefix/b", "2")
+          client.putValue("$prefix/c", "3")
+          untilTrue(15.seconds) { seen.size == 3 } shouldBe true
+          seen.toList() shouldContainExactly listOf("a", "b", "c")
+        }
+      }
+    }
+
+    "cancelling the collector closes the watcher" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val key = "$base/cancel/key"
+        val seen = CopyOnWriteArrayList<String>()
+
+        withCollector(
+          collect = {
+            launch {
+              client.watchEventsAsFlow(key).collect { seen += it.valueAsString }
+            }
+          },
+        ) { job ->
+          client.putValue(key, "before")
+          untilTrue(15.seconds) { seen.size == 1 } shouldBe true
+
+          job.cancelAndJoin()
+
+          client.putValue(key, "after")
+          delay(2_000) // grace: a live watcher would have delivered by now
+          seen.toList() shouldContainExactly listOf("before")
+        }
+      }
+    }
+
+    "two collectors get independent watchers" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val key = "$base/dual/key"
+        val seenA = CopyOnWriteArrayList<String>()
+        val seenB = CopyOnWriteArrayList<String>()
+
+        withCollector(
+          collect = {
+            launch { client.watchEventsAsFlow(key).collect { seenA += it.valueAsString } }
+            launch { client.watchEventsAsFlow(key).collect { seenB += it.valueAsString } }
+          },
+        ) {
+          client.putValue(key, "both")
+          untilTrue(15.seconds) { seenA.size == 1 && seenB.size == 1 } shouldBe true
+          seenA.single() shouldBe "both"
+          seenB.single() shouldBe "both"
+        }
+      }
+    }
+
+    "a slow collector loses nothing under the unlimited default" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val prefix = "$base/slow"
+        val seen = CopyOnWriteArrayList<String>()
+
+        withCollector(
+          collect = {
+            launch {
+              client.watchEventsAsFlow(prefix, watchOption { isPrefix(true) }).collect {
+                delay(50) // slower than the producer
+                seen += it.valueAsString
+              }
+            }
+          },
+        ) {
+          repeat(20) { i -> client.putValue("$prefix/k$i", "v$i") }
+          untilTrue(30.seconds) { seen.size == 20 } shouldBe true
+          seen.toList() shouldContainExactly (0 until 20).map { "v$it" }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/WatchFlowFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/WatchFlowFaultTests.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import io.etcd.recipes.common.EtcdTestContainer
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.compact
+import io.etcd.recipes.common.compactOption
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.keyAsString
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.common.valueAsString
+import io.etcd.recipes.common.watchOption
+import io.etcd.recipes.coroutines.WatchFlowEvent
+import io.etcd.recipes.coroutines.watchAsFlow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Real faults through the Flow watch surface: recovery transitions arrive in-band
+ * as [WatchFlowEvent.Recovery] and the flow keeps delivering afterwards.
+ */
+class WatchFlowFaultTests : StringSpec() {
+  private val path = "/fault/${javaClass.simpleName}"
+
+  private suspend fun untilTrue(
+    timeout: Duration,
+    predicate: () -> Boolean,
+  ): Boolean {
+    val start = TimeSource.Monotonic.markNow()
+    while (start.elapsedNow() < timeout) {
+      if (predicate()) return true
+      delay(50)
+    }
+    return predicate()
+  }
+
+  init {
+    "a flow anchored at a compacted revision resyncs in-band and stays live" {
+      assumeFaultInjection()
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(path)
+        val prefix = "$path/compacted"
+        val key = "$prefix/key"
+
+        client.putValue(key, "v1")
+        val oldRevision = client.getResponse(key).kvs.first().modRevision
+        client.putValue(key, "v2")
+        client.putValue(key, "v3")
+        val headRevision = client.getResponse(key).header.revision
+        client.compact(headRevision, compactOption { withCompactPhysical(true) })
+
+        val seen = CopyOnWriteArrayList<Pair<String, String>>()
+        val recovery = CopyOnWriteArrayList<WatchRecoveryEvent>()
+        val resyncWith = {
+          val resp = client.getResponse(prefix, getOption { isPrefix(true) })
+          resp.kvs.forEach { kv -> seen += kv.key.asString to kv.value.asString }
+          resp.header.revision + 1
+        }
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+          scope.launch {
+            // anchored below the compaction point: etcd kills this watch with ErrCompacted
+            client
+              .watchAsFlow(
+                prefix,
+                watchOption { isPrefix(true).withRevision(oldRevision) },
+                resyncWith = resyncWith,
+              ).collect { element ->
+                when (element) {
+                  is WatchFlowEvent.Response -> {
+                    element.response.events.forEach { seen += it.keyAsString to it.valueAsString }
+                  }
+
+                  is WatchFlowEvent.Recovery -> {
+                    recovery += element.event
+                  }
+                }
+              }
+          }
+
+          untilTrue(30.seconds) { recovery.any { it is WatchRecoveryEvent.Resynced } } shouldBe true
+          val resync = recovery.filterIsInstance<WatchRecoveryEvent.Resynced>().first()
+          (resync.compactRevision > 0L) shouldBe true
+          (resync.anchorRevision > resync.compactRevision) shouldBe true
+          // the resync GET observed the current state despite the lost history
+          untilTrue(10.seconds) { seen.any { it.first == key && it.second == "v3" } } shouldBe true
+
+          // and the re-anchored flow is live for new events
+          client.putValue(key, "v4")
+          untilTrue(30.seconds) { seen.any { it.second == "v4" } } shouldBe true
+        } finally {
+          scope.coroutineContext[Job]!!.cancelAndJoin()
+        }
+      }
+    }
+
+    "a flow survives a paused etcd and delivers events after unpause" {
+      assumeFaultInjection()
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(path)
+        val prefix = "$path/pause"
+        val seen = CopyOnWriteArrayList<String>()
+
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+          scope.launch {
+            client.watchAsFlow(prefix, watchOption { isPrefix(true) }).collect { element ->
+              if (element is WatchFlowEvent.Response) {
+                element.response.events.forEach { seen += it.valueAsString }
+              }
+            }
+          }
+          delay(1_000)
+
+          client.putValue("$prefix/a", "before")
+          untilTrue(10.seconds) { seen.contains("before") } shouldBe true
+
+          EtcdTestContainer.pause()
+          try {
+            delay(3_000)
+          } finally {
+            EtcdTestContainer.unpause()
+          }
+          EtcdTestContainer.awaitReady()
+
+          client.putValue("$prefix/b", "after")
+          untilTrue(30.seconds) { seen.contains("after") } shouldBe true
+        } finally {
+          scope.coroutineContext[Job]!!.cancelAndJoin()
+        }
+      }
+    }
+  }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 testcontainers-core = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers" }
 
@@ -59,6 +60,7 @@ testing = [
   "junit-jupiter-api",
   "kotest-runner-junit5",
   "kotest-assertions-core",
+  "kotlinx-coroutines-test",
   "mockk",
   "testcontainers-core",
 ]


### PR DESCRIPTION
First PR of the coroutines-native API layer (product idea #2: `suspend` + `Flow`). The blocking API is unchanged (Java parity); a Kotlin-first async surface lives alongside it in the new `io.etcd.recipes.coroutines` package — same artifact, no new runtime dependency (coroutines 1.11 already ships `CompletableFuture.await()`).

## What's new

**Suspending RPC engine** (`suspendRetryRpc` / `suspendAwaitRpc`, internal): mirrors the blocking retry/timeout contract exactly — same `RetryPolicy`, same retriable statuses (shared predicate with `RpcRetry.kt`), operation timeouts via `withTimeoutOrNull` (so an enclosing `withTimeout`'s cancellation is never mistaken for an attempt timeout), backoff via `delay` instead of `Thread.sleep`. External cancellation cancels the in-flight RPC future and is never retried.

**Suspending twins of the `common/` extensions**, named with the `await` prefix to avoid overload ambiguity with the near-mandatory `io.etcd.recipes.common.*` import: `awaitPutValue`/`awaitGetValue` (all typed overloads), `awaitGetResponse` (isMore re-fetch loop preserved), the children family, `awaitLeaseGrant`/`awaitLeaseRevoke` (cancellation never swallowed), `awaitTransaction` (never retried — ambiguous-commit rationale carries over), `awaitLock`/`awaitUnlock` (`DISABLED` default preserved: a lock call legitimately waits).

**`Client.watchAsFlow(...)`** — etcd watches as `Flow<WatchFlowEvent>`, backed by the existing resilient watcher rather than a reimplementation:

- Recovery transitions (`Suspended`/`Resubscribed`/`Resynced`/`Failed`) arrive **in-band** — a resilient watch that silently hides a compaction resync invites derived-state corruption in collectors.
- Compaction resync works through the same `resyncWith` anchor mechanism as the blocking API.
- Cancelling the collector closes the watcher; the default unlimited buffer guarantees a slow collector can never stall the watch dispatcher thread (which also runs recovery). Bounded capacity is opt-in backpressure.
- `watchEventsAsFlow` flattens to `Flow<WatchEvent>` for stateless collectors.

**Build**: `kotlinx-coroutines-core` moves from `implementation` to `api` (Flow/suspend appear in public signatures — binary-safe; kotlin-stdlib already ships at compile scope); `kotlinx-coroutines-test` added to the test bundle for virtual-time unit tests.

## Testing

- `SuspendRpcRetryTests` — 13 virtual-time unit tests: retriable-code matrix, cause-chain walk, attempt-timeout → future cancelled → retried, policy exhaustion, external cancel during await and during backoff (prompt, no retry, future cancelled), `suspendAwaitRpc` never retries, cancellation never swallowed as retriable.
- `SuspendKVTests` — integration round-trips: typed puts/gets, children/count/delete, txn CAS exactly-once, lease/lock/unlock/revoke sequence.
- `WatchAsFlowTests` — ordered delivery, prefix flattening, collector-cancel closes the watcher, two collectors get independent watchers, slow collector loses nothing.
- `WatchFlowFaultTests` — a flow anchored at a compacted revision emits `Recovery(Resynced)` in-band with a valid anchor and stays live; flow survives pause/unpause.
- Full Testcontainers gate: **307 passed, 0 failed**; lint/detekt clean; Dokka generates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP