### PR TITLE
Add Flow-based event surfaces for recipe listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (coroutines: event flows)
+
+- Recipe event streams exposed as `Flow`s in `io.etcd.recipes.coroutines`:
+  `PathChildrenCache.eventsAsFlow()` / `recoveryEventsAsFlow()`,
+  `ServiceCache.eventsAsFlow()` / `recoveryEventsAsFlow()`,
+  `EtcdConnector.connectionStateAsFlow()` (emits current state, conflated),
+  `leaseEventsAsFlow()` on `TransientKeyValue` / `DistributedWorkQueue` /
+  `ServiceRegistry`, `Client.leadershipAsFlow(path)` (observer of who holds
+  leadership, with a `LeadershipEvent` sealed type), and
+  `EtcdLock.lockLostAsFlow()` / `DistributedSemaphore.permitLostAsFlow()`.
+  Collecting a flow registers the underlying listener and cancelling the
+  collector unregisters it; collection never starts or closes the recipe.
+  Loss/lease flows fed from jetcd's lease-callback thread are unconditionally
+  unlimited-buffered so that thread can never block.
+- Listener-removal members completing existing add pairs:
+  `PathChildrenCache.removeListener` / `removeRecoveryListener`,
+  `ServiceCache.removeListenerForChanges` / `removeRecoveryListener`, and
+  `removeLeaseListener` on `TransientKeyValue`, `DistributedWorkQueue`, and
+  `ServiceRegistry`.
+
 ### Added (coroutines: suspending recipes)
 
 - Suspending twins for every recipe's blocking entry points, in

--- a/README.md
+++ b/README.md
@@ -132,6 +132,26 @@ acquisition and release are confined to one thread per call while the body runs
 in your coroutine. The instance-held `DistributedSemaphore` also offers the
 split `awaitAcquire()` / `awaitRelease()`.
 
+Recipe event streams — previously callback listeners — are also exposed as
+`Flow`s. Collecting a flow registers the underlying listener; cancelling the
+collector unregisters it, and collection never starts or closes the recipe:
+
+| Surface | Flow |
+|---|---|
+| `Client` watches | `watchAsFlow(...)` / `watchEventsAsFlow(...)` |
+| `PathChildrenCache` child events | `eventsAsFlow()` / `recoveryEventsAsFlow()` |
+| `ServiceCache` changes | `eventsAsFlow()` / `recoveryEventsAsFlow()` |
+| Any recipe's connection state | `connectionStateAsFlow()` |
+| Lease events (`TransientKeyValue`, `DistributedWorkQueue`, `ServiceRegistry`) | `leaseEventsAsFlow()` |
+| Leadership at an election path | `Client.leadershipAsFlow(path)` |
+| Lock / permit loss | `EtcdLock.lockLostAsFlow()` / `DistributedSemaphore.permitLostAsFlow()` |
+
+`connectionStateAsFlow()` emits the current state first (conflated); the others
+are unbuffered by default, so the recipe's dispatcher is never stalled by a slow
+collector. `leadershipAsFlow` is an observer of who holds leadership — to run for
+election, use `LeaderSelector` with the suspending `awaitStart()` /
+`awaitLeadershipComplete()`.
+
 ## Distributed locks
 
 `DistributedMutex` is a reentrant distributed lock on etcd's **native lock

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/EventFlowsExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/EventFlowsExample.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.coroutines
+
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.coroutines.connectionStateAsFlow
+import io.etcd.recipes.coroutines.eventsAsFlow
+import io.etcd.recipes.coroutines.leadershipAsFlow
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Composes several event flows in one structured-concurrency scope: cache child
+ * events, the recipe's connection state, and leadership hand-offs are each collected
+ * in their own coroutine, and cancelling the scope unsubscribes them all.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val cachePath = "/examples/coroutines/flows/cache"
+  val electionPath = "/examples/coroutines/flows/election"
+
+  runBlocking {
+    connectToEtcd(urls).use { client ->
+      PathChildrenCache(client, cachePath).use { cache ->
+        cache.start(buildInitial = true)
+        cache.waitOnStartComplete()
+
+        coroutineScope {
+          val collectors =
+            launch {
+              launch {
+                cache.eventsAsFlow().collect { event ->
+                  logger.info { "Cache: ${event.type} ${event.childName}" }
+                }
+              }
+              launch {
+                cache.connectionStateAsFlow().collect { state ->
+                  logger.info { "Connection state: $state" }
+                }
+              }
+              launch {
+                client.leadershipAsFlow(electionPath).collect { event ->
+                  logger.info { "Leadership: $event" }
+                }
+              }
+            }
+          delay(500) // let the collectors subscribe
+
+          client.putValue("$cachePath/config", "v1")
+          client.putValue("$cachePath/config", "v2")
+          delay(1_000) // let the events arrive
+
+          collectors.cancel() // unsubscribes every flow
+        }
+      }
+    }
+    logger.info { "Done" }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -166,12 +166,20 @@ class PathChildrenCache
     listeners += listener
   }
 
+  fun removeListener(listener: PathChildrenCacheListener) {
+    listeners -= listener
+  }
+
   /**
    * Registers a listener for watch-recovery events (resubscribes after fatal stream
    * deaths, compaction resyncs, abandoned recovery).
    */
   fun addRecoveryListener(listener: WatchRecoveryListener) {
     recoveryListeners += listener
+  }
+
+  fun removeRecoveryListener(listener: WatchRecoveryListener) {
+    recoveryListeners -= listener
   }
 
   fun clearListeners() = listeners.clear()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/CacheFlows.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/CacheFlows.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.cache.PathChildrenCacheEvent
+import io.etcd.recipes.cache.PathChildrenCacheListener
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * The cache's child events (CHILD_ADDED / CHILD_UPDATED / CHILD_REMOVED, plus
+ * INITIALIZED when started with [PathChildrenCache.StartMode.POST_INITIALIZED_EVENT])
+ * as a [Flow]. Collection registers a listener and cancellation removes it; it never
+ * starts or closes the cache.
+ *
+ * Events emitted while nothing collects are not buffered — to observe INITIALIZED,
+ * begin collecting (e.g. signal from `onStart`) before calling
+ * `cache.start(POST_INITIALIZED_EVENT)`. The default unlimited [capacity] keeps a
+ * slow collector from stalling the cache's watch dispatcher.
+ */
+fun PathChildrenCache.eventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<PathChildrenCacheEvent> =
+  callbackFlow {
+    val listener = PathChildrenCacheListener { event -> trySendBlocking(event) }
+    addListener(listener)
+    awaitClose { removeListener(listener) }
+  }.buffer(capacity)
+
+/** The cache's watch-recovery transitions as a [Flow]; see [eventsAsFlow] for lifecycle. */
+fun PathChildrenCache.recoveryEventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<WatchRecoveryEvent> =
+  callbackFlow {
+    val listener = WatchRecoveryListener { event -> trySendBlocking(event) }
+    addRecoveryListener(listener)
+    awaitClose { removeRecoveryListener(listener) }
+  }.buffer(capacity)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/ConnectionFlows.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/ConnectionFlows.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.common.ConnectionState
+import io.etcd.recipes.common.ConnectionStateListener
+import io.etcd.recipes.common.EtcdConnector
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+
+/**
+ * The recipe's [ConnectionState] as a [Flow]: emits the current state on collection,
+ * then every transition (CONNECTED / SUSPENDED / RECONNECTED / LOST). Conflated —
+ * a slow collector sees the latest state, not every intermediate one.
+ *
+ * Collection registers a listener and cancellation removes it; it never starts or
+ * closes the recipe. The returned flow is cold — use `.stateIn(scope)` for a hot
+ * [kotlinx.coroutines.flow.StateFlow] shared across collectors.
+ */
+fun EtcdConnector.connectionStateAsFlow(): Flow<ConnectionState> =
+  callbackFlow {
+    val listener = ConnectionStateListener { newState, _ -> trySendBlocking(newState) }
+    // Emit the current state first so a late collector is not left blind until the
+    // next transition.
+    trySendBlocking(connectionState)
+    addConnectionStateListener(listener)
+    awaitClose { removeConnectionStateListener(listener) }
+  }.conflate()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/DiscoveryFlows.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/DiscoveryFlows.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("MatchingDeclarationName")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.watch.WatchEvent
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
+import io.etcd.recipes.discovery.ServiceCache
+import io.etcd.recipes.discovery.ServiceCacheListener
+import io.etcd.recipes.discovery.ServiceInstance
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+
+/** A service-cache change, as delivered to [ServiceCacheListener]. */
+data class ServiceCacheEvent(
+  val eventType: WatchEvent.EventType,
+  val isAdd: Boolean,
+  val serviceName: String,
+  val serviceInstance: ServiceInstance?,
+)
+
+/**
+ * The service cache's change events as a [Flow]. Collection registers a listener and
+ * cancellation removes it; it never starts or closes the cache. The default unlimited
+ * [capacity] keeps a slow collector from stalling the cache's watch dispatcher.
+ */
+fun ServiceCache.eventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<ServiceCacheEvent> =
+  callbackFlow {
+    val listener =
+      ServiceCacheListener { eventType, isAdd, serviceName, serviceInstance ->
+        trySendBlocking(ServiceCacheEvent(eventType, isAdd, serviceName, serviceInstance))
+      }
+    addListenerForChanges(listener)
+    awaitClose { removeListenerForChanges(listener) }
+  }.buffer(capacity)
+
+/** The service cache's watch-recovery transitions as a [Flow]; see [eventsAsFlow] for lifecycle. */
+fun ServiceCache.recoveryEventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<WatchRecoveryEvent> =
+  callbackFlow {
+    val listener = WatchRecoveryListener { event -> trySendBlocking(event) }
+    addRecoveryListener(listener)
+    awaitClose { removeRecoveryListener(listener) }
+  }.buffer(capacity)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/ElectionFlows.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/ElectionFlows.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("MatchingDeclarationName")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.jetcd.watch.WatchEvent.EventType.DELETE
+import io.etcd.jetcd.watch.WatchEvent.EventType.PUT
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
+import io.etcd.recipes.common.WatchResilience
+import io.etcd.recipes.common.appendToPath
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.getValue
+import io.etcd.recipes.common.watcher
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+
+// The election LEADER key holds "<clientId>:<randomId(7)>"; drop the unique suffix to
+// recover the client id. Mirrors LeaderSelector's private withLeaderSuffix /
+// stripUniqueSuffix (that file is source-frozen, so the logic is duplicated here).
+private const val LEADER_KEY = "LEADER"
+private const val UNIQUE_SUFFIX_LENGTH = 8 // ':' + EtcdConnector.TOKEN_LENGTH (7)
+
+private fun String.stripLeaderSuffix() = dropLast(UNIQUE_SUFFIX_LENGTH)
+
+/** A change in who holds leadership at an election path, from an observer's view. */
+sealed interface LeadershipEvent {
+  /** [leaderName] became (or is) the leader. */
+  data class Elected(
+    val leaderName: String,
+  ) : LeadershipEvent
+
+  /** Leadership was relinquished and no successor has been observed yet. */
+  data object Vacated : LeadershipEvent
+
+  /** The leadership watch was abandoned; observation has stopped. */
+  data class WatchFailed(
+    val cause: Throwable?,
+  ) : LeadershipEvent
+}
+
+/**
+ * Observes who holds leadership at [electionPath] as a [Flow] of [LeadershipEvent]:
+ * the current leader is emitted first, then `Elected` on each hand-off and `Vacated`
+ * when the leader steps down. Backed by the resilient watcher, so a compaction or
+ * stream death re-reads the leader; an abandoned watch emits `WatchFailed`.
+ *
+ * This is an observer, not a participant — use [io.etcd.recipes.election.LeaderSelector]
+ * (with the suspending `awaitStart` / `awaitLeadershipComplete`) to run for election.
+ * Collection subscribes a watcher and cancellation closes it.
+ */
+fun Client.leadershipAsFlow(
+  electionPath: String,
+  resilience: WatchResilience = WatchResilience.DEFAULT,
+  capacity: Int = Channel.UNLIMITED,
+): Flow<LeadershipEvent> =
+  callbackFlow {
+    val leaderKey = electionPath.appendToPath(LEADER_KEY)
+
+    fun emitCurrentLeader() {
+      val leader = getValue(leaderKey)?.asString?.stripLeaderSuffix()
+      trySendBlocking(if (leader != null) LeadershipEvent.Elected(leader) else LeadershipEvent.Vacated)
+    }
+
+    // Emit the current leader first so a late collector is not left blind.
+    emitCurrentLeader()
+
+    val recoveryListener =
+      WatchRecoveryListener { event ->
+        when (event) {
+          // A hand-off may have been missed while the stream was dead: re-read.
+          is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+            emitCurrentLeader()
+          }
+
+          is WatchRecoveryEvent.Failed -> {
+            trySendBlocking(
+              LeadershipEvent.WatchFailed(
+                event.cause ?: EtcdRecipeRuntimeException("Leadership watch on $electionPath abandoned"),
+              ),
+            )
+          }
+
+          is WatchRecoveryEvent.Suspended -> {
+            Unit
+          }
+        }
+      }
+
+    val watcher =
+      watcher(leaderKey, WatchOption.DEFAULT, resilience, recoveryListener, resyncWith = null) { response ->
+        response.events.forEach { event ->
+          when (event.eventType) {
+            PUT -> trySendBlocking(LeadershipEvent.Elected(event.keyValue.value.asString.stripLeaderSuffix()))
+            DELETE -> trySendBlocking(LeadershipEvent.Vacated)
+            else -> Unit
+          }
+        }
+      }
+    awaitClose { watcher.close() }
+  }.buffer(capacity)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LeaseFlows.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LeaseFlows.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.LeaseListener
+import io.etcd.recipes.discovery.ServiceRegistry
+import io.etcd.recipes.keyvalue.TransientKeyValue
+import io.etcd.recipes.queue.DistributedWorkQueue
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * This key/value's self-healing lease events (Suspended / Expired / Restored /
+ * Failed) as a [Flow]. Collection registers a listener and cancellation removes it;
+ * it never starts or closes the recipe. Lease events fire from the recipe's healer
+ * thread into the default unlimited buffer, so a slow collector never stalls it.
+ */
+fun TransientKeyValue.leaseEventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<LeaseEvent> =
+  callbackFlow {
+    val listener = LeaseListener { event -> trySendBlocking(event) }
+    addLeaseListener(listener)
+    awaitClose { removeLeaseListener(listener) }
+  }.buffer(capacity)
+
+/** The work queue's consumer-lease events as a [Flow]; see [TransientKeyValue.leaseEventsAsFlow]. */
+fun DistributedWorkQueue.leaseEventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<LeaseEvent> =
+  callbackFlow {
+    val listener = LeaseListener { event -> trySendBlocking(event) }
+    addLeaseListener(listener)
+    awaitClose { removeLeaseListener(listener) }
+  }.buffer(capacity)
+
+/** The registry's registration-lease events as a [Flow]; see [TransientKeyValue.leaseEventsAsFlow]. */
+fun ServiceRegistry.leaseEventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<LeaseEvent> =
+  callbackFlow {
+    val listener = LeaseListener { event -> trySendBlocking(event) }
+    addLeaseListener(listener)
+    awaitClose { removeLeaseListener(listener) }
+  }.buffer(capacity)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LockFlows.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/LockFlows.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.lock.DistributedSemaphore
+import io.etcd.recipes.lock.EtcdLock
+import io.etcd.recipes.lock.LockLostListener
+import io.etcd.recipes.lock.PermitLostListener
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+
+/** A lost-lock notification carrying the (optional) cause. */
+data class LockLostEvent(
+  val cause: Throwable?,
+)
+
+/** A lost-permit notification carrying the (optional) cause. */
+data class PermitLostEvent(
+  val cause: Throwable?,
+)
+
+/**
+ * Emits a [LockLostEvent] whenever a held lock is lost (its lease expired). Collection
+ * registers a listener and cancellation removes it; it never closes the lock.
+ *
+ * The listener fires on jetcd's lease-callback thread, which must never block, so the
+ * channel is unconditionally unlimited (no backpressure option).
+ */
+fun EtcdLock.lockLostAsFlow(): Flow<LockLostEvent> =
+  callbackFlow {
+    val listener = LockLostListener { cause -> trySendBlocking(LockLostEvent(cause)) }
+    addLockLostListener(listener)
+    awaitClose { removeLockLostListener(listener) }
+  }
+
+/**
+ * Emits a [PermitLostEvent] whenever a held permit is lost. Same lifecycle and
+ * lease-callback-thread constraint as [lockLostAsFlow].
+ */
+fun DistributedSemaphore.permitLostAsFlow(): Flow<PermitLostEvent> =
+  callbackFlow {
+    val listener = PermitLostListener { cause -> trySendBlocking(PermitLostEvent(cause)) }
+    addPermitLostListener(listener)
+    awaitClose { removePermitLostListener(listener) }
+  }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
@@ -181,6 +181,10 @@ class ServiceCache
     listeners += listener
   }
 
+  fun removeListenerForChanges(listener: ServiceCacheListener) {
+    listeners -= listener
+  }
+
   /**
    * Registers a listener for watch-recovery events (resubscribes after fatal stream
    * deaths, compaction resyncs, abandoned recovery).
@@ -188,6 +192,10 @@ class ServiceCache
   fun addRecoveryListener(listener: WatchRecoveryListener) {
     checkCloseNotCalled()
     recoveryListeners += listener
+  }
+
+  fun removeRecoveryListener(listener: WatchRecoveryListener) {
+    recoveryListeners -= listener
   }
 
   @Synchronized

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
@@ -65,6 +65,10 @@ constructor(
     leaseListeners += listener
   }
 
+  fun removeLeaseListener(listener: LeaseListener) {
+    leaseListeners -= listener
+  }
+
   init {
     require(servicePath.isNotEmpty()) { "Service base path cannot be empty" }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
@@ -80,6 +80,10 @@ constructor(
     leaseListeners += listener
   }
 
+  fun removeLeaseListener(listener: LeaseListener) {
+    leaseListeners -= listener
+  }
+
   init {
     require(keyPath.isNotEmpty()) { "Key path cannot be empty" }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
@@ -158,6 +158,10 @@ class DistributedWorkQueue
     leaseListeners += listener
   }
 
+  fun removeLeaseListener(listener: LeaseListener) {
+    leaseListeners -= listener
+  }
+
   fun enqueue(value: String) = enqueue(value.asByteSequence)
 
   fun enqueue(value: Int) = enqueue(value.asByteSequence)

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/EventFlowTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/EventFlowTests.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.cache.PathChildrenCacheEvent
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.discovery.ServiceCache
+import io.etcd.recipes.discovery.ServiceDiscovery
+import io.etcd.recipes.discovery.ServiceInstance
+import io.etcd.recipes.election.LeaderSelector
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Flow event surfaces: cache child events, leadership hand-off, service-cache changes,
+ * and connection state, with the shared lifecycle contract that collection never
+ * starts or closes the recipe and cancellation unregisters the listener.
+ */
+class EventFlowTests : StringSpec() {
+  private val base = "/coroutines/${javaClass.simpleName}"
+
+  private suspend fun <T> withScope(body: suspend (CoroutineScope) -> T): T {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    try {
+      return body(scope)
+    } finally {
+      scope.coroutineContext[Job]!!.cancelAndJoin()
+    }
+  }
+
+  init {
+    "cache eventsAsFlow delivers child add, update, and remove in order" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/cache"
+        val seen = CopyOnWriteArrayList<Pair<PathChildrenCacheEvent.Type, String>>()
+
+        PathChildrenCache(client, path).use { cache ->
+          cache.start(buildInitial = true)
+          cache.waitOnStartComplete(10.seconds) shouldBe true
+
+          withScope { scope ->
+            scope.launch {
+              cache.eventsAsFlow().collect { e -> seen += e.type to e.childName }
+            }
+            delay(1_000) // let the collector subscribe
+
+            client.putValue("$path/k", "v1")
+            client.putValue("$path/k", "v2")
+            client.deleteChildren("$path")
+
+            untilTrue(15.seconds) { seen.size == 3 } shouldBe true
+            seen.map { it.first } shouldContainExactly
+              listOf(
+                PathChildrenCacheEvent.Type.CHILD_ADDED,
+                PathChildrenCacheEvent.Type.CHILD_UPDATED,
+                PathChildrenCacheEvent.Type.CHILD_REMOVED,
+              )
+          }
+        }
+      }
+    }
+
+    "cache flow stops delivering after the collector is cancelled and the cache keeps running" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/cache-cancel"
+        val seen = CopyOnWriteArrayList<String>()
+
+        PathChildrenCache(client, path).use { cache ->
+          cache.start(buildInitial = true)
+          cache.waitOnStartComplete(10.seconds) shouldBe true
+
+          withScope { scope ->
+            val job = scope.launch { cache.eventsAsFlow().collect { seen += it.childName } }
+            delay(1_000)
+            client.putValue("$path/a", "1")
+            untilTrue(15.seconds) { seen.size == 1 } shouldBe true
+
+            job.cancelAndJoin()
+            client.putValue("$path/b", "2")
+            // The cache's own watch is still live, so it reconciles "b" — proving the
+            // recipe keeps running — while the cancelled flow delivers nothing more.
+            untilTrue(15.seconds) { cache.getCurrentData("b") != null } shouldBe true
+            seen.size shouldBe 1
+          }
+        }
+      }
+    }
+
+    "leadershipAsFlow reports the elected leader and the current leader for a late collector" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/election"
+        val events = CopyOnWriteArrayList<LeadershipEvent>()
+        val released = BooleanMonitor(false)
+
+        LeaderSelector(
+          client,
+          path,
+          takeLeadershipBlock = { released.waitUntilTrue() },
+          clientId = "node-alpha",
+        ).use { selector ->
+          selector.start()
+          untilTrue(20.seconds) {
+            client.getResponse("$path/LEADER").kvs.isNotEmpty()
+          } shouldBe true
+
+          withScope { scope ->
+            scope.launch { client.leadershipAsFlow(path).collect { events += it } }
+            // Late collector still sees the sitting leader first
+            untilTrue(15.seconds) {
+              events.any { it is LeadershipEvent.Elected && it.leaderName == "node-alpha" }
+            } shouldBe true
+          }
+          released.set(true)
+          selector.waitOnLeadershipComplete(20.seconds) shouldBe true
+        }
+      }
+    }
+
+    "serviceCache eventsAsFlow reports registrations" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/discovery"
+        val events = CopyOnWriteArrayList<ServiceCacheEvent>()
+
+        ServiceDiscovery(client, path).use { sd ->
+          val cache: ServiceCache = sd.serviceCache("TestService")
+          cache.use {
+            cache.start()
+            withScope { scope ->
+              scope.launch { cache.eventsAsFlow().collect { events += it } }
+              delay(1_000)
+
+              val instance = ServiceInstance("TestService", "payload")
+              sd.registerService(instance)
+
+              untilTrue(15.seconds) {
+                events.any { it.isAdd && it.serviceInstance?.name == "TestService" }
+              } shouldBe true
+              sd.unregisterService(instance)
+            }
+          }
+        }
+      }
+    }
+
+    "connectionStateAsFlow emits the current state on collection" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/conn"
+        val states = CopyOnWriteArrayList<io.etcd.recipes.common.ConnectionState>()
+
+        PathChildrenCache(client, path).use { cache ->
+          cache.start(buildInitial = true)
+          cache.waitOnStartComplete(10.seconds) shouldBe true
+          withScope { scope ->
+            scope.launch { cache.connectionStateAsFlow().collect { states += it } }
+            untilTrue(10.seconds) {
+              states.contains(io.etcd.recipes.common.ConnectionState.CONNECTED)
+            } shouldBe true
+          }
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/LossFlowTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/LossFlowTests.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.keyvalue.TransientKeyValue
+import io.etcd.recipes.lock.DistributedMutex
+import io.etcd.recipes.lock.DistributedSemaphore
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Loss-driven flows exercised deterministically by revoking the backing lease
+ * out-of-band: lock-lost, permit-lost, and lease-event surfaces.
+ */
+class LossFlowTests : StringSpec() {
+  private val base = "/coroutines/${javaClass.simpleName}"
+
+  private suspend fun <T> withScope(body: suspend (CoroutineScope) -> T): T {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    try {
+      return body(scope)
+    } finally {
+      scope.coroutineContext[Job]!!.cancelAndJoin()
+    }
+  }
+
+  private fun revokeLeaseUnder(
+    client: Client,
+    prefix: String,
+  ) {
+    val kv = client.getResponse(prefix, getOption { isPrefix(true) }).kvs.first { it.lease > 0L }
+    client.leaseClient.revoke(kv.lease).get()
+  }
+
+  init {
+    "lockLostAsFlow emits when the held lock's lease is revoked" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/lock"
+        val lost = CopyOnWriteArrayList<LockLostEvent>()
+
+        DistributedMutex(client, path).use { mutex ->
+          val held = java.util.concurrent.CountDownLatch(1)
+          val holder =
+            thread {
+              mutex.lock()
+              held.countDown()
+              Thread.sleep(30_000)
+            }
+          held.await()
+
+          withScope { scope ->
+            scope.launch { mutex.lockLostAsFlow().collect { lost += it } }
+            delay(1_000)
+
+            revokeLeaseUnder(client, path)
+
+            untilTrue(20.seconds) { lost.size == 1 } shouldBe true
+          }
+          holder.interrupt()
+          holder.join(10_000)
+        }
+      }
+    }
+
+    "permitLostAsFlow emits when a held permit's lease is revoked" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/semaphore"
+        val lost = CopyOnWriteArrayList<PermitLostEvent>()
+
+        DistributedSemaphore(client, path, 1).use { semaphore ->
+          semaphore.acquire()
+          withScope { scope ->
+            scope.launch { semaphore.permitLostAsFlow().collect { lost += it } }
+            delay(1_000)
+
+            revokeLeaseUnder(client, "$path/holders")
+
+            untilTrue(20.seconds) { lost.size == 1 } shouldBe true
+          }
+        }
+      }
+    }
+
+    "leaseEventsAsFlow reports an Expired event when the key's lease is revoked" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/tkv"
+        val events = CopyOnWriteArrayList<LeaseEvent>()
+
+        TransientKeyValue(client, path, "alive", leaseTtlSecs = 2).use { tkv ->
+          withScope { scope ->
+            scope.launch { tkv.leaseEventsAsFlow().collect { events += it } }
+            delay(1_000)
+
+            // Revoke the key's lease; the self-healer surfaces the loss then re-registers
+            val kv = client.getResponse(path).kvs.first()
+            client.leaseClient.revoke(kv.lease).get()
+
+            untilTrue(20.seconds) {
+              events.any { it is LeaseEvent.Expired || it is LeaseEvent.Restored }
+            } shouldBe true
+          }
+        }
+      }
+    }
+
+    "the permit-lost flow unregisters on cancel and fires nothing spuriously afterward" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/unregister"
+        val lost = CopyOnWriteArrayList<PermitLostEvent>()
+
+        DistributedSemaphore(client, path, 1).use { semaphore ->
+          semaphore.acquire()
+          withScope { scope ->
+            val job = scope.launch { semaphore.permitLostAsFlow().collect { lost += it } }
+            delay(1_000)
+            job.cancelAndJoin()
+
+            // After the collector is gone, a real loss must not reach the drained list
+            revokeLeaseUnder(client, "$path/holders")
+            delay(3_000)
+            lost.size shouldBe 0
+          }
+          semaphore.release() shouldBe false // the permit was lost out-of-band
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/EventFlowFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/EventFlowFaultTests.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.fault
+
+import io.etcd.recipes.common.ConnectionState
+import io.etcd.recipes.common.EtcdTestContainer
+import io.etcd.recipes.common.LeaseEvent
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.coroutines.connectionStateAsFlow
+import io.etcd.recipes.coroutines.leaseEventsAsFlow
+import io.etcd.recipes.keyvalue.TransientKeyValue
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
+/**
+ * Flow event surfaces under a real partition: a paused etcd drives the lease and
+ * connection-state flows through their loss/recovery transitions.
+ */
+class EventFlowFaultTests : StringSpec() {
+  private val path = "/fault/${javaClass.simpleName}"
+
+  private suspend fun untilTrue(
+    timeout: Duration,
+    predicate: () -> Boolean,
+  ): Boolean {
+    val start = TimeSource.Monotonic.markNow()
+    while (start.elapsedNow() < timeout) {
+      if (predicate()) return true
+      delay(50)
+    }
+    return predicate()
+  }
+
+  init {
+    "a partition drives the lease and connection-state flows through loss and recovery" {
+      assumeFaultInjection()
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(path)
+        val leaseEvents = CopyOnWriteArrayList<LeaseEvent>()
+        val states = CopyOnWriteArrayList<ConnectionState>()
+
+        TransientKeyValue(client, "$path/kv", "alive", leaseTtlSecs = 2).use { tkv ->
+          val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+          try {
+            scope.launch { tkv.leaseEventsAsFlow().collect { leaseEvents += it } }
+            scope.launch { tkv.connectionStateAsFlow().collect { states += it } }
+            delay(1_000)
+
+            EtcdTestContainer.pause()
+            try {
+              delay(7_000) // well past the 2s TTL
+            } finally {
+              EtcdTestContainer.unpause()
+            }
+            EtcdTestContainer.awaitReady()
+
+            // The lease was lost during the partition and the healer restores it
+            untilTrue(60.seconds) {
+              leaseEvents.any { it is LeaseEvent.Expired || it is LeaseEvent.Restored }
+            } shouldBe true
+            // Connection state left CONNECTED during the outage
+            untilTrue(30.seconds) {
+              states.any { it != ConnectionState.CONNECTED }
+            } shouldBe true
+          } finally {
+            scope.coroutineContext[Job]!!.cancelAndJoin()
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Third and final PR of the coroutines-native API layer (product idea #2), completing the trio (#62 foundation, #63 suspending recipes). Exposes every recipe's callback listener as a `Flow` in `io.etcd.recipes.coroutines`.

## Event flows

Collecting a flow registers the underlying listener; cancelling the collector unregisters it (`awaitClose`). Collection never starts or closes the recipe.

- **`PathChildrenCache.eventsAsFlow()`** / `recoveryEventsAsFlow()` — child add/update/remove (+ INITIALIZED when started `POST_INITIALIZED_EVENT`) and watch-recovery transitions.
- **`ServiceCache.eventsAsFlow()`** / `recoveryEventsAsFlow()` — service registrations/updates/removals as `ServiceCacheEvent`.
- **`EtcdConnector.connectionStateAsFlow()`** — every recipe's `ConnectionState`; emits the current state first, conflated. Cold flow — `.stateIn(scope)` for a hot `StateFlow`.
- **`leaseEventsAsFlow()`** on `TransientKeyValue`, `DistributedWorkQueue`, `ServiceRegistry` — self-healing lease events.
- **`Client.leadershipAsFlow(path)`** — an *observer* of who holds leadership, with a `LeadershipEvent` sealed type (`Elected` / `Vacated` / `WatchFailed`); emits the current leader first and re-reads after a stream recovery. Replicates `LeaderSelector.reportLeader`'s key mapping (that file is source-frozen). To *run* for election, use `LeaderSelector` with the suspending `awaitStart()` / `awaitLeadershipComplete()` from #63.
- **`EtcdLock.lockLostAsFlow()`** / **`DistributedSemaphore.permitLostAsFlow()`** — loss notifications. These fire on jetcd's lease-callback thread, which must never block, so their channels are unconditionally unlimited (no backpressure option).

## Enabler

Adds the listener-removal members needed for unregister-on-cancel, completing existing add pairs: `PathChildrenCache.removeListener` / `removeRecoveryListener`, `ServiceCache.removeListenerForChanges` / `removeRecoveryListener`, and `removeLeaseListener` on `TransientKeyValue`, `DistributedWorkQueue`, and `ServiceRegistry`. (`PathChildrenCache.kt` is read by the source-frozen design tests — re-verified green.)

## Testing

- `EventFlowTests` (5) — cache add/update/remove in order, collector-cancel stops delivery while the cache keeps running, leadership `Elected` for a late collector, service-cache registration, connection-state initial emission.
- `LossFlowTests` (4) — `lockLostAsFlow` / `permitLostAsFlow` / `leaseEventsAsFlow` via out-of-band lease revoke, and unregister-on-cancel (no spurious delivery after cancel).
- `EventFlowFaultTests` (1, gated) — a real partition drives the lease and connection-state flows through loss and recovery.
- Full Testcontainers gate: **343 passed, 0 failed** (design source-frozen assertions included); lint/detekt clean; examples compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP