### PR TITLE
Add suspending recipe entry points and make waits interruptible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (coroutines: suspending recipes)
+
+- Suspending twins for every recipe's blocking entry points, in
+  `io.etcd.recipes.coroutines`: queues (`receive`, `awaitEnqueue`, work-queue
+  `awaitReceive`/`awaitAck`), barriers (`await`), locks (scoped `withLock` for
+  the thread-owned mutex/RW-lock; `awaitAcquire`/`withPermit` for the semaphore),
+  `DistributedAtomicLong` arithmetic, and the `start`/`waitOn…` lifecycle waits
+  for cache, election, keyvalue, and discovery. Each runs the blocking call on
+  `Dispatchers.IO` via `runInterruptible`, so coroutine cancellation aborts the
+  wait and the recipe's existing cleanup (lease revoke / entry delete) runs.
+
+### Changed
+
+- `DistributedBarrierWithCount.waitOnBarrier`, `LeaderSelector`'s
+  `waitOnLeadershipComplete`/`waitUntilFinished`, and
+  `PathChildrenCache.waitOnStartComplete` now honor thread interruption (they
+  parked on an uninterruptible monitor despite declaring
+  `@Throws(InterruptedException)`). This makes the blocking API interruptible as
+  documented and lets the coroutine twins cancel these waits cleanly; an
+  interrupted barrier waiter stops counting toward the barrier before propagating.
+
 ### Added (coroutines: suspend KV/lease/txn + Flow watches)
 
 - New `io.etcd.recipes.coroutines` package: a Kotlin-first async surface alongside

--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ dispatcher; cancelling the collector closes the watcher. Use
 `watchEventsAsFlow` for a flattened `Flow<WatchEvent>` when no derived state is
 kept.
 
+Every recipe's blocking entry points have suspending twins that run the
+blocking call on `Dispatchers.IO`, so a coroutine can wait on a queue, barrier,
+lock, or counter without dedicating a thread — and cancelling the coroutine
+aborts the wait, cleaning up any queued entry or lease:
+
+| Recipe | Blocking | Suspending |
+|---|---|---|
+| `DistributedQueue` | `dequeue()` / `poll(t)` / `enqueue(v)` | `receive()` / `receive(t)` / `awaitEnqueue(v)` |
+| `DistributedWorkQueue` | `receive()` / `WorkItem.ack()` | `awaitReceive()` / `WorkItem.awaitAck()` |
+| `DistributedBarrier` | `waitOnBarrier()` | `await()` / `await(t)` |
+| `DistributedBarrierWithCount` | `waitOnBarrier()` | `await()` / `await(t)` |
+| `DistributedMutex` / RW lock | `lock { }` (thread-owned) | `withLock { }` (scoped) |
+| `DistributedSemaphore` | `acquire()` / `withPermit { }` | `awaitAcquire()` / `withPermit { }` |
+| `DistributedAtomicLong` | `increment()` / `add(n)` | `awaitIncrement()` / `awaitAdd(n)` |
+| `LeaderSelector` / `PathChildrenCache` | `start()` / `waitOn…()` | `awaitStart()` / `await…()` |
+
+The thread-owned locks (`DistributedMutex`, `DistributedReadWriteLock`) expose
+only the scoped `withLock { }` — ownership is pinned to the acquiring thread, so
+acquisition and release are confined to one thread per call while the body runs
+in your coroutine. The instance-held `DistributedSemaphore` also offers the
+split `awaitAcquire()` / `awaitRelease()`.
+
 ## Distributed locks
 
 `DistributedMutex` is a reentrant distributed lock on etcd's **native lock

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/SuspendingLockExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/SuspendingLockExample.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.coroutines
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.coroutines.withLock
+import io.etcd.recipes.coroutines.withPermit
+import io.etcd.recipes.lock.DistributedMutex
+import io.etcd.recipes.lock.DistributedSemaphore
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Coroutine-scoped mutual exclusion and concurrency limiting: [withLock] holds a
+ * mutex across a suspend section (acquisition and release confined to one thread),
+ * and [withPermit] caps how many coroutines run a section at once.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+
+  runBlocking {
+    connectToEtcd(urls).use { client ->
+      DistributedMutex(client, "/examples/coroutines/mutex").use { mutex ->
+        val counter = AtomicInteger(0)
+        coroutineScope {
+          repeat(5) { id ->
+            launch(Dispatchers.Default) {
+              mutex.withLock {
+                val n = counter.incrementAndGet()
+                logger.info { "Worker $id holds the mutex (count=$n)" }
+                delay(100)
+              }
+            }
+          }
+        }
+      }
+
+      DistributedSemaphore(client, "/examples/coroutines/semaphore", permits = 2).use { semaphore ->
+        val inFlight = AtomicInteger(0)
+        coroutineScope {
+          repeat(6) { id ->
+            launch(Dispatchers.Default) {
+              semaphore.withPermit {
+                val now = inFlight.incrementAndGet()
+                logger.info { "Worker $id holds a permit ($now of 2 in flight)" }
+                delay(150)
+                inFlight.decrementAndGet()
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/SuspendingQueueExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/SuspendingQueueExample.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.coroutines
+
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.coroutines.awaitEnqueue
+import io.etcd.recipes.coroutines.receive
+import io.etcd.recipes.queue.DistributedQueue
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Structured-concurrency producer/consumers over a distributed queue: one
+ * producer enqueues without blocking a thread, several consumers suspend on
+ * [receive], and cancellation of a parked consumer consumes nothing.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val queuePath = "/examples/coroutines/queue"
+
+  runBlocking {
+    connectToEtcd(urls).use { client ->
+      DistributedQueue(client, queuePath).use { queue ->
+        coroutineScope {
+          // Three consumers, each suspending on receive() with a bounded wait
+          repeat(3) { id ->
+            launch(Dispatchers.Default) {
+              while (true) {
+                val item = withTimeoutOrNull(3.seconds) { queue.receive() } ?: break
+                logger.info { "Consumer $id got ${item.asString}" }
+              }
+            }
+          }
+          // Producer feeds ten jobs, then lets the consumers drain and time out
+          repeat(10) { n ->
+            queue.awaitEnqueue("job-$n")
+            delay(100)
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -280,16 +280,7 @@ constructor(
               // Check one more time in case watch missed the delete just after last check
               checkWaiterCount()
 
-              val signalled =
-                try {
-                  keepAliveClosed.waitUntilTrueWithInterruption(timeout)
-                } catch (e: InterruptedException) {
-                  // Interrupted mid-wait (e.g. a coroutine bridge was cancelled):
-                  // stop counting toward the barrier — closeKeepAlive() halts the
-                  // healer and deletes our waiting key — before propagating.
-                  closeKeepAlive()
-                  throw e
-                }
+              val signalled = keepAliveClosed.waitUntilTrueWithInterruption(timeout)
               // Cleanup if a time-out occurred
               if (!signalled) {
                 closeKeepAlive()
@@ -307,6 +298,13 @@ constructor(
           }
     } finally {
       activeWaiter.compareAndSet(active, null)
+      // Stop counting toward the barrier on ANY exit path — normal trip, timeout,
+      // or an exception (e.g. a coroutine bridge cancelled the wait, interrupting a
+      // blocking RPC). closeKeepAlive() is idempotent and halts the healer, so the
+      // waiting key is removed (or expires at its TTL) rather than lingering as a
+      // phantom participant. The deleteKey inside it is best-effort under a set
+      // interrupt flag.
+      closeKeepAlive()
     }
   }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -124,7 +124,7 @@ constructor(
     timeUnit: TimeUnit,
   ): Boolean = waitOnBarrier(timeUnitToDuration(timeout, timeUnit))
 
-  @Suppress("CyclomaticComplexMethod", "LongMethod")
+  @Suppress("CyclomaticComplexMethod", "LongMethod", "ThrowsCount")
   @Throws(InterruptedException::class, EtcdRecipeException::class)
   fun waitOnBarrier(timeout: Duration): Boolean {
     val keepAliveLease = AtomicReference<SelfHealingKeepAlive?>(null)
@@ -280,7 +280,16 @@ constructor(
               // Check one more time in case watch missed the delete just after last check
               checkWaiterCount()
 
-              val signalled = keepAliveClosed.waitUntilTrue(timeout)
+              val signalled =
+                try {
+                  keepAliveClosed.waitUntilTrueWithInterruption(timeout)
+                } catch (e: InterruptedException) {
+                  // Interrupted mid-wait (e.g. a coroutine bridge was cancelled):
+                  // stop counting toward the barrier — closeKeepAlive() halts the
+                  // healer and deletes our waiting key — before propagating.
+                  closeKeepAlive()
+                  throw e
+                }
               // Cleanup if a time-out occurred
               if (!signalled) {
                 closeKeepAlive()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -273,7 +273,7 @@ class PathChildrenCache
   fun waitOnStartComplete(timeout: Duration): Boolean {
     checkStartCalled()
     checkCloseNotCalled()
-    return startThreadComplete.waitUntilTrue(timeout)
+    return startThreadComplete.waitUntilTrueWithInterruption(timeout)
   }
 
   // Re-sync the cache to etcd's current children. Build the fresh view first, then

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/BarrierSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/BarrierSuspend.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.barrier.DistributedBarrier
+import io.etcd.recipes.barrier.DistributedBarrierWithCount
+import io.etcd.recipes.barrier.DistributedDoubleBarrier
+import kotlin.time.Duration
+
+/** Suspending twin of [DistributedBarrier.setBarrier]. */
+suspend fun DistributedBarrier.awaitSetBarrier(): Boolean = etcdInterruptible { setBarrier() }
+
+/** Suspending twin of [DistributedBarrier.removeBarrier]. */
+suspend fun DistributedBarrier.awaitRemoveBarrier(): Boolean = etcdInterruptible { removeBarrier() }
+
+/**
+ * Suspending twin of [DistributedBarrier.waitOnBarrier]: waits until the barrier is
+ * removed. Cancellation interrupts the wait cleanly.
+ */
+suspend fun DistributedBarrier.await(): Boolean = etcdInterruptible { waitOnBarrier() }
+
+/** Suspending twin of the bounded [DistributedBarrier.waitOnBarrier]. */
+suspend fun DistributedBarrier.await(timeout: Duration): Boolean = etcdInterruptible { waitOnBarrier(timeout) }
+
+/**
+ * Suspending twin of [DistributedBarrierWithCount.waitOnBarrier]: waits until
+ * [DistributedBarrierWithCount.memberCount] waiters have arrived. Cancellation
+ * interrupts the wait and revokes this waiter's entry, so it no longer counts
+ * toward the barrier.
+ */
+suspend fun DistributedBarrierWithCount.await(): Boolean = etcdInterruptible { waitOnBarrier() }
+
+/** Suspending twin of the bounded [DistributedBarrierWithCount.waitOnBarrier]. */
+suspend fun DistributedBarrierWithCount.await(timeout: Duration): Boolean = etcdInterruptible { waitOnBarrier(timeout) }
+
+/** Suspending twin of [DistributedDoubleBarrier.enter]. */
+suspend fun DistributedDoubleBarrier.awaitEnter(): Boolean = etcdInterruptible { enter() }
+
+/** Suspending twin of the bounded [DistributedDoubleBarrier.enter]. */
+suspend fun DistributedDoubleBarrier.awaitEnter(timeout: Duration): Boolean = etcdInterruptible { enter(timeout) }
+
+/** Suspending twin of [DistributedDoubleBarrier.leave]. */
+suspend fun DistributedDoubleBarrier.awaitLeave(): Boolean = etcdInterruptible { leave() }
+
+/** Suspending twin of the bounded [DistributedDoubleBarrier.leave]. */
+suspend fun DistributedDoubleBarrier.awaitLeave(timeout: Duration): Boolean = etcdInterruptible { leave(timeout) }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/Bridges.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/Bridges.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
+
+/**
+ * Runs a blocking recipe call on [Dispatchers.IO]. Coroutine cancellation interrupts
+ * the worker thread, which triggers the recipe's existing interrupt-cleanup (lease
+ * revoke / queue-entry delete in finally blocks); the cleanup completes before this
+ * resumes — `runInterruptible` does not abandon the thread. When cancellation
+ * interrupts a thread parked inside the blocking retry engine (which wraps
+ * `InterruptedException` in `EtcdRecipeRuntimeException`), the caller still observes
+ * `CancellationException`: the cancelled scope wins on resumption.
+ */
+internal suspend fun <T> etcdInterruptible(block: () -> T): T = runInterruptible(Dispatchers.IO, block = block)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/Bridges.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/Bridges.kt
@@ -16,16 +16,35 @@
 
 package io.etcd.recipes.coroutines
 
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.runInterruptible
 
 /**
- * Runs a blocking recipe call on [Dispatchers.IO]. Coroutine cancellation interrupts
- * the worker thread, which triggers the recipe's existing interrupt-cleanup (lease
- * revoke / queue-entry delete in finally blocks); the cleanup completes before this
- * resumes — `runInterruptible` does not abandon the thread. When cancellation
- * interrupts a thread parked inside the blocking retry engine (which wraps
- * `InterruptedException` in `EtcdRecipeRuntimeException`), the caller still observes
- * `CancellationException`: the cancelled scope wins on resumption.
+ * Runs a blocking recipe call on [dispatcher] such that coroutine cancellation
+ * interrupts the worker thread, triggering the recipe's existing interrupt-cleanup
+ * (lease revoke / queue-entry delete in finally blocks); the cleanup completes before
+ * this resumes — `runInterruptible` does not abandon the thread.
+ *
+ * The blocking RPC engine catches a mid-call `InterruptedException` and rethrows it
+ * wrapped in an [EtcdRecipeRuntimeException] (with the interrupt flag re-set), so
+ * `runInterruptible` cannot recognize it as cancellation. This unwraps that case:
+ * when the surrounding coroutine has been cancelled, a wrapped interrupt is surfaced
+ * as the expected `CancellationException` rather than a spurious failure.
  */
-internal suspend fun <T> etcdInterruptible(block: () -> T): T = runInterruptible(Dispatchers.IO, block = block)
+internal suspend fun <T> interruptibleOn(
+  dispatcher: CoroutineDispatcher,
+  block: () -> T,
+): T =
+  try {
+    runInterruptible(dispatcher, block = block)
+  } catch (e: EtcdRecipeRuntimeException) {
+    if (e.cause is InterruptedException) currentCoroutineContext().ensureActive()
+    throw e
+  }
+
+/** Runs a blocking recipe call on [Dispatchers.IO]; see [interruptibleOn]. */
+internal suspend fun <T> etcdInterruptible(block: () -> T): T = interruptibleOn(Dispatchers.IO, block)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/CounterSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/CounterSuspend.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.counter.DistributedAtomicLong
+
+/** Suspending twin of [DistributedAtomicLong.get]. */
+suspend fun DistributedAtomicLong.awaitGet(): Long = etcdInterruptible { get() }
+
+/** Suspending twin of [DistributedAtomicLong.increment]. */
+suspend fun DistributedAtomicLong.awaitIncrement(): Long = etcdInterruptible { increment() }
+
+/** Suspending twin of [DistributedAtomicLong.decrement]. */
+suspend fun DistributedAtomicLong.awaitDecrement(): Long = etcdInterruptible { decrement() }
+
+/** Suspending twin of [DistributedAtomicLong.add]. */
+suspend fun DistributedAtomicLong.awaitAdd(value: Long): Long = etcdInterruptible { add(value) }
+
+/** Suspending twin of [DistributedAtomicLong.subtract]. */
+suspend fun DistributedAtomicLong.awaitSubtract(value: Long): Long = etcdInterruptible { subtract(value) }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/DiscoverySuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/DiscoverySuspend.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.discovery.ServiceCache
+import io.etcd.recipes.discovery.ServiceDiscovery
+import io.etcd.recipes.discovery.ServiceInstance
+
+/** Suspending twin of [ServiceDiscovery.registerService]. */
+suspend fun ServiceDiscovery.awaitRegisterService(service: ServiceInstance): Unit =
+  etcdInterruptible { registerService(service) }
+
+/** Suspending twin of [ServiceDiscovery.updateService]. */
+suspend fun ServiceDiscovery.awaitUpdateService(service: ServiceInstance): Unit =
+  etcdInterruptible { updateService(service) }
+
+/** Suspending twin of [ServiceDiscovery.unregisterService]. */
+suspend fun ServiceDiscovery.awaitUnregisterService(service: ServiceInstance): Unit =
+  etcdInterruptible { unregisterService(service) }
+
+/** Suspending twin of [ServiceDiscovery.queryForNames]. */
+suspend fun ServiceDiscovery.awaitQueryForNames(): List<String> = etcdInterruptible { queryForNames() }
+
+/** Suspending twin of [ServiceDiscovery.queryForInstances]. */
+suspend fun ServiceDiscovery.awaitQueryForInstances(name: String): List<ServiceInstance> =
+  etcdInterruptible { queryForInstances(name) }
+
+/** Suspending twin of [ServiceDiscovery.queryForInstance]. */
+suspend fun ServiceDiscovery.awaitQueryForInstance(
+  name: String,
+  id: String,
+): ServiceInstance = etcdInterruptible { queryForInstance(name, id) }
+
+/** Suspending twin of [ServiceCache.start]. */
+suspend fun ServiceCache.awaitStart(): ServiceCache = etcdInterruptible { start() }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LifecycleSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LifecycleSuspend.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.counter.DistributedAtomicLong
+import io.etcd.recipes.election.LeaderSelector
+import io.etcd.recipes.keyvalue.TransientKeyValue
+import kotlin.time.Duration
+
+/** Suspending twin of [TransientKeyValue.start] (blocks until the key is published). */
+suspend fun TransientKeyValue.awaitStart(): TransientKeyValue = etcdInterruptible { start() }
+
+/** Suspending twin of [DistributedAtomicLong.start]. */
+suspend fun DistributedAtomicLong.awaitStart(): DistributedAtomicLong = etcdInterruptible { start() }
+
+/** Suspending twin of [PathChildrenCache.start] (waits for the start to complete). */
+suspend fun PathChildrenCache.awaitStart(buildInitial: Boolean = false): PathChildrenCache =
+  etcdInterruptible { start(buildInitial) }
+
+/** Suspending twin of [PathChildrenCache.start] with an explicit [PathChildrenCache.StartMode]. */
+suspend fun PathChildrenCache.awaitStart(mode: PathChildrenCache.StartMode): PathChildrenCache =
+  etcdInterruptible { start(mode) }
+
+/** Suspending twin of [PathChildrenCache.waitOnStartComplete]. */
+suspend fun PathChildrenCache.awaitStartComplete(): Boolean = etcdInterruptible { waitOnStartComplete() }
+
+/** Suspending twin of the bounded [PathChildrenCache.waitOnStartComplete]. */
+suspend fun PathChildrenCache.awaitStartComplete(timeout: Duration): Boolean =
+  etcdInterruptible { waitOnStartComplete(timeout) }
+
+/** Suspending twin of [LeaderSelector.start]. */
+suspend fun LeaderSelector.awaitStart(): LeaderSelector = etcdInterruptible { start() }
+
+/** Suspending twin of [LeaderSelector.waitOnLeadershipComplete]. */
+suspend fun LeaderSelector.awaitLeadershipComplete(): Boolean = etcdInterruptible { waitOnLeadershipComplete() }
+
+/** Suspending twin of the bounded [LeaderSelector.waitOnLeadershipComplete]. */
+suspend fun LeaderSelector.awaitLeadershipComplete(timeout: Duration): Boolean =
+  etcdInterruptible { waitOnLeadershipComplete(timeout) }
+
+/** Suspending twin of [LeaderSelector.waitUntilFinished]. */
+suspend fun LeaderSelector.awaitFinished(): Boolean = etcdInterruptible { waitUntilFinished() }
+
+/** Suspending twin of the bounded [LeaderSelector.waitUntilFinished]. */
+suspend fun LeaderSelector.awaitFinished(timeout: Duration): Boolean = etcdInterruptible { waitUntilFinished(timeout) }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LockRecipesSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LockRecipesSuspend.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.lock.DistributedSemaphore
+import io.etcd.recipes.lock.EtcdLock
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withContext
+import java.util.concurrent.Executors
+import kotlin.time.Duration
+
+// One dedicated thread per withLock call: EtcdLock ownership is thread-pinned, so
+// acquire and release MUST run on the same thread. Lock calls are rare enough that
+// a short-lived executor per call is cheap.
+private fun confinedLockDispatcher(): ExecutorCoroutineDispatcher =
+  Executors
+    .newSingleThreadExecutor { r -> Thread(r, "etcd-suspend-lock").apply { isDaemon = true } }
+    .asCoroutineDispatcher()
+
+/**
+ * Runs [action] while holding this lock, releasing it on every exit path —
+ * including cancellation of [action] (the release leg runs non-cancellably).
+ *
+ * [EtcdLock] holds are **thread-owned** (mutex and read-write lock pin ownership to
+ * the acquiring thread), so this scoped form is the ONLY suspend surface for them:
+ * acquisition and release are confined to one dedicated thread per call, while
+ * [action] runs in the caller's coroutine. Raw suspend `lock()`/`unlock()` pairs
+ * would land on different dispatcher threads and throw
+ * [IllegalMonitorStateException].
+ *
+ * NOT reentrant: each call is an independent acquisition on a fresh thread —
+ * nesting `withLock` on the same lock self-deadlocks (like kotlinx `Mutex`), and
+ * the blocking API's write→read downgrade does not apply across calls. Cancelling
+ * a coroutine parked in acquisition interrupts it, which revokes the acquisition
+ * lease and leaves nothing queued.
+ *
+ * A file star-importing both `io.etcd.recipes.lock.*` and
+ * `io.etcd.recipes.coroutines.*` gets a compile-time ambiguity error on
+ * `withLock { }` — import one of the two explicitly.
+ */
+suspend fun <T> EtcdLock.withLock(action: suspend () -> T): T {
+  val confined = confinedLockDispatcher()
+  try {
+    runInterruptible(confined) { lock() }
+    try {
+      return action()
+    } finally {
+      // NonCancellable: the release leg must run even when action() was cancelled
+      withContext(NonCancellable) { runInterruptible(confined) { unlock() } }
+    }
+  } finally {
+    confined.close()
+  }
+}
+
+/**
+ * Bounded variant of [withLock]: runs [action] if the lock is acquired within
+ * [timeout], else returns null without queuing anything (the waiter's lease is
+ * revoked). A null return always means "not acquired".
+ */
+suspend fun <T> EtcdLock.withLock(
+  timeout: Duration,
+  action: suspend () -> T,
+): T? {
+  val confined = confinedLockDispatcher()
+  try {
+    if (!runInterruptible(confined) { tryLock(timeout) }) return null
+    try {
+      return action()
+    } finally {
+      withContext(NonCancellable) { runInterruptible(confined) { unlock() } }
+    }
+  } finally {
+    confined.close()
+  }
+}
+
+/**
+ * Suspending twin of [DistributedSemaphore.acquire]. Semaphore holds are
+ * instance-level (any thread may release), so the split acquire/release surface is
+ * safe under dispatcher hopping — unlike [EtcdLock], which is scoped-only.
+ */
+suspend fun DistributedSemaphore.awaitAcquire(): Unit = etcdInterruptible { acquire() }
+
+/** Suspending twin of [DistributedSemaphore.tryAcquire]. */
+suspend fun DistributedSemaphore.awaitTryAcquire(timeout: Duration): Boolean = etcdInterruptible { tryAcquire(timeout) }
+
+/** Suspending twin of [DistributedSemaphore.release]. */
+suspend fun DistributedSemaphore.awaitRelease(): Boolean = etcdInterruptible { release() }
+
+/** Suspending twin of [DistributedSemaphore.availablePermits]. */
+suspend fun DistributedSemaphore.awaitAvailablePermits(): Int = etcdInterruptible { availablePermits() }
+
+/**
+ * Runs [action] while holding a permit, releasing it on every exit path —
+ * including cancellation of [action] (the release leg runs non-cancellably).
+ * Same dual-star-import caveat as [withLock].
+ */
+suspend fun <T> DistributedSemaphore.withPermit(action: suspend () -> T): T {
+  awaitAcquire()
+  try {
+    return action()
+  } finally {
+    // Instance-held permits: any thread may release, so a plain IO thread is fine
+    withContext(NonCancellable) { runInterruptible(Dispatchers.IO) { release() } }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LockRecipesSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LockRecipesSuspend.kt
@@ -59,7 +59,7 @@ private fun confinedLockDispatcher(): ExecutorCoroutineDispatcher =
 suspend fun <T> EtcdLock.withLock(action: suspend () -> T): T {
   val confined = confinedLockDispatcher()
   try {
-    runInterruptible(confined) { lock() }
+    interruptibleOn(confined) { lock() }
     try {
       return action()
     } finally {
@@ -82,7 +82,7 @@ suspend fun <T> EtcdLock.withLock(
 ): T? {
   val confined = confinedLockDispatcher()
   try {
-    if (!runInterruptible(confined) { tryLock(timeout) }) return null
+    if (!interruptibleOn(confined) { tryLock(timeout) }) return null
     try {
       return action()
     } finally {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/QueueSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/QueueSuspend.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.recipes.queue.AbstractQueue
+import io.etcd.recipes.queue.DistributedPriorityQueue
+import io.etcd.recipes.queue.DistributedQueue
+import kotlin.time.Duration
+
+/**
+ * Suspending twin of [AbstractQueue.dequeue]: waits until an item is available.
+ * Cancellation interrupts the wait and leaves the queue intact — no item is
+ * consumed. Compose with `withTimeout { }` or use the bounded overload.
+ */
+suspend fun AbstractQueue.receive(): ByteSequence = etcdInterruptible { dequeue() }
+
+/** Suspending twin of [AbstractQueue.poll]: an item, or null once [timeout] elapses. */
+suspend fun AbstractQueue.receive(timeout: Duration): ByteSequence? = etcdInterruptible { poll(timeout) }
+
+/** Suspending twin of [AbstractQueue.tryDequeue] (non-blocking claim; RPCs still run off-thread). */
+suspend fun AbstractQueue.awaitTryDequeue(): ByteSequence? = etcdInterruptible { tryDequeue() }
+
+/** Suspending twin of [DistributedQueue.enqueue]. */
+suspend fun DistributedQueue.awaitEnqueue(value: ByteSequence): Unit = etcdInterruptible { enqueue(value) }
+
+/** Suspending twin of [DistributedQueue.enqueue] for String values. */
+suspend fun DistributedQueue.awaitEnqueue(value: String): Unit = etcdInterruptible { enqueue(value) }
+
+/** Suspending twin of [DistributedQueue.enqueue] for Int values. */
+suspend fun DistributedQueue.awaitEnqueue(value: Int): Unit = etcdInterruptible { enqueue(value) }
+
+/** Suspending twin of [DistributedQueue.enqueue] for Long values. */
+suspend fun DistributedQueue.awaitEnqueue(value: Long): Unit = etcdInterruptible { enqueue(value) }
+
+/** Suspending twin of [DistributedQueue.enqueueAll] (one all-or-nothing transaction). */
+suspend fun DistributedQueue.awaitEnqueueAll(values: Collection<ByteSequence>): Unit =
+  etcdInterruptible { enqueueAll(values) }
+
+/** Suspending twin of [DistributedPriorityQueue.enqueue]. */
+suspend fun DistributedPriorityQueue.awaitEnqueue(
+  value: ByteSequence,
+  priority: UShort,
+): Unit = etcdInterruptible { enqueue(value, priority) }
+
+/** Suspending twin of [DistributedPriorityQueue.enqueue] for String values. */
+suspend fun DistributedPriorityQueue.awaitEnqueue(
+  value: String,
+  priority: UShort,
+): Unit = etcdInterruptible { enqueue(value, priority) }
+
+/** Suspending twin of [DistributedPriorityQueue.enqueue] for Int values. */
+suspend fun DistributedPriorityQueue.awaitEnqueue(
+  value: Int,
+  priority: UShort,
+): Unit = etcdInterruptible { enqueue(value, priority) }
+
+/** Suspending twin of [DistributedPriorityQueue.enqueue] for Long values. */
+suspend fun DistributedPriorityQueue.awaitEnqueue(
+  value: Long,
+  priority: UShort,
+): Unit = etcdInterruptible { enqueue(value, priority) }
+
+/** Suspending twin of [DistributedPriorityQueue.enqueue] with an Int priority. */
+suspend fun DistributedPriorityQueue.awaitEnqueue(
+  value: ByteSequence,
+  priority: Int,
+): Unit = etcdInterruptible { enqueue(value, priority) }
+
+/** Suspending twin of [DistributedPriorityQueue.enqueue] for String values with an Int priority. */
+suspend fun DistributedPriorityQueue.awaitEnqueue(
+  value: String,
+  priority: Int,
+): Unit = etcdInterruptible { enqueue(value, priority) }
+
+/** Suspending twin of [DistributedPriorityQueue.enqueue] for Int values with an Int priority. */
+suspend fun DistributedPriorityQueue.awaitEnqueue(
+  value: Int,
+  priority: Int,
+): Unit = etcdInterruptible { enqueue(value, priority) }
+
+/** Suspending twin of [DistributedPriorityQueue.enqueue] for Long values with an Int priority. */
+suspend fun DistributedPriorityQueue.awaitEnqueue(
+  value: Long,
+  priority: Int,
+): Unit = etcdInterruptible { enqueue(value, priority) }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/WorkQueueSuspend.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/WorkQueueSuspend.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.recipes.queue.DistributedWorkQueue
+import kotlin.time.Duration
+
+/** Suspending twin of [DistributedWorkQueue.enqueue]. */
+suspend fun DistributedWorkQueue.awaitEnqueue(value: ByteSequence): Unit = etcdInterruptible { enqueue(value) }
+
+/** Suspending twin of [DistributedWorkQueue.enqueue] for String values. */
+suspend fun DistributedWorkQueue.awaitEnqueue(value: String): Unit = etcdInterruptible { enqueue(value) }
+
+/** Suspending twin of [DistributedWorkQueue.enqueue] for Int values. */
+suspend fun DistributedWorkQueue.awaitEnqueue(value: Int): Unit = etcdInterruptible { enqueue(value) }
+
+/** Suspending twin of [DistributedWorkQueue.enqueue] for Long values. */
+suspend fun DistributedWorkQueue.awaitEnqueue(value: Long): Unit = etcdInterruptible { enqueue(value) }
+
+/** Suspending twin of the delayed [DistributedWorkQueue.enqueue]. */
+suspend fun DistributedWorkQueue.awaitEnqueue(
+  value: ByteSequence,
+  delay: Duration,
+): Unit = etcdInterruptible { enqueue(value, delay) }
+
+/** Suspending twin of the delayed [DistributedWorkQueue.enqueue] for String values. */
+suspend fun DistributedWorkQueue.awaitEnqueue(
+  value: String,
+  delay: Duration,
+): Unit = etcdInterruptible { enqueue(value, delay) }
+
+/** Suspending twin of [DistributedWorkQueue.enqueueAll] (one all-or-nothing transaction). */
+suspend fun DistributedWorkQueue.awaitEnqueueAll(values: Collection<ByteSequence>): Unit =
+  etcdInterruptible { enqueueAll(values) }
+
+/**
+ * Suspending twin of [DistributedWorkQueue.receive]: waits until an item can be
+ * claimed. Cancellation interrupts the wait without leaving an orphan claim.
+ */
+suspend fun DistributedWorkQueue.awaitReceive(): DistributedWorkQueue.WorkItem = etcdInterruptible { receive() }
+
+/** Suspending twin of the bounded [DistributedWorkQueue.receive]. */
+suspend fun DistributedWorkQueue.awaitReceive(timeout: Duration): DistributedWorkQueue.WorkItem? =
+  etcdInterruptible { receive(timeout) }
+
+/** Suspending twin of [DistributedWorkQueue.tryReceive]. */
+suspend fun DistributedWorkQueue.awaitTryReceive(): DistributedWorkQueue.WorkItem? = etcdInterruptible { tryReceive() }
+
+/** Suspending twin of [DistributedWorkQueue.WorkItem.ack]. */
+suspend fun DistributedWorkQueue.WorkItem.awaitAck(): Boolean = etcdInterruptible { ack() }
+
+/** Suspending twin of [DistributedWorkQueue.WorkItem.requeue]. */
+suspend fun DistributedWorkQueue.WorkItem.awaitRequeue(): Boolean = etcdInterruptible { requeue() }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -315,8 +315,8 @@ constructor(
     checkStartCalled()
     checkCloseNotCalled()
     // Check startThreadComplete here in case start() was re-used without a call to close()
-    startThreadComplete.waitUntilTrue()
-    return leadershipComplete.waitUntilTrue(timeout)
+    startThreadComplete.waitUntilTrueWithInterruption()
+    return leadershipComplete.waitUntilTrueWithInterruption(timeout)
   }
 
   // Blocking form of [isFinished]: waits until leadership completes (set by close()
@@ -334,7 +334,7 @@ constructor(
   ): Boolean = waitUntilFinished(timeUnitToDuration(timeout, timeUnit))
 
   @Throws(InterruptedException::class)
-  fun waitUntilFinished(timeout: Duration): Boolean = leadershipComplete.waitUntilTrue(timeout)
+  fun waitUntilFinished(timeout: Duration): Boolean = leadershipComplete.waitUntilTrueWithInterruption(timeout)
 
   private fun markLeadershipComplete() {
     terminateWatch.set(true)

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/CoroutineTestSupport.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/CoroutineTestSupport.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import kotlinx.coroutines.delay
+import kotlin.time.Duration
+import kotlin.time.TimeSource
+
+/** Suspending pollUntil: true as soon as [predicate] holds, false once [timeout] elapses. */
+internal suspend fun untilTrue(
+  timeout: Duration,
+  predicate: () -> Boolean,
+): Boolean {
+  val start = TimeSource.Monotonic.markNow()
+  while (start.elapsedNow() < timeout) {
+    if (predicate()) return true
+    delay(50)
+  }
+  return predicate()
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendBarrierTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendBarrierTests.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.barrier.DistributedBarrier
+import io.etcd.recipes.barrier.DistributedBarrierWithCount
+import io.etcd.recipes.barrier.DistributedDoubleBarrier
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Suspend surface for the barriers: waits complete on removal/arrival, bounded
+ * waits time out, and a cancelled barrier-with-count waiter stops counting.
+ */
+class SuspendBarrierTests : StringSpec() {
+  private val base = "/coroutines/${javaClass.simpleName}"
+
+  init {
+    "await returns true when the barrier is removed" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedBarrier(client, "$base/simple").use { barrier ->
+          barrier.awaitSetBarrier() shouldBe true
+          coroutineScope {
+            val waiter = async { barrier.await() }
+            delay(1_000)
+            waiter.isCompleted shouldBe false
+
+            barrier.awaitRemoveBarrier() shouldBe true
+            withTimeout(10.seconds) { waiter.await() } shouldBe true
+          }
+        }
+      }
+    }
+
+    "await with a timeout returns false while the barrier stands" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedBarrier(client, "$base/bounded").use { barrier ->
+          barrier.awaitSetBarrier() shouldBe true
+          barrier.await(2.seconds) shouldBe false
+          barrier.awaitRemoveBarrier() shouldBe true
+        }
+      }
+    }
+
+    "a cancelled barrier-with-count waiter stops counting toward the barrier" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/counted"
+
+        DistributedBarrierWithCount(client, path, memberCount = 3).use { early ->
+          coroutineScope {
+            val doomed = launch { early.await() }
+            untilTrue(15.seconds) { early.waiterCount == 1L } shouldBe true
+            doomed.cancelAndJoin()
+            untilTrue(15.seconds) { early.waiterCount == 0L } shouldBe true
+          }
+        }
+
+        // The cancelled waiter left nothing behind: exactly 3 fresh waiters trip it
+        coroutineScope {
+          val results =
+            (1..3).map {
+              async(Dispatchers.Default) {
+                connectToEtcd(urls).use { c ->
+                  DistributedBarrierWithCount(c, path, memberCount = 3).use { barrier ->
+                    barrier.await(30.seconds)
+                  }
+                }
+              }
+            }
+          results.awaitAll() shouldBe listOf(true, true, true)
+        }
+      }
+    }
+
+    "double barrier rendezvous through the suspend twins" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/double"
+
+        coroutineScope {
+          val results =
+            (1..2).map {
+              async(Dispatchers.Default) {
+                connectToEtcd(urls).use { c ->
+                  DistributedDoubleBarrier(c, path, memberCount = 2).use { barrier ->
+                    val entered = barrier.awaitEnter(30.seconds)
+                    val left = barrier.awaitLeave(30.seconds)
+                    entered to left
+                  }
+                }
+              }
+            }
+          results.awaitAll().forEach { (entered, left) ->
+            entered shouldBe true
+            left shouldBe true
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendLifecycleTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendLifecycleTests.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getValue
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.counter.DistributedAtomicLong
+import io.etcd.recipes.discovery.ServiceDiscovery
+import io.etcd.recipes.discovery.ServiceInstance
+import io.etcd.recipes.election.LeaderSelector
+import io.etcd.recipes.keyvalue.TransientKeyValue
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Suspend surface for counter, keyvalue, cache, election, and discovery: start
+ * variants, waits, CAS counter arithmetic, and register/query round-trips.
+ */
+class SuspendLifecycleTests : StringSpec() {
+  private val base = "/coroutines/${javaClass.simpleName}"
+
+  init {
+    "concurrent awaitAdd lands every increment" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedAtomicLong(client, "$base/counter").use { counter ->
+          coroutineScope {
+            repeat(4) {
+              launch(Dispatchers.Default) {
+                repeat(5) { counter.awaitAdd(1) }
+              }
+            }
+          }
+          counter.awaitGet() shouldBe 20L
+        }
+      }
+    }
+
+    "path children cache awaitStart builds the initial cache" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/cache"
+        client.putValue("$path/a", "1")
+        client.putValue("$path/b", "2")
+
+        PathChildrenCache(client, path).use { cache ->
+          cache.awaitStart(buildInitial = true)
+          cache.awaitStartComplete(10.seconds) shouldBe true
+          cache.currentData.size shouldBe 2
+        }
+      }
+    }
+
+    "leader selector awaitStart and awaitLeadershipComplete" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val elected = BooleanMonitor(false)
+
+        LeaderSelector(
+          client,
+          "$base/election",
+          takeLeadershipBlock = { elected.set(true) },
+        ).use { selector ->
+          selector.awaitStart()
+          selector.awaitLeadershipComplete(30.seconds) shouldBe true
+          elected.get() shouldBe true
+        }
+      }
+    }
+
+    "transient key value awaitStart publishes the key" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/tkv"
+
+        TransientKeyValue(client, path, "alive", autoStart = false).use { tkv ->
+          tkv.awaitStart()
+          untilTrue(10.seconds) { client.getValue(path, "") == "alive" } shouldBe true
+        }
+      }
+    }
+
+    "service discovery suspend round-trip" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+
+        ServiceDiscovery(client, "$base/discovery").use { sd ->
+          val service = ServiceInstance("TestService", "payload")
+          sd.awaitRegisterService(service)
+
+          sd.awaitQueryForNames().size shouldBe 1
+          sd.awaitQueryForInstances("TestService").size shouldBe 1
+          sd.awaitQueryForInstance("TestService", service.id).name shouldBe "TestService"
+
+          val cache = sd.serviceCache("TestService")
+          cache.use {
+            cache.awaitStart()
+            untilTrue(10.seconds) { cache.instances.size == 1 } shouldBe true
+          }
+
+          sd.awaitUnregisterService(service)
+          sd.awaitQueryForInstances("TestService").size shouldBe 0
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendLockTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendLockTests.kt
@@ -1,0 +1,285 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getChildCount
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.lock.DistributedMutex
+import io.etcd.recipes.lock.DistributedReadWriteLock
+import io.etcd.recipes.lock.DistributedSemaphore
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.ints.shouldBeLessThanOrEqual
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Suspend surface for the lock suite. EtcdLock holds are thread-owned, so the only
+ * suspend form is the scoped withLock (acquire and release confined to one dedicated
+ * thread per call); the semaphore's instance-held permits get the full split API.
+ */
+class SuspendLockTests : StringSpec() {
+  private val base = "/coroutines/${javaClass.simpleName}"
+
+  init {
+    "split lock and unlock on different threads throws: why the suspend surface is scoped-only" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedMutex(client, "$base/split").use { mutex ->
+          val d1 = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+          val d2 = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+          try {
+            runInterruptible(d1) { mutex.lock() }
+            shouldThrow<IllegalMonitorStateException> {
+              runInterruptible(d2) { mutex.unlock() }
+            }
+            runInterruptible(d1) { mutex.unlock() } shouldBe true
+          } finally {
+            d1.close()
+            d2.close()
+          }
+        }
+      }
+    }
+
+    "withLock serializes concurrent coroutines" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val inCritical = AtomicInteger(0)
+        val maxInCritical = AtomicInteger(0)
+        var unguarded = 0
+
+        DistributedMutex(client, "$base/serialize").use { mutex ->
+          coroutineScope {
+            repeat(4) {
+              launch(Dispatchers.Default) {
+                repeat(3) {
+                  mutex.withLock {
+                    val now = inCritical.incrementAndGet()
+                    maxInCritical.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                    unguarded += 1
+                    delay(50)
+                    inCritical.decrementAndGet()
+                  }
+                }
+              }
+            }
+          }
+        }
+        maxInCritical.get() shouldBeLessThanOrEqual 1
+        unguarded shouldBe 12
+      }
+    }
+
+    "withLock releases on exception" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedMutex(client, "$base/exception").use { mutex ->
+          shouldThrow<IllegalArgumentException> {
+            mutex.withLock { throw IllegalArgumentException("boom") }
+          }
+          mutex.withLock(5.seconds) { "reacquired" } shouldBe "reacquired"
+        }
+      }
+    }
+
+    "withLock with timeout returns null while held and the value when free" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/timeout"
+        DistributedMutex(client, path).use { holderSide ->
+          DistributedMutex(client, path).use { contenderSide ->
+            coroutineScope {
+              val held = CompletableDeferred<Unit>()
+              val release = CompletableDeferred<Unit>()
+              val holder =
+                launch {
+                  holderSide.withLock {
+                    held.complete(Unit)
+                    release.await()
+                  }
+                }
+              held.await()
+
+              contenderSide.withLock(2.seconds) { "never" } shouldBe null
+
+              release.complete(Unit)
+              holder.join()
+              contenderSide.withLock(10.seconds) { "got it" } shouldBe "got it"
+            }
+          }
+        }
+      }
+    }
+
+    "cancelling a coroutine parked in withLock leaks nothing" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/cancel"
+        DistributedMutex(client, path).use { holderSide ->
+          DistributedMutex(client, path).use { waiterSide ->
+            coroutineScope {
+              val held = CompletableDeferred<Unit>()
+              val release = CompletableDeferred<Unit>()
+              val holder =
+                launch {
+                  holderSide.withLock {
+                    held.complete(Unit)
+                    release.await()
+                  }
+                }
+              held.await()
+
+              val waiter = launch { waiterSide.withLock { "never" } }
+              untilTrue(15.seconds) { client.getChildCount(path) == 2L } shouldBe true
+
+              waiter.cancelAndJoin()
+              untilTrue(15.seconds) { client.getChildCount(path) == 1L } shouldBe true
+
+              release.complete(Unit)
+              holder.join()
+              waiterSide.withLock(10.seconds) { "after" } shouldBe "after"
+            }
+          }
+        }
+      }
+    }
+
+    "withLock is not reentrant: a nested attempt on the same lock times out" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedMutex(client, "$base/nested").use { mutex ->
+          mutex.withLock {
+            mutex.withLock(2.seconds) { "inner" } shouldBe null
+            "outer"
+          } shouldBe "outer"
+        }
+      }
+    }
+
+    "read lock shares and write lock excludes through withLock" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/rw"
+        DistributedReadWriteLock(client, path).use { rw ->
+          val concurrent = AtomicInteger(0)
+          val maxConcurrent = AtomicInteger(0)
+          coroutineScope {
+            repeat(2) {
+              launch(Dispatchers.Default) {
+                rw.readLock.withLock {
+                  val now = concurrent.incrementAndGet()
+                  maxConcurrent.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                  delay(500)
+                  concurrent.decrementAndGet()
+                }
+              }
+            }
+          }
+          maxConcurrent.get() shouldBe 2
+
+          coroutineScope {
+            val held = CompletableDeferred<Unit>()
+            val release = CompletableDeferred<Unit>()
+            val writer =
+              launch {
+                rw.writeLock.withLock {
+                  held.complete(Unit)
+                  release.await()
+                }
+              }
+            held.await()
+            rw.readLock.withLock(2.seconds) { "never" } shouldBe null
+            release.complete(Unit)
+            writer.join()
+          }
+        }
+      }
+    }
+
+    "semaphore split acquire and release survive dispatcher hops" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedSemaphore(client, "$base/sem-split", 1).use { sem ->
+          sem.awaitAcquire()
+          delay(100) // resumption may land on a different IO thread — instance-held, so fine
+          sem.awaitAvailablePermits() shouldBe 0
+          sem.awaitRelease() shouldBe true
+          sem.awaitAvailablePermits() shouldBe 1
+        }
+      }
+    }
+
+    "withPermit caps concurrency and releases on cancellation" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/permits"
+        val inFlight = AtomicInteger(0)
+        val maxInFlight = AtomicInteger(0)
+
+        DistributedSemaphore(client, path, 2).use { sem ->
+          coroutineScope {
+            repeat(5) {
+              launch(Dispatchers.Default) {
+                sem.withPermit {
+                  val now = inFlight.incrementAndGet()
+                  maxInFlight.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                  delay(200)
+                  inFlight.decrementAndGet()
+                }
+              }
+            }
+          }
+          maxInFlight.get() shouldBeLessThanOrEqual 2
+        }
+
+        DistributedSemaphore(client, "$base/permit-cancel", 1).use { sem ->
+          coroutineScope {
+            val entered = CompletableDeferred<Unit>()
+            val holder =
+              launch {
+                sem.withPermit {
+                  entered.complete(Unit)
+                  awaitCancellation()
+                }
+              }
+            entered.await()
+            holder.cancelAndJoin()
+
+            sem.awaitTryAcquire(10.seconds) shouldBe true
+            sem.awaitRelease() shouldBe true
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendQueueTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendQueueTests.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.queue.DistributedPriorityQueue
+import io.etcd.recipes.queue.DistributedQueue
+import io.etcd.recipes.queue.DistributedWorkQueue
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Suspend surface for the queues: FIFO delivery, bounded receive, priority order,
+ * work-queue claim/ack, delayed maturity, and cancellation consuming nothing.
+ */
+class SuspendQueueTests : StringSpec() {
+  private val base = "/coroutines/${javaClass.simpleName}"
+
+  init {
+    "receive returns enqueued values in order" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedQueue(client, "$base/fifo").use { queue ->
+          queue.awaitEnqueue("a")
+          queue.awaitEnqueue("b")
+          queue.awaitEnqueue("c")
+          queue.receive().asString shouldBe "a"
+          queue.receive().asString shouldBe "b"
+          queue.receive().asString shouldBe "c"
+        }
+      }
+    }
+
+    "receive with timeout returns null on an empty queue" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedQueue(client, "$base/empty").use { queue ->
+          queue.receive(2.seconds) shouldBe null
+        }
+      }
+    }
+
+    "cancelling a parked receive consumes nothing" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedQueue(client, "$base/park").use { queue ->
+          coroutineScope {
+            val parked = launch { queue.receive() }
+            delay(1_000) // let it park on the empty queue
+            parked.cancelAndJoin()
+          }
+          queue.awaitEnqueue("later")
+          queue.receive(10.seconds).shouldNotBeNull().asString shouldBe "later"
+        }
+      }
+    }
+
+    "awaitEnqueueAll preserves order in one transaction" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedQueue(client, "$base/batch").use { queue ->
+          queue.awaitEnqueueAll(listOf("x".asByteSequence, "y".asByteSequence, "z".asByteSequence))
+          queue.receive().asString shouldBe "x"
+          queue.receive().asString shouldBe "y"
+          queue.receive().asString shouldBe "z"
+        }
+      }
+    }
+
+    "priority queue delivers by priority through the suspend twins" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedPriorityQueue(client, "$base/priority", minimumWaitTime = 0.milliseconds).use { queue ->
+          queue.awaitEnqueue("low", 10)
+          queue.awaitEnqueue("high", 1)
+          queue.awaitEnqueue("mid", 5u.toUShort())
+          queue.receive().asString shouldBe "high"
+          queue.receive().asString shouldBe "mid"
+          queue.receive().asString shouldBe "low"
+        }
+      }
+    }
+
+    "work queue claim and ack lifecycle" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedWorkQueue(client, "$base/work").use { wq ->
+          wq.awaitEnqueue("job1")
+          val item = wq.awaitReceive()
+          item.value.asString shouldBe "job1"
+          item.awaitAck() shouldBe true
+          wq.awaitTryReceive() shouldBe null
+        }
+      }
+    }
+
+    "cancelling a parked awaitReceive leaves no claim behind" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedWorkQueue(client, "$base/work-cancel").use { wq ->
+          coroutineScope {
+            val parked = launch { wq.awaitReceive() }
+            delay(1_000)
+            parked.cancelAndJoin()
+          }
+          wq.awaitEnqueue("survivor")
+          val item = wq.awaitReceive(10.seconds).shouldNotBeNull()
+          item.value.asString shouldBe "survivor"
+          item.awaitAck() shouldBe true
+        }
+      }
+    }
+
+    "delayed enqueue matures through the suspend twins" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        DistributedWorkQueue(client, "$base/delayed").use { wq ->
+          wq.awaitEnqueue("slow".asByteSequence, 2.seconds)
+          wq.awaitTryReceive() shouldBe null // not matured yet
+          val item = wq.awaitReceive(15.seconds).shouldNotBeNull()
+          item.value.asString shouldBe "slow"
+          item.awaitAck() shouldBe true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Second PR of the coroutines-native API layer (product idea #2), building on the foundation from #62. Adds suspending twins for every recipe's blocking entry points in `io.etcd.recipes.coroutines`.

## Suspending recipe surface

Each twin runs the blocking call on `Dispatchers.IO` via `runInterruptible`, so a coroutine can wait on a queue, barrier, lock, or counter without dedicating a thread — and cancelling the coroutine aborts the wait, letting the recipe's existing cleanup (lease revoke / entry delete) run.

- **Queues** — `AbstractQueue.receive()` / `receive(t)` / `awaitTryDequeue`; `DistributedQueue` / `DistributedPriorityQueue` `awaitEnqueue` overloads + `awaitEnqueueAll`; `DistributedWorkQueue` `awaitReceive` / delayed `awaitEnqueue` / `WorkItem.awaitAck` / `awaitRequeue`.
- **Barriers** — `await()` / `await(t)` for `DistributedBarrier` and `DistributedBarrierWithCount`; `awaitEnter` / `awaitLeave` for the double barrier.
- **Locks** — the thread-owned mutex and RW-lock pin ownership to the acquiring thread, so they expose only a **scoped `withLock`** that confines acquire and release to one dedicated thread per call while the body runs in the caller's coroutine (raw split `lock`/`unlock` would land on different IO threads and throw `IllegalMonitorStateException` — there's a test asserting exactly that). The instance-held `DistributedSemaphore` gets the full `awaitAcquire` / `awaitRelease` / `awaitTryAcquire` + `withPermit` surface.
- **Counter / keyvalue / cache / election / discovery** — `awaitGet` / `awaitAdd`, `awaitStart`, `awaitStartComplete`, `awaitLeadershipComplete`, register/query round-trips.

## Interruptibility fix

`DistributedBarrierWithCount.waitOnBarrier`, `LeaderSelector.waitOnLeadershipComplete` / `waitUntilFinished`, and `PathChildrenCache.waitOnStartComplete` parked on Guava's **uninterruptible** monitor despite all declaring `@Throws(InterruptedException)`. They now use the interruptible monitor variant, so:

- the blocking API honors thread interruption as it already documented (latent inconsistency fixed), and
- the coroutine twins can cancel these waits cleanly instead of hanging.

An interrupted barrier waiter runs `closeKeepAlive()` first, so it stops counting toward the barrier before propagating. Verified regression-clean against the design (source-frozen), barrier, election, and cache suites.

## Testing

- `SuspendLockTests` (9) — the split-lock-throws proof, `withLock` serialization / release-on-exception / timeout / cancel-leaks-nothing / non-reentrancy, RW share+exclude, semaphore split + `withPermit` cap and cancel-release.
- `SuspendQueueTests` (8) — FIFO receive, bounded receive, cancel-consumes-nothing, batch, priority order, work-queue claim/ack, cancel-leaves-no-claim, delayed maturity.
- `SuspendBarrierTests` (4) — await/remove, bounded timeout, **cancelled barrier-with-count waiter stops counting** (the case that exposed the hang), double-barrier rendezvous.
- `SuspendLifecycleTests` — concurrent `awaitAdd`, cache `awaitStart`, leader `awaitStart`/`awaitLeadershipComplete`, keyvalue `awaitStart`, discovery round-trip.
- Full Testcontainers gate: **333 passed, 0 failed**; lint/detekt clean; examples compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP