### PR TITLE
Anchor lock waiters' DELETE-watch at the observed revision to fix a lost-wakeup hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Fixed (locks: read-write lock / semaphore wait)
+
+- `DistributedReadWriteLock` and `DistributedSemaphore` could park a caller
+  indefinitely under contention. A waiter's DELETE-watch was created without a
+  start revision, so it began at whatever revision etcd assigned when it processed
+  the create — racing the pre-live recheck GET. A predecessor's release landing in
+  that watch-establishment window was missed by both the watch and the recheck, and
+  an unbounded `lock()` then parked forever. Each wait now anchors its watch at the
+  revision where its ranged read observed the blocker present, so the release is
+  always (re)delivered; the pre-live recheck is now only a fast path.
+
 ### Added (discovery: load-balancing ServiceProvider)
 
 - `ServiceProvider` now extends `EtcdConnector` and owns an internal `ServiceCache`:

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
@@ -21,7 +21,6 @@ package io.etcd.recipes.lock
 import com.pambrose.common.time.timeUnitToDuration
 import com.pambrose.common.util.randomId
 import io.etcd.jetcd.Client
-import io.etcd.jetcd.KeyValue
 import io.etcd.jetcd.options.GetOption
 import io.etcd.recipes.common.EtcdConnector
 import io.etcd.recipes.common.EtcdRecipeRuntimeException
@@ -274,10 +273,11 @@ class DistributedReadWriteLock
           if (attempt.phase.load() == Phase.DEAD) latch.countDown() // fatal raced the install
           WaiterSupport.awaitKeyDeletion(
             client,
-            conflict.key.asString,
+            conflict.key,
             resilience,
             latch,
             deadline,
+            observedRevision = conflict.observedRevision,
             reportRecovery = { event -> reportRecoveryEvent(event) },
             recordException = { e -> exceptionList.value += e },
           )
@@ -298,13 +298,15 @@ class DistributedReadWriteLock
 
   // One consistent snapshot (a single ranged read), sorted by create revision.
   // The nearest EARLIER conflicting entry is the wait target; the calling
-  // thread's own write entry is excluded so write→read downgrade admits.
+  // thread's own write entry is excluded so write→read downgrade admits. The
+  // snapshot's revision rides along so the wait can anchor its DELETE-watch at
+  // the point the conflict was observed present (see WaiterSupport).
   private fun nearestConflict(
     side: Side,
     thread: Thread,
     ownEntryKey: String,
     ownCreateRevision: Long,
-  ): KeyValue? {
+  ): Conflict? {
     val snapshot =
       client.getResponse(
         lockPath,
@@ -316,21 +318,31 @@ class DistributedReadWriteLock
         resilience.rpc,
       )
     val ownWriteEntry = writeHolds[thread]?.entryKey
-    return snapshot.kvs
-      .asSequence()
-      .filter { it.createRevision < ownCreateRevision }
-      .filter { kv ->
-        val basename = kv.key.asString.substringAfterLast('/')
-        when (side) {
-          Side.WRITE -> true
+    val conflict =
+      snapshot.kvs
+        .asSequence()
+        .filter { it.createRevision < ownCreateRevision }
+        .filter { kv ->
+          val basename = kv.key.asString.substringAfterLast('/')
+          when (side) {
+            Side.WRITE -> true
 
-          // any earlier entry conflicts with a writer
-          Side.READ -> basename.startsWith(Side.WRITE.entryPrefix)
+            // any earlier entry conflicts with a writer
+            Side.READ -> basename.startsWith(Side.WRITE.entryPrefix)
+          }
         }
-      }
-      .filter { it.key.asString != ownEntryKey && it.key.asString != ownWriteEntry }
-      .maxByOrNull { it.createRevision }
+        .filter { it.key.asString != ownEntryKey && it.key.asString != ownWriteEntry }
+        .maxByOrNull { it.createRevision }
+        ?: return null
+    return Conflict(conflict.key.asString, snapshot.header.revision)
   }
+
+  // Nearest earlier conflicting entry plus the revision at which the ranged read
+  // observed it present.
+  private data class Conflict(
+    val key: String,
+    val observedRevision: Long,
+  )
 
   // Runs on jetcd's lease callback thread — no blocking RPCs here. The phase
   // machine guarantees exactly one of {waiter-abort, lockLost} runs.

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
@@ -253,13 +253,13 @@ class DistributedSemaphore
           }
           if (deadline != null && deadline.hasPassedNow()) return false
 
-          val rank = rankOf(entryKey)
+          val snap = rankOf(entryKey)
             ?: run {
               // Own entry gone: the lease died in the window
               Thread.sleep(LEASE_HEAL_PAUSE_MS)
               continue@outer
             }
-          if (rank < permits) {
+          if (snap.rank < permits) {
             // Admitted: publish the hold BEFORE claiming the phase (a fatal in
             // the win window must always find the hold — or the CAS failure
             // below rolls it back).
@@ -284,9 +284,10 @@ class DistributedSemaphore
             resilience,
             latch,
             deadline,
+            observedRevision = snap.observedRevision,
             shouldWake = {
               val now = rankOf(entryKey)
-              now == null || now < permits
+              now == null || now.rank < permits
             },
             reportRecovery = { event -> reportRecoveryEvent(event) },
             recordException = { e -> exceptionList.value += e },
@@ -306,9 +307,11 @@ class DistributedSemaphore
     }
   }
 
-  // Create-revision rank of the entry within one consistent prefix snapshot;
-  // null once the entry no longer exists (its lease died).
-  private fun rankOf(entryKey: String): Int? {
+  // Create-revision rank of the entry within one consistent prefix snapshot,
+  // plus the revision at which that snapshot observed the blockers present (so
+  // the wait can anchor its DELETE-watch there); null once the entry no longer
+  // exists (its lease died).
+  private fun rankOf(entryKey: String): RankSnapshot? {
     val snapshot =
       client.getResponse(
         "$holdersPath/",
@@ -320,8 +323,13 @@ class DistributedSemaphore
         resilience.rpc,
       )
     val idx = snapshot.kvs.indexOfFirst { it.key.asString == entryKey }
-    return if (idx < 0) null else idx
+    return if (idx < 0) null else RankSnapshot(idx, snapshot.header.revision)
   }
+
+  private data class RankSnapshot(
+    val rank: Int,
+    val observedRevision: Long,
+  )
 
   // Runs on jetcd's lease callback thread — no blocking RPCs here. The phase
   // machine guarantees exactly one of {waiter-abort, permitLost} runs.

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/WaiterSupport.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/WaiterSupport.kt
@@ -42,21 +42,32 @@ import kotlin.time.Duration
  * deadline passes. Watch failures unpark and throw. Follows the queue/barrier
  * watcher discipline: recheck RPCs run on the watch dispatcher thread, never on
  * jetcd's event loop.
+ *
+ * Every waiter anchors its watch at `observedRevision + 1`, where `observedRevision`
+ * is the store revision at which the caller's ranged read last saw the awaited
+ * predecessor present. An un-anchored watch starts at whatever revision etcd assigns
+ * when it processes the create — which races the pre-live recheck GET, so a DELETE
+ * landing in that establishment window is missed by both and an unbounded `lock()`
+ * parks forever. Anchoring replays every event after the observation, closing the
+ * window; the pre-live recheck then only shortcuts the already-satisfied case. Pass
+ * `observedRevision = 0` to opt out (watch from the current revision).
  */
 internal object WaiterSupport {
   /** Waits for the DELETE of exactly [key]; the wake predicate is key absence. */
+  @Suppress("LongParameterList")
   fun awaitKeyDeletion(
     client: Client,
     key: String,
     resilience: ResilienceConfig,
     latch: CountDownLatch,
     deadline: ComparableTimeMark?,
+    observedRevision: Long,
     reportRecovery: (WatchRecoveryEvent) -> Unit,
     recordException: (Throwable) -> Unit,
   ) = await(
     client,
     key,
-    watchOption { withNoPut(true) },
+    watchOption { withNoPut(true).anchorAt(observedRevision) },
     resilience,
     latch,
     deadline,
@@ -78,13 +89,14 @@ internal object WaiterSupport {
     resilience: ResilienceConfig,
     latch: CountDownLatch,
     deadline: ComparableTimeMark?,
+    observedRevision: Long,
     shouldWake: () -> Boolean,
     reportRecovery: (WatchRecoveryEvent) -> Unit,
     recordException: (Throwable) -> Unit,
   ) = await(
     client,
     prefix,
-    watchOption { withNoPut(true).isPrefix(true) },
+    watchOption { withNoPut(true).isPrefix(true).anchorAt(observedRevision) },
     resilience,
     latch,
     deadline,
@@ -92,6 +104,12 @@ internal object WaiterSupport {
     reportRecovery,
     recordException,
   )
+
+  // Anchor the watch just past the revision at which the predecessor was observed
+  // present, so its DELETE (necessarily at a later revision) is always (re)delivered.
+  // observedRevision <= 0 means "no anchor" — subscribe at the current revision.
+  private fun WatchOption.Builder.anchorAt(observedRevision: Long): WatchOption.Builder =
+    apply { if (observedRevision > 0L) withRevision(observedRevision + 1) }
 
   @Suppress("LongParameterList")
   private fun await(

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/WaiterSupportTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/WaiterSupportTests.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.recipes.common.ResilienceConfig
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+
+/**
+ * Anchoring contract for [WaiterSupport]. A DELETE-watch created without a start revision
+ * begins at whatever the store revision happens to be when etcd processes the create — so a
+ * DELETE that lands in the gap between the pre-live recheck and the watch going live is lost
+ * by both, and an unbounded `lock()` parks forever. The fix is to anchor the watch at the
+ * revision at which the awaited predecessor was last observed present, guaranteeing every
+ * later DELETE is (re)delivered. These tests pin that the subscribed [WatchOption] carries
+ * `observedRevision + 1`.
+ *
+ * jetcd's [Watch] is mocked (in the [io.etcd.recipes.common.ResilientWatcherTests] style) so
+ * the option handed to the subscribe call can be captured; no etcd connection is required. An
+ * already-open latch plus a null deadline lets `await` return the instant the subscribe is
+ * recorded.
+ */
+class WaiterSupportTests : StringSpec() {
+  /** Captures the [WatchOption] of every subscribe the watcher under test makes. */
+  private class WatchMocks {
+    val options = CopyOnWriteArrayList<WatchOption>()
+
+    val watch: Watch =
+      mockk {
+        every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+          options += secondArg<WatchOption>()
+          mockk<Watch.Watcher>(relaxed = true)
+        }
+      }
+
+    val client: Client = mockk { every { watchClient } returns watch }
+  }
+
+  init {
+    "awaitKeyDeletion anchors the DELETE watch at observedRevision + 1" {
+      val mocks = WatchMocks()
+      WaiterSupport.awaitKeyDeletion(
+        mocks.client,
+        "/lock/write-0001",
+        ResilienceConfig.DEFAULT,
+        CountDownLatch(0),
+        deadline = null,
+        observedRevision = 100L,
+        reportRecovery = {},
+        recordException = {},
+      )
+      mocks.options.size shouldBe 1
+      mocks.options[0].revision shouldBe 101L
+      mocks.options[0].isNoPut shouldBe true
+    }
+
+    "awaitKeyDeletion with observedRevision 0 leaves the watch un-anchored" {
+      val mocks = WatchMocks()
+      WaiterSupport.awaitKeyDeletion(
+        mocks.client,
+        "/lock/write-0001",
+        ResilienceConfig.DEFAULT,
+        CountDownLatch(0),
+        deadline = null,
+        observedRevision = 0L,
+        reportRecovery = {},
+        recordException = {},
+      )
+      mocks.options.size shouldBe 1
+      mocks.options[0].revision shouldBe 0L
+    }
+
+    "awaitPrefixDeletion anchors the prefix DELETE watch at observedRevision + 1" {
+      val mocks = WatchMocks()
+      WaiterSupport.awaitPrefixDeletion(
+        mocks.client,
+        "/sem/holders/",
+        ResilienceConfig.DEFAULT,
+        CountDownLatch(0),
+        deadline = null,
+        observedRevision = 200L,
+        shouldWake = { false },
+        reportRecovery = {},
+        recordException = {},
+      )
+      mocks.options.size shouldBe 1
+      mocks.options[0].revision shouldBe 201L
+      mocks.options[0].isPrefix shouldBe true
+      mocks.options[0].isNoPut shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
## Problem

`DistributedReadWriteLock` and `DistributedSemaphore` could park a caller **indefinitely** under contention — the cause of a lock test hanging a CI gate for ~7 hours.

In `WaiterSupport`, a waiter's DELETE-watch was created **without a start revision**, so it began at whatever revision etcd assigned when it *processed* the create request. That races the pre-live recheck GET: if a blocker's release (DELETE) lands in the window between the recheck being processed and the watch going live, it is missed by **both** — the recheck saw the key present, and the watch started after the delete. The unbounded `lock()` then parks forever.

This is rare and load-dependent (needs request reordering plus a DELETE inside a sub-millisecond window), which is why it passed six prior gates and hung once.

## Fix

Anchor each waiter's watch at `observedRevision + 1`, where `observedRevision` is the store revision at which the caller's ranged read last observed the blocker present. Because the blocker was present at that revision, its release necessarily commits *later*, so the anchored watch is guaranteed to (re)deliver it. The pre-live recheck degrades to a fast path.

This is the same anchoring `PathChildrenCache` and `ServiceCache` already do (`header.revision + 1`) — the caches had it right; the locks didn't. Compaction of a just-observed revision is handled by the existing `ResilientWatcher` resync path.

## Changes

- **`lock/WaiterSupport.kt`** — new `observedRevision` parameter on `awaitKeyDeletion`/`awaitPrefixDeletion` and an `anchorAt` helper (`0` opts out → watch from the current revision).
- **`lock/DistributedReadWriteLock.kt`** — `nearestConflict` returns `Conflict(key, observedRevision)`.
- **`lock/DistributedSemaphore.kt`** — `rankOf` returns `RankSnapshot(rank, observedRevision)`.
- **`lock/WaiterSupportTests.kt`** *(new)* — TDD; pins that the subscribed watch is anchored at `observedRevision + 1` (and un-anchored when `0`).
- **`CHANGELOG.md`** — `### Fixed` entry.

## Verification

- New `WaiterSupportTests` green (written RED-first).
- Lock package green, including the previously-hanging contention and downgrade cases.
- **10/10** stress runs of the contention-heavy suites.
- Full `make tests-tc` gate: **375/375** (one earlier run had a transient Testcontainers/Ryuk container-startup flake — infra, not code — green on clean rerun).
- `lintKotlin` + `detekt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP
