### PR TITLE
Add push-based background-exception callback and health checks (observability phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (observability: push errors + health)
+
+- **Push-based background-exception callback** on `EtcdConnector`: register a
+  `BackgroundExceptionListener` (`addBackgroundExceptionListener` /
+  `removeBackgroundExceptionListener`) to be notified — with a short source context
+  (the recipe's path/clientId) — the moment a background failure occurs (keep-alive
+  death, abandoned watcher, lost lock/leadership, a throwing user callback), instead
+  of polling the `exceptions` list. Every recipe now routes its failures through a
+  single `recordException` sink; the pull-only `exceptions` API is unchanged.
+- **Health** on `EtcdConnector`: `isHealthy()` (passive — healthy unless a lease
+  expired / watcher was abandoned, or the connector is closed) and `ping()` (an
+  active, bounded, non-mutating reachability probe).
+- Coroutines: `EtcdConnector.backgroundExceptionsAsFlow()` surfaces the same
+  notifications as a `Flow<BackgroundException>`.
+
 ### Fixed (locks: read-write lock / semaphore wait)
 
 - `DistributedReadWriteLock` and `DistributedSemaphore` could park a caller

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -77,6 +77,8 @@ constructor(
     require(barrierPath.isNotEmpty()) { "Barrier path cannot be empty" }
   }
 
+  override val exceptionContext get() = "DistributedBarrier[$barrierPath]"
+
   fun isBarrierSet(): Boolean {
     checkCloseNotCalled()
     return client.isKeyPresent(barrierPath, resilience.rpc)
@@ -129,14 +131,14 @@ constructor(
   private fun onBarrierLeaseEvent(event: LeaseEvent) {
     reportLeaseEvent(event)
     when (event) {
-      is LeaseEvent.Suspended -> exceptionList.value += event.cause
+      is LeaseEvent.Suspended -> recordException(event.cause)
 
-      is LeaseEvent.Expired -> exceptionList.value += (
-        event.cause ?: EtcdRecipeRuntimeException("Barrier lease for $barrierPath expired; healing")
+      is LeaseEvent.Expired -> recordException(
+        event.cause ?: EtcdRecipeRuntimeException("Barrier lease for $barrierPath expired; healing"),
       )
 
-      is LeaseEvent.Failed -> exceptionList.value += (
-        event.cause ?: EtcdRecipeRuntimeException("Barrier lease healing for $barrierPath abandoned")
+      is LeaseEvent.Failed -> recordException(
+        event.cause ?: EtcdRecipeRuntimeException("Barrier lease healing for $barrierPath abandoned"),
       )
 
       is LeaseEvent.Restored -> logger.info {
@@ -246,7 +248,7 @@ constructor(
           val cause = event.cause
             ?: EtcdRecipeRuntimeException("Watch on $barrierPath abandoned while waiting on barrier")
           watchFailure.set(cause)
-          exceptionList.value += cause
+          recordException(cause)
           waitLatch.countDown()
         }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -105,6 +105,8 @@ constructor(
     require(memberCount > 0) { "Member count must be > 0" }
   }
 
+  override val exceptionContext get() = "DistributedBarrierWithCount[$barrierPath]"
+
   private val isReadySet: Boolean
     get() {
       checkCloseNotCalled()
@@ -265,7 +267,7 @@ constructor(
                     val cause = event.cause
                       ?: EtcdRecipeRuntimeException("Watch on $barrierPath abandoned while waiting on barrier")
                     watchFailure.set(cause)
-                    exceptionList.value += cause
+                    recordException(cause)
                     closeKeepAlive()
                   }
 
@@ -332,14 +334,14 @@ constructor(
   private fun onWaiterLeaseEvent(event: LeaseEvent) {
     reportLeaseEvent(event)
     when (event) {
-      is LeaseEvent.Suspended -> exceptionList.value += event.cause
+      is LeaseEvent.Suspended -> recordException(event.cause)
 
-      is LeaseEvent.Expired -> exceptionList.value += (
-        event.cause ?: EtcdRecipeRuntimeException("Waiter lease for $barrierPath expired; healing")
+      is LeaseEvent.Expired -> recordException(
+        event.cause ?: EtcdRecipeRuntimeException("Waiter lease for $barrierPath expired; healing"),
       )
 
-      is LeaseEvent.Failed -> exceptionList.value += (
-        event.cause ?: EtcdRecipeRuntimeException("Waiter lease healing for $barrierPath abandoned")
+      is LeaseEvent.Failed -> recordException(
+        event.cause ?: EtcdRecipeRuntimeException("Waiter lease healing for $barrierPath abandoned"),
       )
 
       is LeaseEvent.Restored -> logger.info {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -84,6 +84,8 @@ class PathChildrenCache
   // Use a single-threaded executor to maintain order
   private val executor = userExecutor ?: Executors.newSingleThreadExecutor()
 
+  override val exceptionContext get() = "PathChildrenCache[$cachePath]"
+
   enum class StartMode {
     /**
      * cache will _not_ be primed. i.e. it will start empty and you will receive
@@ -142,7 +144,7 @@ class PathChildrenCache
                 listener.childEvent(cacheEvent)
               } catch (e: Throwable) {
                 logger.error(e) { "Exception in cacheChanged()" }
-                exceptionList.value += e
+                recordException(e)
               }
             }
           startThreadComplete.set(true)
@@ -203,7 +205,7 @@ class PathChildrenCache
       setupWatcher(anchorRevision)
     } catch (e: Throwable) {
       logger.error(e) { "Exception in loadDataAndStartWatcher()" }
-      exceptionList.value += e
+      recordException(e)
     }
   }
 
@@ -237,7 +239,7 @@ class PathChildrenCache
                   listener.childEvent(cacheEvent)
                 } catch (e: Throwable) {
                   logger.error(e) { "Exception in cacheChanged()" }
-                  exceptionList.value += e
+                  recordException(e)
                 }
               }
             }
@@ -251,7 +253,7 @@ class PathChildrenCache
                   listener.childEvent(cacheEvent)
                 } catch (e: Throwable) {
                   logger.error(e) { "Exception in cacheChanged()" }
-                  exceptionList.value += e
+                  recordException(e)
                 }
               }
             }
@@ -318,15 +320,17 @@ class PathChildrenCache
   private fun onRecoveryEvent(event: WatchRecoveryEvent) {
     reportRecoveryEvent(event)
     if (event is WatchRecoveryEvent.Failed) {
-      exceptionList.value += event.cause
-        ?: EtcdRecipeRuntimeException("Watch on $cachePath abandoned; cache is no longer updating")
+      recordException(
+        event.cause
+          ?: EtcdRecipeRuntimeException("Watch on $cachePath abandoned; cache is no longer updating"),
+      )
     }
     recoveryListeners.forEach { listener ->
       try {
         listener.onRecoveryEvent(event)
       } catch (e: Throwable) {
         logger.error(e) { "Exception in recovery listener" }
-        exceptionList.value += e
+        recordException(e)
       }
     }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/BackgroundExceptionListener.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/BackgroundExceptionListener.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.common
+
+/**
+ * Push-based notification of a background failure that a recipe would otherwise only
+ * record in the pull-only [EtcdConnector.exceptions] list — a keep-alive death, an
+ * abandoned watcher, a lost lock/leadership, or a user callback that threw.
+ *
+ * [context] is a short, human-readable source hint (typically the recipe's clientId or
+ * path plus a kind, e.g. `"DistributedMutex:ab12cd3 keep-alive"`) so a single handler
+ * registered across many recipes can attribute the failure. Listeners run on the
+ * reporting recipe's own thread (a healer/dispatcher thread, never jetcd's event loop);
+ * a listener that throws is logged and dropped, never re-recorded.
+ */
+fun interface BackgroundExceptionListener {
+  fun onException(
+    context: String,
+    throwable: Throwable,
+  )
+}
+
+/** Value form of a [BackgroundExceptionListener] notification, for the Flow surface. */
+data class BackgroundException(
+  val context: String,
+  val throwable: Throwable,
+)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
@@ -21,6 +21,7 @@ package io.etcd.recipes.common
 import com.pambrose.common.concurrent.BooleanMonitor
 import com.pambrose.common.util.randomId
 import io.etcd.jetcd.Client
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.io.Closeable
 import java.util.Collections.synchronizedList
 import java.util.concurrent.CopyOnWriteArrayList
@@ -56,6 +57,48 @@ open class EtcdConnector(
 
   fun clearExceptions() {
     if (exceptionList.isInitialized()) exceptionList.value.clear()
+  }
+
+  private val backgroundExceptionListeners = CopyOnWriteArrayList<BackgroundExceptionListener>()
+
+  fun addBackgroundExceptionListener(listener: BackgroundExceptionListener) {
+    backgroundExceptionListeners += listener
+  }
+
+  fun removeBackgroundExceptionListener(listener: BackgroundExceptionListener) {
+    backgroundExceptionListeners -= listener
+  }
+
+  /**
+   * Short source hint attached to background exceptions from this connector so a shared
+   * handler can attribute which recipe failed. Subclasses override it with their path /
+   * clientId; the default is the recipe type name.
+   */
+  protected open val exceptionContext: String
+    get() = this::class.simpleName ?: "EtcdConnector"
+
+  /** Records [throwable] under this connector's [exceptionContext]. */
+  protected fun recordException(throwable: Throwable) = recordException(exceptionContext, throwable)
+
+  /**
+   * The single sink for background failures: records [throwable] in [exceptions] and pushes
+   * it to every [BackgroundExceptionListener] with a short source [context]. Recipes call
+   * this instead of appending to the exception list directly. A listener that throws is
+   * logged and dropped — never re-recorded — so notification cannot recurse.
+   */
+  @Suppress("TooGenericExceptionCaught")
+  protected fun recordException(
+    context: String,
+    throwable: Throwable,
+  ) {
+    exceptionList.value += throwable
+    backgroundExceptionListeners.forEach { listener ->
+      try {
+        listener.onException(context, throwable)
+      } catch (e: Throwable) {
+        logger.error(e) { "Background-exception listener threw while handling [$context]" }
+      }
+    }
   }
 
   protected fun checkStartCalled() {
@@ -111,10 +154,25 @@ open class EtcdConnector(
       try {
         listener.stateChanged(newState, previous)
       } catch (e: Throwable) {
-        exceptionList.value += e
+        recordException("connection-state-listener", e)
       }
     }
   }
+
+  /**
+   * Passive health: healthy unless a lease expired or a watcher was abandoned
+   * ([connectionState] == [ConnectionState.LOST]), or this connector is closed. Derived from
+   * events the recipes already observe — no RPC. For an active check use [ping].
+   */
+  fun isHealthy(): Boolean = connectionState != ConnectionState.LOST && !closeCalled.load()
+
+  /**
+   * Active reachability probe: a bounded, non-mutating count-only GET against etcd, through
+   * the same retry/timeout funnel as every other RPC. Returns false instead of throwing when
+   * etcd cannot be reached within the RPC timeout.
+   */
+  fun ping(): Boolean =
+    runCatching { client.getResponse(PING_PROBE_KEY, getOption { withCountOnly(true) }, resilience.rpc) }.isSuccess
 
   // Template-method close: idempotency is enforced here so subclasses cannot
   // forget to guard against double-close. Subclasses override doClose() for
@@ -129,8 +187,10 @@ open class EtcdConnector(
   protected open fun doClose() {}
 
   companion object {
+    private val logger = KotlinLogging.logger {}
     internal const val TOKEN_LENGTH = 7
     internal const val DEFAULT_TTL_SECS = 2L
+    private const val PING_PROBE_KEY = "health-check-probe"
 
     internal fun defaultClientId(prefix: String) = "$prefix:${randomId(TOKEN_LENGTH)}"
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/ExceptionFlows.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/ExceptionFlows.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.recipes.common.BackgroundException
+import io.etcd.recipes.common.BackgroundExceptionListener
+import io.etcd.recipes.common.EtcdConnector
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * This recipe's background failures as a [Flow] of [BackgroundException] — the push
+ * counterpart to the pull-only [EtcdConnector.exceptions] list. Collection registers a
+ * [BackgroundExceptionListener] and cancellation removes it; it never starts or closes the
+ * recipe.
+ *
+ * The listener fires on the reporting recipe's own thread (a healer/dispatcher thread), so
+ * the channel is buffered (unlimited by default) — a failure is never dropped and the
+ * reporting thread never blocks.
+ */
+fun EtcdConnector.backgroundExceptionsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<BackgroundException> =
+  callbackFlow {
+    val listener =
+      BackgroundExceptionListener { context, throwable ->
+        trySendBlocking(BackgroundException(context, throwable))
+      }
+    addBackgroundExceptionListener(listener)
+    awaitClose { removeBackgroundExceptionListener(listener) }
+  }.buffer(capacity)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
@@ -59,6 +59,8 @@ class ServiceCache
     require(serviceName.isNotEmpty()) { "ServiceCache service name cannot be empty" }
   }
 
+  override val exceptionContext get() = "ServiceCache[$serviceName]"
+
   @Synchronized
   @Suppress("TooGenericExceptionCaught", "LongMethod")
   fun start(): ServiceCache {
@@ -100,7 +102,7 @@ class ServiceCache
                   listener.cacheChanged(event.eventType, isAdd, stripped, ServiceInstance.toObject(v))
                 } catch (e: Throwable) {
                   logger.error(e) { "Exception in cacheChanged()" }
-                  exceptionList.value += e
+                  recordException(e)
                 }
               }
             }
@@ -112,7 +114,7 @@ class ServiceCache
                   listener.cacheChanged(event.eventType, false, stripped, prevValue)
                 } catch (e: Throwable) {
                   logger.error(e) { "Exception in cacheChanged()" }
-                  exceptionList.value += e
+                  recordException(e)
                 }
               }
             }
@@ -157,15 +159,17 @@ class ServiceCache
   private fun onRecoveryEvent(event: WatchRecoveryEvent) {
     reportRecoveryEvent(event)
     if (event is WatchRecoveryEvent.Failed) {
-      exceptionList.value += event.cause
-        ?: EtcdRecipeRuntimeException("Watch on $servicePath abandoned; service cache is no longer updating")
+      recordException(
+        event.cause
+          ?: EtcdRecipeRuntimeException("Watch on $servicePath abandoned; service cache is no longer updating"),
+      )
     }
     recoveryListeners.forEach { listener ->
       try {
         listener.onRecoveryEvent(event)
       } catch (e: Throwable) {
         logger.error(e) { "Exception in recovery listener" }
-        exceptionList.value += e
+        recordException(e)
       }
     }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
@@ -73,6 +73,8 @@ constructor(
     require(servicePath.isNotEmpty()) { "Service base path cannot be empty" }
   }
 
+  override val exceptionContext get() = "ServiceRegistry[$servicePath]"
+
   internal class ServiceInstanceContext(
     val service: ServiceInstance,
     val client: Client,
@@ -153,17 +155,19 @@ constructor(
     reportLeaseEvent(event)
     when (event) {
       is LeaseEvent.Suspended -> {
-        exceptionList.value += event.cause
+        recordException(event.cause)
       }
 
       is LeaseEvent.Expired -> {
-        event.cause?.let { exceptionList.value += it }
-        ?: run { exceptionList.value += EtcdRecipeRuntimeException("Lease for $instancePath expired; healing") }
+        event.cause?.let { recordException(it) }
+        ?: run { recordException(EtcdRecipeRuntimeException("Lease for $instancePath expired; healing")) }
       }
 
       is LeaseEvent.Failed -> {
-        exceptionList.value += event.cause
-        ?: EtcdRecipeRuntimeException("Lease healing for $instancePath abandoned; instance is unregistered")
+        recordException(
+          event.cause
+            ?: EtcdRecipeRuntimeException("Lease healing for $instancePath abandoned; instance is unregistered"),
+        )
       }
 
       is LeaseEvent.Restored -> {
@@ -177,7 +181,7 @@ constructor(
         listener.onLeaseEvent(event)
       } catch (e: Throwable) {
         logger.error(e) { "Exception in lease listener" }
-        exceptionList.value += e
+        recordException(e)
       }
     }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderLatch.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderLatch.kt
@@ -77,6 +77,8 @@ class LeaderLatch
       require(leaseTtlSecs > 0) { "Lease TTL must be > 0" }
     }
 
+    override val exceptionContext get() = "LeaderLatch[$electionPath]"
+
     private val closing = AtomicBoolean(false)
 
     // Serializes inner-selector lifecycle (construct/start) against close(): the worker
@@ -174,15 +176,15 @@ class LeaderLatch
             logger.debug(e) { "Latch worker interrupted while awaiting term end" }
           }
 
-          if (sel.hasExceptions) exceptionList.value += sel.exceptions
-          runCatching { sel.close() }.onFailure { exceptionList.value += it }
+          if (sel.hasExceptions) sel.exceptions.forEach { recordException(it) }
+          runCatching { sel.close() }.onFailure { recordException(it) }
 
           if (closing.get()) return
           // Otherwise the term ended via step-down: loop back and re-contest with a
           // fresh selector (one selector per full term, so no tight spin).
         }
       } catch (e: Throwable) {
-        exceptionList.value += e
+        recordException(e)
       } finally {
         leadershipMonitor.set(false)
         firstTermStarted.set(true) // never leave start() blocked if the worker died early
@@ -210,7 +212,7 @@ class LeaderLatch
               listener.call()
             } catch (e: Throwable) {
               logger.error(e) { "Exception in LeaderLatch listener" }
-              exceptionList.value += e
+              recordException(e)
             }
           }
         }
@@ -231,7 +233,7 @@ class LeaderLatch
           w.interrupt() // backstop
           w.join(TimeUnit.SECONDS.toMillis(5))
           if (w.isAlive)
-            exceptionList.value += EtcdRecipeRuntimeException("LeaderLatch worker did not terminate")
+            recordException(EtcdRecipeRuntimeException("LeaderLatch worker did not terminate"))
         }
       }
       leadershipMonitor.set(false)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderObserver.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderObserver.kt
@@ -64,6 +64,8 @@ class LeaderObserver
       require(electionPath.isNotEmpty()) { "Election path cannot be empty" }
     }
 
+    override val exceptionContext get() = "LeaderObserver[$electionPath]"
+
     private val leaderKey = ElectionPaths.leaderKey(electionPath)
     private val listeners = CopyOnWriteArrayList<LeaderListener>()
     private val currentLeaderRef = AtomicReference<String?>(null)
@@ -122,7 +124,7 @@ class LeaderObserver
         } catch (e: Throwable) {
           logger.error(e) { "Exception in LeaderObserver takeLeadership" }
           runCatching { listener.onError(e) }
-          exceptionList.value += e
+          recordException(e)
         }
       }
     }
@@ -136,7 +138,7 @@ class LeaderObserver
         } catch (e: Throwable) {
           logger.error(e) { "Exception in LeaderObserver relinquishLeadership" }
           runCatching { listener.onError(e) }
-          exceptionList.value += e
+          recordException(e)
         }
       }
     }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -175,6 +175,8 @@ constructor(
     require(leaseTtlSecs > 0) { "Lease TTL must be > 0" }
   }
 
+  override val exceptionContext get() = "LeaderSelector[$electionPath]"
+
   val isLeader get() = electedLeader.load()
 
   val isFinished get() = leadershipComplete.get()
@@ -231,7 +233,7 @@ constructor(
                     val cause = event.cause
                       ?: EtcdRecipeRuntimeException("Watch on $leaderPath abandoned; no further re-election attempts")
                     logger.error(cause) { "Leader watch on $leaderPath abandoned" }
-                    exceptionList.value += cause
+                    recordException(cause)
                   }
 
                   is WatchRecoveryEvent.Suspended -> {
@@ -260,7 +262,7 @@ constructor(
             }
           } catch (e: Throwable) {
             logger.error(e) { "In withWatchClient()" }
-            exceptionList.value += e
+            recordException(e)
           } finally {
             watchComplete.set(true)
           }
@@ -271,7 +273,7 @@ constructor(
             advertiseParticipation()
           } catch (e: Throwable) {
             logger.error(e) { "In advertiseParticipation()" }
-            exceptionList.value += e
+            recordException(e)
           } finally {
             advertiseComplete.set(true)
           }
@@ -290,7 +292,7 @@ constructor(
         advertiseComplete.waitUntilTrue()
       } catch (e: Throwable) {
         logger.error(e) { "In start()" }
-        exceptionList.value += e
+        recordException(e)
       } finally {
         startThreadComplete.set(true)
       }
@@ -407,14 +409,14 @@ constructor(
   private fun onParticipationLeaseEvent(event: LeaseEvent) {
     reportLeaseEvent(event)
     when (event) {
-      is LeaseEvent.Suspended -> exceptionList.value += event.cause
+      is LeaseEvent.Suspended -> recordException(event.cause)
 
-      is LeaseEvent.Expired -> exceptionList.value += (
-        event.cause ?: EtcdRecipeRuntimeException("Participation lease for $clientId expired; healing")
+      is LeaseEvent.Expired -> recordException(
+        event.cause ?: EtcdRecipeRuntimeException("Participation lease for $clientId expired; healing"),
       )
 
-      is LeaseEvent.Failed -> exceptionList.value += (
-        event.cause ?: EtcdRecipeRuntimeException("Participation lease healing for $clientId abandoned")
+      is LeaseEvent.Failed -> recordException(
+        event.cause ?: EtcdRecipeRuntimeException("Participation lease healing for $clientId abandoned"),
       )
 
       is LeaseEvent.Restored -> logger.info {
@@ -497,14 +499,14 @@ constructor(
         listener.relinquishLeadership(this)
       } catch (e: Throwable) {
         logger.error(e) { "In relinquishLeadership()" }
-        exceptionList.value += e
+        recordException(e)
       }
 
       takeLeadershipError?.let { throw it }
       return !leaseLostDuringLeadership.load()
     } catch (e: Throwable) {
       logger.error(e) { "In attemptToBecomeLeader()" }
-      exceptionList.value += e
+      recordException(e)
       return false
     } finally {
       registration.close()
@@ -533,7 +535,7 @@ constructor(
         if (e.isLeaseNotFound()) {
           stepDownFromLeadership(e)
         } else {
-          exceptionList.value += e
+          recordException(e)
           reportLeaseEvent(LeaseEvent.Suspended(leaseId, e))
         }
       }
@@ -551,7 +553,7 @@ constructor(
     if (!leaseLostDuringLeadership.compareAndSet(false, true)) return
 
     logger.warn(cause) { "Leadership lease lost for $clientId; stepping down" }
-    exceptionList.value += (cause ?: EtcdRecipeRuntimeException("Leadership lease expired; stepping down"))
+    recordException(cause ?: EtcdRecipeRuntimeException("Leadership lease expired; stepping down"))
     electedLeader.store(false)
     reportLeaseEvent(LeaseEvent.Expired(leadershipLeaseId.load(), cause))
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
@@ -91,6 +91,8 @@ constructor(
       start()
   }
 
+  override val exceptionContext get() = "TransientKeyValue[$keyPath]"
+
   @Suppress("TooGenericExceptionCaught")
   @Synchronized
   fun start(): TransientKeyValue {
@@ -119,7 +121,7 @@ constructor(
         logger.debug { "$leaseTtl keep-alive terminated for $clientId $keyPath" }
       } catch (e: Throwable) {
         logger.error(e) { "In start()" }
-        exceptionList.value += e
+        recordException(e)
       } finally {
         runCatching { healer?.close() }
         // Always release the start() caller, even on failure. The previous
@@ -167,17 +169,19 @@ constructor(
     reportLeaseEvent(event)
     when (event) {
       is LeaseEvent.Suspended -> {
-        exceptionList.value += event.cause
+        recordException(event.cause)
       }
 
       is LeaseEvent.Expired -> {
-        event.cause?.let { exceptionList.value += it }
-        ?: run { exceptionList.value += EtcdRecipeRuntimeException("Lease for $keyPath expired; healing") }
+        event.cause?.let { recordException(it) }
+        ?: run { recordException(EtcdRecipeRuntimeException("Lease for $keyPath expired; healing")) }
       }
 
       is LeaseEvent.Failed -> {
-        exceptionList.value += event.cause
-        ?: EtcdRecipeRuntimeException("Lease healing for $keyPath abandoned; key is gone")
+        recordException(
+          event.cause
+            ?: EtcdRecipeRuntimeException("Lease healing for $keyPath abandoned; key is gone"),
+        )
       }
 
       is LeaseEvent.Restored -> {
@@ -189,7 +193,7 @@ constructor(
         listener.onLeaseEvent(event)
       } catch (e: Throwable) {
         logger.error(e) { "Exception in lease listener" }
-        exceptionList.value += e
+        recordException(e)
       }
     }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedMutex.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedMutex.kt
@@ -98,6 +98,8 @@ class DistributedMutex
     require(leaseTtlSecs > 0) { "Lease TTL must be > 0" }
   }
 
+  override val exceptionContext get() = "DistributedMutex[$lockPath]"
+
   override fun lock() {
     check(acquire(null)) { "unbounded acquisition returned without the lock" }
   }
@@ -181,7 +183,7 @@ class DistributedMutex
           leaseTtlSecs,
           resilience.rpc,
           onTransient = { e ->
-            exceptionList.value += e
+            recordException(e)
             reportLeaseEvent(LeaseEvent.Suspended(-1L, e))
           },
           onFatal = { cause -> onAttemptFatal(attempt, cause) },
@@ -207,7 +209,7 @@ class DistributedMutex
           } catch (e: Exception) {
             // Lease death mid-wait, "no leader", or a close() abort. Retry with a
             // fresh lease (paced); tryLock stays bounded by the loop's deadline check.
-            exceptionList.value += e
+            recordException(e)
             if (closeCalled.load()) {
               throw EtcdRecipeRuntimeException("Lock attempt on $lockPath aborted by close()", e)
             }
@@ -277,14 +279,14 @@ class DistributedMutex
     val data = threadData.remove(thread) ?: return
     dispossessed[thread] = data.holdCount
     logger.warn(cause) { "Lock on $lockPath lost by $clientId (lease expired)" }
-    exceptionList.value += (cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
+    recordException(cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
     reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
     lockLostListeners.forEach { listener ->
       try {
         listener.onLockLost(cause)
       } catch (e: Throwable) {
         logger.error(e) { "Exception in lock-lost listener" }
-        exceptionList.value += e
+        recordException(e)
       }
     }
     if (interruptOnLockLoss) thread.interrupt()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
@@ -110,6 +110,8 @@ class DistributedReadWriteLock
     require(leaseTtlSecs > 0) { "Lease TTL must be > 0" }
   }
 
+  override val exceptionContext get() = "DistributedReadWriteLock[$lockPath]"
+
   val readLock: EtcdLock = LockView(Side.READ)
   val writeLock: EtcdLock = LockView(Side.WRITE)
 
@@ -219,7 +221,7 @@ class DistributedReadWriteLock
           leaseTtlSecs,
           resilience.rpc,
           onTransient = { e ->
-            exceptionList.value += e
+            recordException(e)
             reportLeaseEvent(LeaseEvent.Suspended(-1L, e))
           },
           onFatal = { cause -> onEntryFatal(side, attempt, cause) },
@@ -279,7 +281,7 @@ class DistributedReadWriteLock
             deadline,
             observedRevision = conflict.observedRevision,
             reportRecovery = { event -> reportRecoveryEvent(event) },
-            recordException = { e -> exceptionList.value += e },
+            recordException = { e -> recordException(e) },
           )
           attempt.wake.set(null)
           // Loop: re-evaluate the conflict set (it only shrinks)
@@ -352,8 +354,8 @@ class DistributedReadWriteLock
     cause: Throwable?,
   ) {
     if (attempt.phase.compareAndSet(Phase.WAITING, Phase.DEAD)) {
-      exceptionList.value += (
-        cause ?: EtcdRecipeRuntimeException("Lock entry lease expired while waiting on $lockPath")
+      recordException(
+        cause ?: EtcdRecipeRuntimeException("Lock entry lease expired while waiting on $lockPath"),
       )
       attempt.wake.get()?.countDown()
     } else if (attempt.phase.load() == Phase.HOLDING) {
@@ -370,14 +372,14 @@ class DistributedReadWriteLock
     val data = holdsFor(side).remove(thread) ?: return
     dispossessedFor(side)[thread] = data.holdCount
     logger.warn(cause) { "${side.entryPrefix} lock on $lockPath lost by $clientId (lease expired)" }
-    exceptionList.value += (cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
+    recordException(cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
     reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
     listenersFor(side).forEach { listener ->
       try {
         listener.onLockLost(cause)
       } catch (e: Throwable) {
         logger.error(e) { "Exception in lock-lost listener" }
-        exceptionList.value += e
+        recordException(e)
       }
     }
     if (interruptOnLockLoss) thread.interrupt()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
@@ -131,6 +131,8 @@ class DistributedSemaphore
     require(leaseTtlSecs > 0) { "Lease TTL must be > 0" }
   }
 
+  override val exceptionContext get() = "DistributedSemaphore[$semaphorePath]"
+
   fun acquire() {
     check(acquireInternal(null)) { "unbounded acquisition returned without a permit" }
   }
@@ -227,7 +229,7 @@ class DistributedSemaphore
           leaseTtlSecs,
           resilience.rpc,
           onTransient = { e ->
-            exceptionList.value += e
+            recordException(e)
             reportLeaseEvent(LeaseEvent.Suspended(-1L, e))
           },
           onFatal = { cause -> onEntryFatal(attempt, cause) },
@@ -290,7 +292,7 @@ class DistributedSemaphore
               now == null || now.rank < permits
             },
             reportRecovery = { event -> reportRecoveryEvent(event) },
-            recordException = { e -> exceptionList.value += e },
+            recordException = { e -> recordException(e) },
           )
           attempt.wake.set(null)
           // Loop: re-evaluate the rank (it only shrinks while the entry lives)
@@ -338,8 +340,8 @@ class DistributedSemaphore
     cause: Throwable?,
   ) {
     if (attempt.phase.compareAndSet(Phase.WAITING, Phase.DEAD)) {
-      exceptionList.value += (
-        cause ?: EtcdRecipeRuntimeException("Semaphore entry lease expired while waiting on $semaphorePath")
+      recordException(
+        cause ?: EtcdRecipeRuntimeException("Semaphore entry lease expired while waiting on $semaphorePath"),
       )
       attempt.wake.get()?.countDown()
     } else if (attempt.phase.load() == Phase.HOLDING) {
@@ -356,14 +358,14 @@ class DistributedSemaphore
     if (!holds.remove(data)) return // already released, or close() took it
     dispossessedCount.incrementAndGet()
     logger.warn(cause) { "Permit on $semaphorePath lost by $clientId (lease expired)" }
-    exceptionList.value += (cause ?: EtcdRecipeRuntimeException("Permit lease for $semaphorePath expired; permit lost"))
+    recordException(cause ?: EtcdRecipeRuntimeException("Permit lease for $semaphorePath expired; permit lost"))
     reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
     lostListeners.forEach { listener ->
       try {
         listener.onPermitLost(cause)
       } catch (e: Throwable) {
         logger.error(e) { "Exception in permit-lost listener" }
-        exceptionList.value += e
+        recordException(e)
       }
     }
     if (interruptOnPermitLoss) attempt.owner.interrupt()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -54,6 +54,8 @@ abstract class AbstractQueue(
     require(queuePath.isNotEmpty()) { "Queue path cannot be empty" }
   }
 
+  override val exceptionContext get() = "AbstractQueue[$queuePath]"
+
   fun dequeue(): ByteSequence = checkNotNull(takeWithDeadline(null)) { "unbounded take returned empty" }
 
   /** Non-blocking take: the head item, or null when the queue is empty. */
@@ -215,7 +217,7 @@ abstract class AbstractQueue(
           val cause = event.cause
             ?: EtcdRecipeRuntimeException("Watch on $queuePath abandoned while waiting for an item")
           watchFailure.set(cause)
-          exceptionList.value += cause
+          recordException(cause)
           synchronized(watchLatch) {
             if (watchLatch.count > 0) watchLatch.countDown()
           }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedPriorityQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedPriorityQueue.kt
@@ -52,6 +52,8 @@ class DistributedPriorityQueue
     val minimumWaitTime: Duration,
     resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
   ) : AbstractQueue(client, queuePath, SortTarget.KEY, resilience) {
+  override val exceptionContext get() = "DistributedPriorityQueue[$queuePath]"
+
   private var lastWriteTime = TimeSource.Monotonic.markNow()
 
   fun enqueue(

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedQueue.kt
@@ -42,6 +42,8 @@ class DistributedQueue
     queuePath: String,
     resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
   ) : AbstractQueue(client, queuePath, SortTarget.MOD, resilience) {
+  override val exceptionContext get() = "DistributedQueue[$queuePath]"
+
   fun enqueue(value: String) = enqueue(value.asByteSequence)
 
   fun enqueue(value: Int) = enqueue(value.asByteSequence)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
@@ -124,6 +124,8 @@ class DistributedWorkQueue
     require(queuePath.isNotEmpty()) { "Queue path cannot be empty" }
   }
 
+  override val exceptionContext get() = "DistributedWorkQueue[$queuePath]"
+
   // The consumer lease all claim markers hang off. Self-healing for FUTURE claims
   // only: markers made under a dead lease are deliberately lost (that IS the
   // visibility contract — their items become reclaimable), and the trivial
@@ -448,7 +450,7 @@ class DistributedWorkQueue
             val cause = event.cause
               ?: EtcdRecipeRuntimeException("Watch on $itemsPath abandoned while waiting for work")
             watchFailure.set(cause)
-            exceptionList.value += cause
+            recordException(cause)
             latch.countDown()
           }
 
@@ -494,14 +496,14 @@ class DistributedWorkQueue
   private fun onLeaseEvent(event: LeaseEvent) {
     reportLeaseEvent(event)
     when (event) {
-      is LeaseEvent.Suspended -> exceptionList.value += event.cause
+      is LeaseEvent.Suspended -> recordException(event.cause)
 
-      is LeaseEvent.Expired -> exceptionList.value += (
-        event.cause ?: EtcdRecipeRuntimeException("Consumer lease expired; outstanding claims are reclaimable")
+      is LeaseEvent.Expired -> recordException(
+        event.cause ?: EtcdRecipeRuntimeException("Consumer lease expired; outstanding claims are reclaimable"),
       )
 
-      is LeaseEvent.Failed -> exceptionList.value += (
-        event.cause ?: EtcdRecipeRuntimeException("Consumer lease healing abandoned; claims will not renew")
+      is LeaseEvent.Failed -> recordException(
+        event.cause ?: EtcdRecipeRuntimeException("Consumer lease healing abandoned; claims will not renew"),
       )
 
       is LeaseEvent.Restored -> logger.info {
@@ -513,7 +515,7 @@ class DistributedWorkQueue
         listener.onLeaseEvent(event)
       } catch (e: Throwable) {
         logger.error(e) { "Exception in lease listener" }
-        exceptionList.value += e
+        recordException(e)
       }
     }
   }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdConnectorObservabilityTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdConnectorObservabilityTests.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.options.GetOption
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * Covers the observability surface added to [EtcdConnector] (idea #7 phase 1): the
+ * push-based background-exception callback, the passive [EtcdConnector.isHealthy]
+ * signal, and the active [EtcdConnector.ping] reachability probe.
+ */
+class EtcdConnectorObservabilityTests : StringSpec() {
+  /** Exposes the protected reporting hooks so tests can drive state deterministically. */
+  private class TestConnector(
+    client: Client,
+  ) : EtcdConnector(client) {
+    fun record(
+      context: String,
+      t: Throwable,
+    ) = recordException(context, t)
+
+    fun reportRecovery(event: WatchRecoveryEvent) = reportRecoveryEvent(event)
+
+    fun reportLease(event: LeaseEvent) = reportLeaseEvent(event)
+  }
+
+  /** A mock client whose probe GET either completes or fails, for [EtcdConnector.ping]. */
+  private fun clientWithProbe(succeeds: Boolean): Client =
+    mockk {
+      every { kvClient } returns
+        mockk<KV> {
+          every { get(any<ByteSequence>(), any<GetOption>()) } answers {
+            if (succeeds) {
+              // count-only probe: empty kvs, not paginated
+              CompletableFuture.completedFuture(
+                mockk<GetResponse> {
+                  every { kvs } returns emptyList()
+                  every { isMore } returns false
+                },
+              )
+            } else {
+              // Non-retriable failure → retryRpc rethrows immediately (no slow retry loop)
+              CompletableFuture.failedFuture(IllegalStateException("etcd unreachable"))
+            }
+          }
+        }
+    }
+
+  init {
+    "recordException appends to exceptions and notifies listeners with context" {
+      val connector = TestConnector(mockk())
+      val seen = CopyOnWriteArrayList<Pair<String, Throwable>>()
+      connector.addBackgroundExceptionListener { context, throwable -> seen += context to throwable }
+
+      val boom = RuntimeException("boom")
+      connector.record("alpha keep-alive", boom)
+
+      connector.exceptions shouldBe listOf(boom)
+      seen shouldBe listOf("alpha keep-alive" to boom)
+    }
+
+    "a throwing background-exception listener is caught and does not recurse or re-record" {
+      val connector = TestConnector(mockk())
+      connector.addBackgroundExceptionListener { _, _ -> throw IllegalStateException("listener blew up") }
+
+      connector.record("ctx", RuntimeException("original"))
+
+      // Exactly the original is recorded — the listener's throw is logged, never re-recorded.
+      connector.exceptions.size shouldBe 1
+    }
+
+    "removeBackgroundExceptionListener stops delivery" {
+      val connector = TestConnector(mockk())
+      val count = CopyOnWriteArrayList<Throwable>()
+      val listener = BackgroundExceptionListener { _, t -> count += t }
+      connector.addBackgroundExceptionListener(listener)
+      connector.record("ctx", RuntimeException("1"))
+      connector.removeBackgroundExceptionListener(listener)
+      connector.record("ctx", RuntimeException("2"))
+
+      count.size shouldBe 1
+    }
+
+    "isHealthy is true initially and false after a LOST-inducing event" {
+      val connector = TestConnector(mockk())
+      connector.isHealthy() shouldBe true
+
+      connector.reportLease(LeaseEvent.Expired(leaseId = 7L, cause = null)) // → ConnectionState.LOST
+      connector.isHealthy() shouldBe false
+    }
+
+    "isHealthy is false after close" {
+      val connector = TestConnector(mockk(relaxed = true))
+      connector.isHealthy() shouldBe true
+      connector.close()
+      connector.isHealthy() shouldBe false
+    }
+
+    "ping returns true when the probe GET succeeds" {
+      TestConnector(clientWithProbe(succeeds = true)).ping() shouldBe true
+    }
+
+    "ping returns false when the probe GET fails" {
+      TestConnector(clientWithProbe(succeeds = false)).ping() shouldBe false
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/BackgroundExceptionFlowTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/BackgroundExceptionFlowTests.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.coroutines
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.BackgroundException
+import io.etcd.recipes.common.EtcdConnector
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Deterministic coverage of [backgroundExceptionsAsFlow]: recorded background exceptions
+ * reach a collector with their context, and cancelling the collector unregisters the
+ * listener. No etcd needed — the recipe's own `recordException` is driven directly.
+ */
+class BackgroundExceptionFlowTests : StringSpec() {
+  private class TestConnector(
+    client: Client,
+  ) : EtcdConnector(client) {
+    override val exceptionContext get() = "test-recipe"
+
+    fun record(t: Throwable) = recordException(t)
+  }
+
+  private suspend fun <T> withScope(body: suspend (CoroutineScope) -> T): T {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    try {
+      return body(scope)
+    } finally {
+      scope.coroutineContext[Job]!!.cancelAndJoin()
+    }
+  }
+
+  init {
+    "backgroundExceptionsAsFlow emits recorded exceptions with their context" {
+      val connector = TestConnector(mockk())
+      val seen = CopyOnWriteArrayList<BackgroundException>()
+      withScope { scope ->
+        scope.launch { connector.backgroundExceptionsAsFlow().collect { seen += it } }
+        delay(500)
+
+        val boom = RuntimeException("boom")
+        connector.record(boom)
+
+        untilTrue(10.seconds) { seen.size == 1 } shouldBe true
+        seen.first().context shouldBe "test-recipe"
+        seen.first().throwable shouldBe boom
+      }
+    }
+
+    "the flow unregisters its listener on cancel and receives nothing afterward" {
+      val connector = TestConnector(mockk())
+      val seen = CopyOnWriteArrayList<BackgroundException>()
+      withScope { scope ->
+        val job = scope.launch { connector.backgroundExceptionsAsFlow().collect { seen += it } }
+        delay(500)
+        job.cancelAndJoin()
+
+        connector.record(RuntimeException("after cancel"))
+        delay(500)
+        seen.size shouldBe 0
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The library has **zero metrics** and its only failure surface is the pull-only
`EtcdConnector.exceptions` list — so background failures (keep-alive death, an abandoned
watcher, a lost lock/leadership, a throwing user callback) are **invisible** until behavior
degrades. For a library whose recipes hold locks and leadership, that's a
production-readiness gap.

This is **phase 1 of 3** of the observability layer (product idea #7): push-based
error/lifecycle callbacks + a health surface. **No new dependencies.** (Phase 2 = optional
Micrometer metrics via a metrics SPI + a separate binding module; phase 3 = a
structured-logging pass.)

## What's added — all on `EtcdConnector`

- **Push-based background-exception callback:** register a `BackgroundExceptionListener`
  (`addBackgroundExceptionListener` / `removeBackgroundExceptionListener`) to be notified —
  with a short **source context** (the recipe's path/clientId) — the moment a background
  failure occurs, instead of polling `exceptions`. Every recipe now funnels its failures
  through a single `recordException` sink; the pull-only `exceptions` / `hasExceptions` /
  `clearExceptions` API is unchanged. A listener that throws is logged and dropped, never
  re-recorded (notification cannot recurse).
- **`isHealthy()`** — passive: healthy unless a lease expired / a watcher was abandoned
  (`connectionState == LOST`), or the connector is closed. Derived from events the recipes
  already observe — no RPC.
- **`ping()`** — active: a bounded, non-mutating count-only GET reachability probe through
  the same retry/timeout funnel as every other RPC; returns `false` instead of throwing.
- **`EtcdConnector.backgroundExceptionsAsFlow(): Flow<BackgroundException>`** — the same
  notifications as a `Flow`.

Each recipe overrides `exceptionContext` with its path/clientId so a shared handler can
attribute which recipe failed.

## Changes

- New: `common/BackgroundExceptionListener.kt` (+ `BackgroundException`),
  `coroutines/ExceptionFlows.kt`.
- `common/EtcdConnector.kt`: the listener registry + `recordException` sink, `exceptionContext`,
  `isHealthy()`, `ping()`.
- All **71** `exceptionList.value += …` sites across 16 recipes routed through
  `recordException`.
- Tests: `EtcdConnectorObservabilityTests` (callback/health/ping) and
  `BackgroundExceptionFlowTests` (flow), both written RED-first.
- `CHANGELOG.md`.

## Verification

- 9 new tests RED→GREEN; existing `EtcdConnectorExceptionsTests` still pass.
- Frozen `design.*` oracle green — the `EtcdConnector` reflection invariants (`close()`
  `final`, `doClose()` once, `defaultClientId`, `client` `PROTECTED`) survive the new members,
  and no pinned source-text substrings were touched by the routing.
- Full `make tests-tc` gate: **387/387**. `lintKotlin` + `detekt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP
