### PR TITLE
Add load-balancing ServiceProvider with pluggable strategies and noteError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (discovery: load-balancing ServiceProvider)
+
+- `ServiceProvider` now extends `EtcdConnector` and owns an internal `ServiceCache`:
+  `start()` backs reads with a watch-updated in-memory instance map (`close()` releases
+  it); without `start()` each read does a direct etcd lookup, so the existing 3-arg
+  constructor and `getAllInstances()`/`getInstance()` behavior is unchanged.
+- Pluggable `ProviderStrategy` (SAM): `RandomStrategy` (default), `RoundRobinStrategy`,
+  `StickyStrategy` (session affinity).
+- `noteError(instance)` ejects a failing instance from selection after an error
+  threshold for a down window, then auto-recovers (keyed by instance value, not the
+  unstable `id`).
+- `ServiceDiscovery.serviceProvider(name, strategy, …)` overload + `withServiceProvider { }`.
+
 ### Added (election: leader latch)
 
 - `LeaderLatch` — a Curator-style leader latch that acquires leadership and **holds

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ what [Curator](https://curator.apache.org) provides for [ZooKeeper](https://zook
 | `io.etcd.recipes.barrier` | `DistributedBarrier`, `DistributedBarrierWithCount`, `DistributedDoubleBarrier` |
 | `io.etcd.recipes.cache` | `PathChildrenCache` (key-prefix cache with PUT/UPDATE/DELETE listeners) |
 | `io.etcd.recipes.counter` | `DistributedAtomicLong` |
-| `io.etcd.recipes.discovery` | `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`, `ServiceProvider` |
+| `io.etcd.recipes.discovery` | `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`, `ServiceProvider`, `ProviderStrategy` |
 | `io.etcd.recipes.election` | `LeaderSelector`, `LeaderLatch`, `LeaderObserver`, `LeaderSelectorListener`, `Participant` |
 | `io.etcd.recipes.keyvalue` | `TransientKeyValue` (lease-backed key/value) |
 | `io.etcd.recipes.lock` | `DistributedMutex`, `DistributedReadWriteLock`, `DistributedSemaphore` |
@@ -218,6 +218,35 @@ Holds are instance-level, Java-`Semaphore`-style: any thread may release
 (releases are LIFO among the instance's holds), and a permit whose lease
 expires is lost cooperatively — a `PermitLostListener` fires and the matching
 `release()` returns false.
+
+## Load-balancing service provider
+
+`ServiceProvider` hands out instances of a registered service with a pluggable
+[`ProviderStrategy`](etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ProviderStrategy.kt)
+— `RandomStrategy` (the default), `RoundRobinStrategy`, or `StickyStrategy` (session
+affinity) — the basis for client-side load balancing. Call `start()` to back reads
+with a watch-updated `ServiceCache` (in-memory, current); without `start()` each read
+does a direct etcd lookup (the original behavior). Mark a failing instance with
+`noteError`: after an error threshold it is ejected from selection for a down window,
+then automatically becomes eligible again.
+
+```kotlin
+import io.etcd.recipes.discovery.RoundRobinStrategy
+import io.etcd.recipes.discovery.withServiceDiscovery
+
+withServiceDiscovery(client, "/services/app") {
+    withServiceProvider("worker", RoundRobinStrategy()) {
+        start()                         // watch-backed, in-memory reads
+        val instance = getInstance()    // round-robin pick
+        // … on a failed request to `instance`:
+        noteError(instance)             // eject it from rotation for a while
+    }
+}
+```
+
+Stateful strategies (`RoundRobinStrategy`, `StickyStrategy`) hold per-provider state —
+use a fresh one per provider. The observer-only `LeaderObserver` /
+`Client.leadershipAsFlow` are the election analogues.
 
 ## Reliable work queue
 

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/discovery/ServiceProviderExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/discovery/ServiceProviderExample.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.discovery
+
+import com.pambrose.common.util.sleep
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.discovery.RoundRobinStrategy
+import io.etcd.recipes.discovery.ServiceInstance
+import io.etcd.recipes.discovery.withServiceDiscovery
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Client-side load balancing: register three instances of a service, then hand them out
+ * round-robin from a watch-backed [io.etcd.recipes.discovery.ServiceProvider]. One
+ * instance is marked failing via `noteError` and is skipped until its down window elapses.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val servicePath = "/services/provider-example"
+  val serviceName = "worker"
+
+  connectToEtcd(urls) { client ->
+    withServiceDiscovery(client, servicePath) {
+      for (i in 1..3) registerService(ServiceInstance(serviceName, IntPayload(i).toJson()))
+
+      // errorThreshold=1 so a single noteError ejects; short down window for the demo.
+      withServiceProvider(serviceName, RoundRobinStrategy(), errorThreshold = 1, downPeriod = 5.seconds) {
+        start()
+        while (getAllInstances().size < 3) sleep(200.milliseconds)
+
+        logger.info { "Round-robin across all three instances:" }
+        repeat(6) { logger.info { "  -> ${getInstance().jsonPayload}" } }
+
+        val failing = getInstance()
+        logger.info { "Marking ${failing.jsonPayload} as failing" }
+        noteError(failing)
+
+        logger.info { "It is now skipped:" }
+        repeat(6) { logger.info { "  -> ${getInstance().jsonPayload}" } }
+
+        sleep(6.seconds)
+        logger.info { "After the down window it is back in rotation:" }
+        repeat(6) { logger.info { "  -> ${getInstance().jsonPayload}" } }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ProviderStrategy.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ProviderStrategy.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("MatchingDeclarationName")
+
+package io.etcd.recipes.discovery
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Picks one instance from the currently-available set (a [ServiceProvider]'s live
+ * instances minus any ejected by `noteError`), or null if the set is empty.
+ * Community-extensible: implement this to add a custom load-balancing policy.
+ */
+fun interface ProviderStrategy {
+  fun select(instances: List<ServiceInstance>): ServiceInstance?
+}
+
+/**
+ * Uniformly random selection — the default. Stateless, so a single instance is safe to
+ * share across providers.
+ */
+object RandomStrategy : ProviderStrategy {
+  override fun select(instances: List<ServiceInstance>): ServiceInstance? = instances.randomOrNull()
+}
+
+/**
+ * Even round-robin via a monotonic cursor. `Math.floorMod` keeps the index non-negative
+ * across `AtomicInteger` overflow and adapts automatically to list-size changes.
+ *
+ * STATEFUL — use a fresh instance per [ServiceProvider]; sharing one across providers
+ * interleaves their cursors.
+ */
+class RoundRobinStrategy : ProviderStrategy {
+  private val cursor = AtomicInteger(0)
+
+  override fun select(instances: List<ServiceInstance>): ServiceInstance? {
+    if (instances.isEmpty()) return null
+    return instances[Math.floorMod(cursor.getAndIncrement(), instances.size)]
+  }
+}
+
+/**
+ * Session affinity: returns the previously-selected instance while it is still present
+ * (by value-equality, id-independent), otherwise [delegate]s to pick a new one and
+ * remembers it.
+ *
+ * STATEFUL — use a fresh instance per [ServiceProvider].
+ */
+class StickyStrategy(
+  private val delegate: ProviderStrategy = RandomStrategy,
+) : ProviderStrategy {
+  private val last = AtomicReference<ServiceInstance?>(null)
+
+  @Suppress("ReturnCount")
+  override fun select(instances: List<ServiceInstance>): ServiceInstance? {
+    if (instances.isEmpty()) {
+      last.set(null)
+      return null
+    }
+    val current = last.get()
+    if (current != null && current in instances) return current
+    val picked = delegate.select(instances)
+    last.set(picked)
+    return picked
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceDiscovery.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceDiscovery.kt
@@ -31,6 +31,7 @@ import io.etcd.recipes.common.getValue
 import io.etcd.recipes.discovery.ServiceDiscovery.Companion.defaultClientId
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration
 
 @JvmOverloads
 fun <T> withServiceDiscovery(
@@ -95,12 +96,28 @@ constructor(
     receiver: ServiceCache.() -> T,
   ) = serviceCache(name).use { it.receiver() }
 
-  fun serviceProvider(serviceName: String): ServiceProvider {
+  @JvmOverloads
+  fun serviceProvider(
+    serviceName: String,
+    strategy: ProviderStrategy = RandomStrategy,
+    errorThreshold: Int = ServiceProvider.DEFAULT_ERROR_THRESHOLD,
+    downPeriod: Duration = ServiceProvider.DEFAULT_DOWN_PERIOD,
+  ): ServiceProvider {
     checkCloseNotCalled()
-    val provider = ServiceProvider(client, namesPath, serviceName)
+    val provider =
+      ServiceProvider(client, namesPath, serviceName, strategy, errorThreshold, downPeriod, resilienceConfig)
     serviceProviderList += provider
     return provider
   }
+
+  @JvmOverloads
+  fun <T> withServiceProvider(
+    serviceName: String,
+    strategy: ProviderStrategy = RandomStrategy,
+    errorThreshold: Int = ServiceProvider.DEFAULT_ERROR_THRESHOLD,
+    downPeriod: Duration = ServiceProvider.DEFAULT_DOWN_PERIOD,
+    receiver: ServiceProvider.() -> T,
+  ): T = serviceProvider(serviceName, strategy, errorThreshold, downPeriod).use { it.receiver() }
 
   @Synchronized
   fun queryForNames(): List<String> {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceProvider.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceProvider.kt
@@ -19,35 +19,134 @@
 package io.etcd.recipes.discovery
 
 import io.etcd.jetcd.Client
+import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdRecipeException
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
 import io.etcd.recipes.common.appendToPath
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.getChildrenValues
-import java.io.Closeable
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
 
-class ServiceProvider(
-  private val client: Client,
-  namesPath: String,
-  val serviceName: String,
-) : Closeable {
-  // Direct path to the service's instances. The previous implementation lazily
-  // constructed a nested ServiceDiscovery rooted at namesPath, which caused
-  // path double-nesting (`namesPath/names/...`) and escaped lifecycle tracking
-  // by the parent ServiceDiscovery.
-  private val instancesPath: String = namesPath.appendToPath(serviceName)
+/**
+ * Client-side load balancer over a service's instances. Selection is pluggable
+ * ([ProviderStrategy]; [RandomStrategy] by default) and failing instances can be ejected
+ * with [noteError].
+ *
+ * Two read modes:
+ * - after [start], reads are served from an owned, watch-updated [ServiceCache] — cheap
+ *   and current, the mode to use on a hot path;
+ * - before [start] (or without ever starting), each read does a direct etcd range GET —
+ *   the original behavior, kept for callers that just want a one-off lookup.
+ *
+ * Stateful strategies ([RoundRobinStrategy], [StickyStrategy]) must not be shared across
+ * providers. [close] releases the owned cache (if started) and is a safe no-op otherwise.
+ */
+class ServiceProvider
+  @JvmOverloads
+  constructor(
+    client: Client,
+    private val namesPath: String,
+    val serviceName: String,
+    private val strategy: ProviderStrategy = RandomStrategy,
+    private val errorThreshold: Int = DEFAULT_ERROR_THRESHOLD,
+    private val downPeriod: Duration = DEFAULT_DOWN_PERIOD,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : EtcdConnector(client, resilience) {
+    // Direct path to the service's instances (no path doubling — mirrors ServiceCache).
+    private val instancesPath: String = namesPath.appendToPath(serviceName)
 
-  // "No instances available" is an ordinary discovery condition, not a programming
-  // error, so surface the library's typed exception (matching ServiceDiscovery's
-  // absent-instance contract) instead of letting List.random() throw a bare,
-  // context-free NoSuchElementException.
-  @Throws(EtcdRecipeException::class)
-  fun getInstance(): ServiceInstance =
-    getAllInstances().randomOrNull() ?: throw EtcdRecipeException("No instances available for service $serviceName")
+    // Owned, lazily-started cache; non-null only between start() and doClose(). Plain var
+    // guarded by @Synchronized start()/doClose(), matching ServiceCache's `watcher` style.
+    private var cache: ServiceCache? = null
 
-  fun getAllInstances(): List<ServiceInstance> =
-    client.getChildrenValues(instancesPath).map { ServiceInstance.toObject(it.asString) }
+    // Ejected instances, keyed by ServiceInstance value-equality (id is not stable).
+    private val down = ConcurrentHashMap<ServiceInstance, DownEntry>()
 
-  override fun close() {
-    // No owned resources: provider does not hold a watcher, lease, or executor.
+    init {
+      require(serviceName.isNotEmpty()) { "ServiceProvider service name cannot be empty" }
+      require(errorThreshold > 0) { "errorThreshold must be > 0" }
+    }
+
+    /** Opens the owned watch-backed cache so subsequent reads are in-memory. One-shot. */
+    @Synchronized
+    fun start(): ServiceProvider {
+      if (startCalled.load()) throw EtcdRecipeRuntimeException("start() already called")
+      checkCloseNotCalled()
+      cache = ServiceCache(client, namesPath, serviceName, resilience).start()
+      startCalled.store(true)
+      startThreadComplete.set(true)
+      return this
+    }
+
+    /** All registered instances: cache-backed once [start]ed, a direct GET otherwise. */
+    fun getAllInstances(): List<ServiceInstance> =
+      if (startCalled.load())
+        cache?.instances ?: emptyList()
+      else
+        client.getChildrenValues(instancesPath).map { ServiceInstance.toObject(it.asString) }
+
+    /**
+     * Selects one available instance via the configured [strategy]. Throws the typed
+     * [EtcdRecipeException] (naming the service) when nothing is available — whether none
+     * are registered or all have been ejected by [noteError].
+     */
+    @Throws(EtcdRecipeException::class)
+    fun getInstance(): ServiceInstance =
+      strategy.select(availableInstances())
+        ?: throw EtcdRecipeException("No instances available for service $serviceName")
+
+    // getAllInstances() minus instances still inside their down window.
+    private fun availableInstances(): List<ServiceInstance> {
+      val all = getAllInstances()
+      return if (down.isEmpty()) all else all.filterNot { isDown(it) }
+    }
+
+    /**
+     * Records a failed request against [instance]. After [errorThreshold] errors it is
+     * ejected from selection for [downPeriod], then automatically becomes eligible again.
+     * Pass the instance returned by [getInstance] unmodified — ejection keys on its value.
+     */
+    fun noteError(instance: ServiceInstance) {
+      val entry = down.computeIfAbsent(instance) { DownEntry() }
+      if (entry.errors.incrementAndGet() >= errorThreshold) {
+        entry.downUntil = TimeSource.Monotonic.markNow() + downPeriod
+        entry.errors.set(0)
+      }
+    }
+
+    @Suppress("ReturnCount")
+    private fun isDown(instance: ServiceInstance): Boolean {
+      val entry = down[instance] ?: return false
+      val until = entry.downUntil ?: return false
+      if (until.hasPassedNow()) {
+        down.remove(instance) // lazy cleanup on auto-recovery
+        return false
+      }
+      return true
+    }
+
+    @Synchronized
+    override fun doClose() {
+      // No checkStartCalled(): an un-started provider must close as a no-op.
+      cache?.close()
+      cache = null
+      down.clear()
+    }
+
+    private class DownEntry {
+      val errors = AtomicInteger(0)
+
+      @Volatile
+      var downUntil: TimeSource.Monotonic.ValueTimeMark? = null
+    }
+
+    companion object {
+      const val DEFAULT_ERROR_THRESHOLD = 3
+      val DEFAULT_DOWN_PERIOD: Duration = 30.seconds
+    }
   }
-}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ProviderStrategyTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ProviderStrategyTests.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.discovery
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.shouldBe
+
+/**
+ * Pure selection semantics of the load-balancing strategies — no etcd. Instances carry
+ * distinct payloads so value-equality distinguishes them.
+ */
+class ProviderStrategyTests : StringSpec() {
+  private fun instances(n: Int) = (1..n).map { serviceInstance("svc", "payload-$it") }
+
+  init {
+    "RandomStrategy returns an element of a non-empty list" {
+      val list = instances(3)
+      repeat(20) { RandomStrategy.select(list) shouldBeIn list }
+    }
+
+    "RandomStrategy returns null on an empty list" {
+      RandomStrategy.select(emptyList()) shouldBe null
+    }
+
+    "RoundRobinStrategy cycles through every instance in order and wraps" {
+      val list = instances(3)
+      val strategy = RoundRobinStrategy()
+      val picks = (1..6).map { strategy.select(list) }
+      picks shouldBe listOf(list[0], list[1], list[2], list[0], list[1], list[2])
+    }
+
+    "RoundRobinStrategy stays valid when the list shrinks" {
+      val three = instances(3)
+      val strategy = RoundRobinStrategy()
+      strategy.select(three) // advance the cursor
+      strategy.select(three)
+      // List drops to 1: index must stay in range, never throw.
+      val one = listOf(three[0])
+      repeat(5) { strategy.select(one) shouldBe three[0] }
+    }
+
+    "RoundRobinStrategy returns null on an empty list" {
+      RoundRobinStrategy().select(emptyList()) shouldBe null
+    }
+
+    "StickyStrategy returns the same instance until it leaves, then re-picks" {
+      val list = instances(3)
+      val strategy = StickyStrategy()
+      val first = strategy.select(list)!!
+      repeat(5) { strategy.select(list) shouldBe first } // sticks
+
+      // Remove the stuck instance: a different one is selected and then sticks.
+      val without = list.filter { it != first }
+      val second = strategy.select(without)!!
+      (second != first) shouldBe true
+      repeat(5) { strategy.select(without) shouldBe second }
+    }
+
+    "StickyStrategy returns null on empty and re-picks after the list refills" {
+      val list = instances(2)
+      val strategy = StickyStrategy()
+      strategy.select(list)
+      strategy.select(emptyList()) shouldBe null
+      strategy.select(list) shouldBeIn list
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceProviderCacheTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceProviderCacheTests.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.discovery
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The started provider is backed by a watch-updated ServiceCache: reads are in-memory
+ * and converge on registrations, selection load-balances, and noteError ejects an
+ * instance until its down window elapses.
+ */
+class ServiceProviderCacheTests : StringSpec() {
+  private val path = "/discovery/${javaClass.simpleName}"
+  private val name = "cached-svc"
+
+  init {
+    beforeSpec { urls }
+
+    "a started provider serves cache-backed instances and round-robins across all" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        withServiceDiscovery(client, path) {
+          val instances = (1..4).map { ServiceInstance(name, "payload-$it") }
+          instances.forEach { registerService(it) }
+
+          withServiceProvider(name, RoundRobinStrategy()) {
+            start()
+            pollUntil(20.seconds) { getAllInstances().size == instances.size } shouldBe true
+
+            val hits = (1..instances.size * 3).map { getInstance().jsonPayload }.toSet()
+            hits shouldContainExactlyInAnyOrder instances.map { it.jsonPayload }
+          }
+        }
+      }
+    }
+
+    "noteError removes an instance from selection until the down window elapses" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        withServiceDiscovery(client, path) {
+          val instances = (1..3).map { ServiceInstance(name, "note-$it") }
+          instances.forEach { registerService(it) }
+
+          withServiceProvider(name, RoundRobinStrategy(), errorThreshold = 1, downPeriod = 2.seconds) {
+            start()
+            pollUntil(20.seconds) { getAllInstances().size == instances.size } shouldBe true
+
+            val target = getInstance()
+            noteError(target)
+
+            // Ejected across many selections while inside the window.
+            repeat(12) { (getInstance().jsonPayload == target.jsonPayload) shouldBe false }
+
+            // Eligible again once the window elapses.
+            pollUntil(10.seconds) {
+              (1..6).map { getInstance().jsonPayload }.contains(target.jsonPayload)
+            } shouldBe true
+          }
+        }
+      }
+    }
+
+    "close is clean and idempotent after start" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(path)
+        withServiceDiscovery(client, path) {
+          registerService(ServiceInstance(name, "solo"))
+          val provider = serviceProvider(name).start()
+          pollUntil(20.seconds) { provider.getAllInstances().size == 1 } shouldBe true
+          provider.close()
+          provider.close() // idempotent no-op
+          provider.hasExceptions shouldBe false
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceProviderTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceProviderTests.kt
@@ -24,13 +24,17 @@ import io.etcd.jetcd.KeyValue
 import io.etcd.jetcd.kv.GetResponse
 import io.etcd.recipes.common.EtcdRecipeException
 import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.pollUntil
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class ServiceProviderTests : StringSpec() {
     private fun clientReturning(kvs: List<KeyValue>): Client {
@@ -41,6 +45,17 @@ class ServiceProviderTests : StringSpec() {
         every { kv.get(any(), any()) } returns CompletableFuture.completedFuture(getResp)
         return mockk { every { kvClient } returns kv }
     }
+
+    // Build a mocked client whose ranged GET returns these instances (unstarted read path).
+    private fun clientReturningInstances(instances: List<ServiceInstance>): Client =
+        clientReturning(
+            instances.mapIndexed { i, instance ->
+                mockk<KeyValue> {
+                    every { key } returns "/services/names/my-service/id$i".asByteSequence
+                    every { value } returns instance.toJson().asByteSequence
+                }
+            },
+        )
 
     init {
         // Regression test for #10: an empty result is an ordinary discovery condition,
@@ -63,6 +78,42 @@ class ServiceProviderTests : StringSpec() {
             val provider = ServiceProvider(clientReturning(listOf(kv)), "/services/names", "my-service")
 
             provider.getInstance().name shouldBe "my-service"
+        }
+
+        "round-robin distributes getInstance across all instances" {
+            val instances = (1..3).map { serviceInstance("my-service", "payload-$it") }
+            val provider =
+                ServiceProvider(
+                    clientReturningInstances(instances),
+                    "/services/names",
+                    "my-service",
+                    strategy = RoundRobinStrategy(),
+                )
+
+            val picks = (1..3).map { provider.getInstance() }
+            picks shouldContainExactlyInAnyOrder instances
+        }
+
+        "noteError ejects an instance until its down window elapses, then it recovers" {
+            val alive = serviceInstance("my-service", "alive")
+            val failing = serviceInstance("my-service", "failing")
+            val provider =
+                ServiceProvider(
+                    clientReturningInstances(listOf(alive, failing)),
+                    "/services/names",
+                    "my-service",
+                    strategy = RoundRobinStrategy(),
+                    errorThreshold = 1,
+                    downPeriod = 500.milliseconds,
+                )
+
+            provider.noteError(failing) // threshold 1 -> ejected immediately
+
+            // Within the window only the healthy instance is ever selected.
+            repeat(10) { provider.getInstance() shouldBe alive }
+
+            // After the window the ejected instance becomes eligible again.
+            pollUntil(5.seconds) { (1..4).map { provider.getInstance() }.contains(failing) } shouldBe true
         }
     }
 }


### PR DESCRIPTION
Product idea #5, core (no gRPC `NameResolver` — a possible follow-up). `ServiceProvider` did a full etcd range read and a random pick on **every** `getInstance()`, ignoring the watch-backed `ServiceCache` that already maintains the instance map. It's now a cache-backed client-side load balancer.

## What's new

- **Cache-backed, dual-mode reads.** `ServiceProvider` extends `EtcdConnector` and owns an internal `ServiceCache`. After `start()`, reads are served from that watch-updated in-memory map (cheap, current — the mode for a hot path); without `start()`, each read does a direct etcd lookup, so the existing 3-arg constructor and `getAllInstances()`/`getInstance()` behavior is **unchanged**. `close()` releases the owned cache (if started) and is a safe idempotent no-op otherwise.
- **Pluggable `ProviderStrategy`** (SAM interface): `RandomStrategy` (default, backward-compatible), `RoundRobinStrategy`, `StickyStrategy` (session affinity). Stateful strategies are per-provider (documented).
- **`noteError(instance)` down-instance tracking.** After an error threshold (default 3) an instance is ejected from selection for a down window (default 30s), then automatically becomes eligible again. Keyed by `ServiceInstance` **value-equality** — `id` is a body property regenerated on every deserialization, so it can't be the key.
- **`ServiceDiscovery.serviceProvider(name, strategy, …)`** overload (the frozen 1-arg call still resolves) + `withServiceProvider(name, strategy…) { }`.

## Compatibility

The dual-mode read is the linchpin: every frozen `DesignFixesTests` case (Fix #6 both parts, Fix #12) and the mocked `ServiceProviderTests` call the read **unstarted**, so they hit the preserved direct-read path. A purely cache-backed provider would have broken them (the mocked test stubs only `kvClient.get`, no watcher). `ServiceCache` and `ServiceInstance` are untouched (including the reflection-frozen `watcher` field and the `equals`/`id` semantics).

## Testing

- `ProviderStrategyTests` (7, pure) — Random element/empty; RoundRobin cycles-and-wraps and stays valid under a shrinking list; Sticky holds then re-picks.
- `ServiceProviderTests` (extended, mocked/unstarted) — the two frozen cases, plus round-robin distribution and `noteError` eject-then-recover.
- `ServiceProviderCacheTests` (3, real etcd) — started provider serves cache-backed instances and round-robins across all N; `noteError` removes one until the window elapses; close is clean + idempotent.
- Full Testcontainers gate: **372 passed, 0 failed**; lint/detekt clean; example compiles; the frozen `DesignFixesTests` oracle stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP