### PR TITLE
Anchor barrier and queue waiter watches to close the same lost-wakeup race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ non-blocking consumption on the existing queues.
   revision where its ranged read observed the blocker present, so the release is
   always (re)delivered; the pre-live recheck is now only a fast path.
 
+### Fixed (barriers / queue: waiter watch)
+
+- `DistributedBarrier`, `DistributedBarrierWithCount`, and the queues
+  (`DistributedQueue` / `DistributedPriorityQueue`) shared the same un-anchored-watch
+  race as the locks: a waiter's watch was subscribed without a start revision, so a
+  barrier DELETE / ready DELETE / queue PUT landing in the watch-establishment window
+  could be lost by both the watch and the pre-live recheck. Each now anchors its watch
+  at the revision its pre-subscribe read observed, so the awaited event is always
+  (re)delivered.
+
 ### Added (discovery: load-balancing ServiceProvider)
 
 - `ServiceProvider` now extends `EtcdConnector` and owns an internal `ServiceCache`:

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -31,6 +31,7 @@ import io.etcd.recipes.common.SelfHealingKeepAlive
 import io.etcd.recipes.common.WatchRecoveryEvent
 import io.etcd.recipes.common.WatchRecoveryListener
 import io.etcd.recipes.common.deleteKey
+import io.etcd.recipes.common.doesExist
 import io.etcd.recipes.common.doesNotExist
 import io.etcd.recipes.common.isKeyPresent
 import io.etcd.recipes.common.putOption
@@ -180,10 +181,19 @@ constructor(
     } else {
       // Presence at wait start bounds the recovery recheck below: with
       // waitOnMissingBarriers=true a waiter on a never-set barrier must keep
-      // waiting across recoveries, not release spuriously.
-      val barrierPresentAtStart = isBarrierSet()
+      // waiting across recoveries, not release spuriously. The probe's revision
+      // anchors the watch at observedRevision + 1 so a DELETE landing in the
+      // watch-establishment window (between this probe and the watch going live)
+      // is still delivered; the pre-live recheck below is then only a fast path.
+      val startProbe = client.transaction(resilience.rpc) { If(barrierPath.doesExist) }
+      val barrierPresentAtStart = startProbe.isSucceeded
+      val observedRevision = startProbe.header.revision
       val waitLatch = CountDownLatch(1)
-      val watchOption = watchOption { withNoPut(true) }
+      val watchOption =
+        watchOption {
+          if (observedRevision > 0L) withRevision(observedRevision + 1)
+          withNoPut(true)
+        }
       val watchFailure = AtomicReference<Throwable?>()
       val recoveryListener = waiterRecoveryListener(barrierPresentAtStart, waitLatch, watchFailure)
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -41,6 +41,8 @@ import io.etcd.recipes.common.deleteOp
 import io.etcd.recipes.common.doesExist
 import io.etcd.recipes.common.doesNotExist
 import io.etcd.recipes.common.getChildCount
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
 import io.etcd.recipes.common.isKeyPresent
 import io.etcd.recipes.common.putOption
 import io.etcd.recipes.common.selfHealingKeepAlive
@@ -230,7 +232,20 @@ constructor(
           } else {
             // Watch for DELETE of /ready and PUTS on /waiters/*
             val trailingKey = barrierPath.ensureSuffix("/")
-            val watchOption = watchOption { isPrefix(true) }
+            // Anchor the prefix watch at observedRevision + 1 so a /ready DELETE or
+            // waiter PUT landing in the watch-establishment window is still delivered;
+            // checkWaiterCount below is then only a fast-path recheck.
+            val observedRevision =
+              client.getResponse(
+                trailingKey,
+                getOption { isPrefix(true).withCountOnly(true) },
+                resilience.rpc,
+              ).header.revision
+            val watchOption =
+              watchOption {
+                if (observedRevision > 0L) withRevision(observedRevision + 1)
+                isPrefix(true)
+              }
             val watchFailure = java.util.concurrent.atomic.AtomicReference<Throwable?>()
 
             // A ready-key DELETE or waiter PUT can be lost while the watch stream is

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -89,7 +89,8 @@ abstract class AbstractQueue(
     // retry could allocate a new watcher (with its own dispatcher executor).
     // Under high contention the resulting churn was unbounded.
     while (true) {
-      val childList = client.getFirstChild(queuePath, target, resilience.rpc).kvs
+      val firstChild = client.getFirstChild(queuePath, target, resilience.rpc)
+      val childList = firstChild.kvs
       if (childList.isNotEmpty()) {
         val child = childList.first()
         if (deleteRevKey(child)) {
@@ -103,16 +104,23 @@ abstract class AbstractQueue(
 
       // Queue is empty; wait under a single watcher. If the CAS delete fails
       // after waking up, loop and retry — withWatcher closes its dispatcher
-      // before we retry, so no executor or watcher resources accumulate.
-      val winner = waitForFirstChild(deadline) ?: continue
+      // before we retry, so no executor or watcher resources accumulate. Anchor
+      // the watch at the revision we observed the queue empty, so a PUT landing
+      // in the watch-establishment window is still delivered (the pre-live poll
+      // then only shortcuts the already-arrived case).
+      val winner = waitForFirstChild(deadline, firstChild.header.revision) ?: continue
       if (deleteRevKey(winner)) return winner.value
     }
   }
 
-  private fun waitForFirstChild(deadline: ComparableTimeMark? = null): KeyValue? {
+  private fun waitForFirstChild(
+    deadline: ComparableTimeMark?,
+    observedRevision: Long,
+  ): KeyValue? {
     val watchLatch = CountDownLatch(1)
     val watchOption =
       watchOption {
+        if (observedRevision > 0L) withRevision(observedRevision + 1)
         isPrefix(true)
         withNoDelete(true)
       }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWatchRecoveryTests.kt
@@ -38,6 +38,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -56,6 +57,7 @@ class BarrierWatchRecoveryTests : StringSpec() {
     private val presentProbes: Int,
   ) {
     val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    val options = CopyOnWriteArrayList<WatchOption>()
     private val probeCount = AtomicInteger(0)
 
     val client: Client =
@@ -68,18 +70,29 @@ class BarrierWatchRecoveryTests : StringSpec() {
                 every { If(*anyVararg()) } returns this
                 every { Then(*anyVararg()) } returns this
                 every { commit() } returns
-                  CompletableFuture.completedFuture(mockk<TxnResponse> { every { isSucceeded } returns present })
+                  CompletableFuture.completedFuture(
+                    mockk<TxnResponse> {
+                      every { isSucceeded } returns present
+                      every { header } returns mockk { every { revision } returns OBSERVED_REV }
+                    },
+                  )
               }
             }
           }
         every { watchClient } returns
           mockk<Watch> {
             every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+              options += secondArg<WatchOption>()
               listeners += thirdArg<Watch.Listener>()
               mockk<Watch.Watcher>(relaxed = true)
             }
           }
       }
+
+    companion object {
+      /** Revision the presence probe observes the barrier at; the watch must anchor at +1. */
+      const val OBSERVED_REV = 100L
+    }
   }
 
   private fun Watch.Listener.die() {
@@ -88,6 +101,19 @@ class BarrierWatchRecoveryTests : StringSpec() {
   }
 
   init {
+    "waitOnBarrier anchors its DELETE-watch at the observed-present revision" {
+      // The presence probe saw the barrier set at OBSERVED_REV; a DELETE landing before
+      // the watch goes live would be lost by an un-anchored watch. The watch must start
+      // at OBSERVED_REV + 1 so the release is (re)delivered.
+      val mocks = BarrierMocks(presentProbes = Int.MAX_VALUE) // stays present → parks until timeout
+      DistributedBarrier(mocks.client, "/barrier/recovery").use { barrier ->
+        barrier.waitOnBarrier(500.milliseconds)
+        mocks.options.size shouldBe 1
+        mocks.options.first().revision shouldBe BarrierMocks.OBSERVED_REV + 1
+        mocks.options.first().isNoPut shouldBe true
+      }
+    }
+
     "waiter releases after recovery when the barrier DELETE happened during the outage" {
       // Probe #1 (presence at wait start): present. Later probes (recovery recheck): absent.
       val mocks = BarrierMocks(presentProbes = 1)

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWithCountWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWithCountWatchRecoveryTests.kt
@@ -43,6 +43,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -62,6 +63,7 @@ class BarrierWithCountWatchRecoveryTests : StringSpec() {
     private val readyPresentProbes: Int,
   ) {
     val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    val options = CopyOnWriteArrayList<WatchOption>()
     private val txnCount = AtomicInteger(0)
 
     val client: Client =
@@ -84,6 +86,7 @@ class BarrierWithCountWatchRecoveryTests : StringSpec() {
                   every { count } returns 1L // waiter count stays below memberCount
                   every { kvs } returns emptyList()
                   every { isMore } returns false
+                  every { header } returns mockk { every { revision } returns OBSERVED_REV }
                 },
               )
             every { delete(any<ByteSequence>()) } returns
@@ -99,11 +102,17 @@ class BarrierWithCountWatchRecoveryTests : StringSpec() {
         every { watchClient } returns
           mockk<Watch> {
             every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+              options += secondArg<WatchOption>()
               listeners += thirdArg<Watch.Listener>()
               mockk<Watch.Watcher>(relaxed = true)
             }
           }
       }
+
+    companion object {
+      /** Revision the pre-subscribe read observes; the prefix watch must anchor at +1. */
+      const val OBSERVED_REV = 100L
+    }
   }
 
   private fun Watch.Listener.die() {
@@ -112,6 +121,19 @@ class BarrierWithCountWatchRecoveryTests : StringSpec() {
   }
 
   init {
+    "waitOnBarrier anchors its prefix watch at the observed revision" {
+      // The pre-subscribe read saw the barrier state at OBSERVED_REV; a /ready DELETE or
+      // waiter PUT landing before the watch goes live would be lost by an un-anchored
+      // watch. The prefix watch must start at OBSERVED_REV + 1.
+      val mocks = CountBarrierMocks(readyPresentProbes = Int.MAX_VALUE) // ready stays set → parks
+      DistributedBarrierWithCount(mocks.client, "/barrier/count", memberCount = 2).use { barrier ->
+        barrier.waitOnBarrier(500.milliseconds)
+        mocks.options.size shouldBe 1
+        mocks.options.first().revision shouldBe CountBarrierMocks.OBSERVED_REV + 1
+        mocks.options.first().isPrefix shouldBe true
+      }
+    }
+
     "counted waiter releases after recovery when the ready DELETE happened during the outage" {
       // Ready-key probes: 2 present (initial checkWaiterCount + pre-park recheck),
       // then absent (deleted during the dead-stream window).

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueueWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueueWatchRecoveryTests.kt
@@ -42,6 +42,7 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -56,6 +57,7 @@ class QueueWatchRecoveryTests : StringSpec() {
     private val emptyGets: Int,
   ) {
     val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    val options = CopyOnWriteArrayList<WatchOption>()
     val getCount = AtomicInteger(0)
 
     private val item: KeyValue =
@@ -70,6 +72,7 @@ class QueueWatchRecoveryTests : StringSpec() {
       return mockk {
         every { kvs } returns if (empty) emptyList() else listOf(item)
         every { isMore } returns false
+        every { header } returns mockk { every { revision } returns OBSERVED_REV }
       }
     }
 
@@ -91,11 +94,17 @@ class QueueWatchRecoveryTests : StringSpec() {
         every { watchClient } returns
           mockk<Watch> {
             every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+              options += secondArg<WatchOption>()
               listeners += thirdArg<Watch.Listener>()
               mockk<Watch.Watcher>(relaxed = true)
             }
           }
       }
+
+    companion object {
+      /** Revision the head-poll observes the (empty) queue at; the watch must anchor at +1. */
+      const val OBSERVED_REV = 100L
+    }
   }
 
   private fun Watch.Listener.die() {
@@ -104,6 +113,20 @@ class QueueWatchRecoveryTests : StringSpec() {
   }
 
   init {
+    "waitForFirstChild anchors its PUT-watch at the observed empty-queue revision" {
+      // The head-poll saw the queue empty at OBSERVED_REV; a PUT landing before the
+      // watch goes live would be lost by an un-anchored watch. The watch must start
+      // at OBSERVED_REV + 1 so any later PUT is (re)delivered.
+      val mocks = QueueMocks(emptyGets = Int.MAX_VALUE)
+      DistributedQueue(mocks.client, "/queue/recovery").use { queue ->
+        queue.poll(500.milliseconds) // empty → subscribes, parks briefly, returns null
+        mocks.options.size shouldBe 1
+        mocks.options.first().revision shouldBe QueueMocks.OBSERVED_REV + 1
+        mocks.options.first().isPrefix shouldBe true
+        mocks.options.first().isNoDelete shouldBe true
+      }
+    }
+
     "parked dequeue delivers an item that arrived while the watch stream was dead" {
       // GET #1 (fast path) and #2 (pre-live gap poll) see an empty queue; the
       // recovery re-poll and everything after see the item.


### PR DESCRIPTION
## Problem

Follow-up to #67 (the lock lost-wakeup fix). `DistributedBarrier`,
`DistributedBarrierWithCount`, and the queues (`DistributedQueue` /
`DistributedPriorityQueue`) call `withWatcher` directly and shared the **same
un-anchored-watch race**: a waiter's watch was subscribed without a start revision, so
it began at whatever revision etcd assigned when it *processed* the create request —
racing the pre-live recheck. A barrier DELETE, a `/ready` DELETE, or a queue PUT landing
in that watch-establishment window could be lost by **both** the watch and the recheck.

These hadn't manifested a hang in the wild, but the race is identical to the one that
hung a lock gate for ~7 hours.

## Fix

Each waiter now anchors its watch at `observedRevision + 1`, captured from a read taken
just before subscribing, so the awaited event is guaranteed to be (re)delivered; the
pre-live recheck degrades to a fast path. Same pattern as #67 and as
`PathChildrenCache`/`ServiceCache` already use.

- **`DistributedBarrier`** — the presence probe returns its revision (one txn, same as
  the old `isKeyPresent`) and anchors the DELETE-watch.
- **`DistributedBarrierWithCount`** — a count-only pre-subscribe read anchors the prefix
  watch.
- **`AbstractQueue`** — the empty-queue `getFirstChild` revision anchors the PUT-watch.

## Changes

- Main: `DistributedBarrier.kt`, `DistributedBarrierWithCount.kt`, `AbstractQueue.kt`.
- Tests: each recipe's watch-recovery test gains an anchor-contract case asserting the
  subscribed watch starts at `observedRevision + 1` (written RED-first).
- `CHANGELOG.md` — `### Fixed (barriers / queue: waiter watch)`.

## Verification

- 3 new anchor tests green (RED-first: `expected:<101L> but was:<0L>` before the fix).
- 6 existing watch-recovery tests still green.
- Frozen `design.*` oracle green — `dequeue()` still appears once, `while (true)` intact,
  barrier lease markers intact.
- Barrier + queue + design subgate: 102 tests. **8/8** stress on the timing-sensitive
  barrier/queue suites.
- Full `make tests-tc` gate: **378/378** (two earlier runs each hit one Ryuk
  container-startup flake on unrelated tests — infra, not code; both passed solo).
- `lintKotlin` + `detekt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP
