### PR TITLE
Add an EtcdMetrics SPI and instrument the RPC, watch, and lease funnels (observability phase 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ non-blocking consumption on the existing queues.
 - Coroutines: `EtcdConnector.backgroundExceptionsAsFlow()` surfaces the same
   notifications as a `Flow<BackgroundException>`.
 
+### Added (observability: metrics SPI)
+
+- `EtcdMetrics` — a dependency-free instrumentation SPI. Install a backend with
+  `ResilienceConfig.withMetrics(metrics)` (bring your own, or a Micrometer binding in a
+  later release); the default (`EtcdMetrics.NoOp`) records nothing, so off means zero
+  overhead. The three connection funnels every recipe shares are instrumented: blocking
+  RPC latency / attempts / outcome (`recordRpc`), resilient-watcher recovery transitions
+  (`incrementWatchRecovery`), and self-healing-lease events (`incrementKeepAlive`).
+
 ### Fixed (locks: read-write lock / semaphore wait)
 
 - `DistributedReadWriteLock` and `DistributedSemaphore` could park a caller

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdMetrics.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdMetrics.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("EmptyFunctionBlock")
+
+package io.etcd.recipes.common
+
+import kotlin.time.Duration
+
+/**
+ * Instrumentation sink the library calls at its key seams. This is a dependency-free SPI:
+ * the library ships only the no-op [EtcdMetrics.NoOp]. Install a backend with
+ * [ResilienceConfig.withMetrics] — either a Micrometer binding (a separate module) or your
+ * own implementation. Every method has an empty default body, so a backend overrides only the
+ * seams it cares about and callers pay nothing when metrics are off.
+ *
+ * Implementations must be thread-safe and cheap: seams are hit from RPC-caller threads, the
+ * watch dispatcher, and lease-healer threads. `key`/`leaseId` are passed for context; a
+ * backend should keep tag cardinality low (prefer the `kind`/outcome dimensions).
+ *
+ * Currently instruments the three connection funnels every recipe shares; recipe-level seams
+ * (lock wait/hold, queue, election, cache) are added as they are instrumented.
+ */
+interface EtcdMetrics {
+  /** One completed blocking RPC: total [duration], number of [attempts], and whether it ultimately [failed]. */
+  fun recordRpc(
+    opName: String,
+    duration: Duration,
+    attempts: Int,
+    failed: Boolean,
+  ) {}
+
+  /** A resilient-watcher recovery transition; [kind] is one of suspended / resubscribed / resynced / failed. */
+  fun incrementWatchRecovery(
+    kind: String,
+    key: String,
+  ) {}
+
+  /** A self-healing-lease event; [kind] is one of renewal / suspended / expired / restored / failed. */
+  fun incrementKeepAlive(
+    kind: String,
+    leaseId: Long,
+  ) {}
+
+  companion object {
+    /** The default: records nothing. Selected unless a backend is installed via [ResilienceConfig.withMetrics]. */
+    val NoOp: EtcdMetrics = object : EtcdMetrics {}
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LeaseResilience.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/LeaseResilience.kt
@@ -38,7 +38,10 @@ class LeaseResilience
      * retry under the policy instead of parking forever on an unreachable server.
      */
     val healOperationTimeout: Duration = 10.seconds,
+    val metrics: EtcdMetrics = EtcdMetrics.NoOp,
   ) {
+    fun withMetrics(metrics: EtcdMetrics): LeaseResilience = LeaseResilience(retryPolicy, healOperationTimeout, metrics)
+
     companion object {
       @JvmField
       val DEFAULT = LeaseResilience()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ResilienceConfig.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/ResilienceConfig.kt
@@ -26,6 +26,13 @@ data class ResilienceConfig(
   val lease: LeaseResilience = LeaseResilience.DEFAULT,
   val rpc: RpcResilience = RpcResilience.DEFAULT,
 ) {
+  /** The metrics sink shared by the sub-configs (installed via [withMetrics]); [EtcdMetrics.NoOp] by default. */
+  val metrics: EtcdMetrics get() = rpc.metrics
+
+  /** A copy that routes every recipe seam and RPC/watch/lease funnel to [metrics]. */
+  fun withMetrics(metrics: EtcdMetrics): ResilienceConfig =
+    copy(watch = watch.withMetrics(metrics), lease = lease.withMetrics(metrics), rpc = rpc.withMetrics(metrics))
+
   companion object {
     @JvmField
     val DEFAULT = ResilienceConfig()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/RpcResilience.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/RpcResilience.kt
@@ -40,7 +40,10 @@ class RpcResilience
     val retryPolicy: RetryPolicy = RetryPolicy.bounded(maxAttempts = 4, delay = 250.milliseconds),
     /** Per-attempt deadline; [Duration.INFINITE] restores unbounded waiting. */
     val operationTimeout: Duration = 30.seconds,
+    val metrics: EtcdMetrics = EtcdMetrics.NoOp,
   ) {
+    fun withMetrics(metrics: EtcdMetrics): RpcResilience = RpcResilience(retryPolicy, operationTimeout, metrics)
+
     companion object {
       @JvmField
       val DEFAULT = RpcResilience()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/RpcRetry.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/RpcRetry.kt
@@ -45,33 +45,47 @@ internal fun <T> retryRpc(
 ): T {
   val start = TimeSource.Monotonic.markNow()
   var attempt = 0
-  var lastFailure: Throwable
-  while (true) {
-    attempt += 1
-    try {
-      val future = op()
-      return if (rpc.operationTimeout.isFinite()) {
-        try {
-          future.get(rpc.operationTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-        } catch (e: TimeoutException) {
-          future.cancel(true)
-          throw e
-        }
-      } else {
-        future.get()
+  var failed = true
+  try {
+    var lastFailure: Throwable
+    while (true) {
+      attempt += 1
+      try {
+        val result = op().awaitBounded(rpc) { throw it } // a timeout is a retriable failure
+        failed = false
+        return result
+      } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        throw EtcdRecipeRuntimeException("$opName interrupted", e)
+      } catch (e: Throwable) {
+        if (!e.isRetriableRpcFailure()) throw e
+        lastFailure = e
       }
-    } catch (e: InterruptedException) {
-      Thread.currentThread().interrupt()
-      throw EtcdRecipeRuntimeException("$opName interrupted", e)
-    } catch (e: Throwable) {
-      if (!e.isRetriableRpcFailure()) throw e
-      lastFailure = e
+      val delay = rpc.retryPolicy.nextDelay(attempt, start.elapsedNow())
+        ?: throw EtcdRecipeRuntimeException("$opName failed after $attempt attempts", lastFailure)
+      if (delay > Duration.ZERO) Thread.sleep(delay.inWholeMilliseconds)
     }
-    val delay = rpc.retryPolicy.nextDelay(attempt, start.elapsedNow())
-      ?: throw EtcdRecipeRuntimeException("$opName failed after $attempt attempts", lastFailure)
-    if (delay > Duration.ZERO) Thread.sleep(delay.inWholeMilliseconds)
+  } finally {
+    rpc.metrics.recordRpc(opName, start.elapsedNow(), attempt, failed)
   }
 }
+
+// Blocks on the future with the operation timeout applied; on timeout it cancels the
+// future and runs [onTimeout] (which must not return). No retry or metrics — pure await.
+private fun <T> CompletableFuture<T>.awaitBounded(
+  rpc: RpcResilience,
+  onTimeout: (TimeoutException) -> Nothing,
+): T =
+  if (rpc.operationTimeout.isFinite()) {
+    try {
+      get(rpc.operationTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+    } catch (e: TimeoutException) {
+      cancel(true)
+      onTimeout(e)
+    }
+  } else {
+    get()
+  }
 
 // internal: the suspend RPC engine in io.etcd.recipes.coroutines shares this predicate
 internal fun Throwable.isRetriableRpcFailure(): Boolean =
@@ -87,14 +101,17 @@ internal fun <T> awaitRpc(
   rpc: RpcResilience,
   opName: String,
   future: CompletableFuture<T>,
-): T =
-  if (rpc.operationTimeout.isFinite()) {
-    try {
-      future.get(rpc.operationTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-    } catch (e: TimeoutException) {
-      future.cancel(true)
-      throw EtcdRecipeRuntimeException("$opName timed out after ${rpc.operationTimeout}", e)
-    }
-  } else {
-    future.get()
+): T {
+  val start = TimeSource.Monotonic.markNow()
+  var failed = true
+  try {
+    val result =
+      future.awaitBounded(rpc) { e ->
+        throw EtcdRecipeRuntimeException("$opName timed out after ${rpc.operationTimeout}", e)
+      }
+    failed = false
+    return result
+  } finally {
+    rpc.metrics.recordRpc(opName, start.elapsedNow(), attempts = 1, failed = failed)
   }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/SelfHealingKeepAlive.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/SelfHealingKeepAlive.kt
@@ -118,7 +118,10 @@ class SelfHealingKeepAlive internal constructor(
     client.leaseClient.keepAlive(
       granted.id,
       Observers.builder<LeaseKeepAliveResponse>()
-        .onNext { next -> logger.debug { "KeepAlive next resp: $next" } }
+        .onNext { next ->
+          logger.debug { "KeepAlive next resp: $next" }
+          resilience.metrics.incrementKeepAlive("renewal", granted.id)
+        }
         .onError { e -> onStreamEvent(granted, e) }
         .onCompleted { onStreamEvent(granted, null) }
         .build(),
@@ -230,9 +233,26 @@ class SelfHealingKeepAlive internal constructor(
   }
 
   private fun emit(event: LeaseEvent) {
+    resilience.metrics.incrementKeepAlive(leaseKind(event), leaseIdOf(event))
     runCatching { leaseListener?.onLeaseEvent(event) }
       .onFailure { e -> logger.error(e) { "Lease listener threw on $event" } }
   }
+
+  private fun leaseKind(event: LeaseEvent): String =
+    when (event) {
+      is LeaseEvent.Suspended -> "suspended"
+      is LeaseEvent.Expired -> "expired"
+      is LeaseEvent.Restored -> "restored"
+      is LeaseEvent.Failed -> "failed"
+    }
+
+  private fun leaseIdOf(event: LeaseEvent): Long =
+    when (event) {
+      is LeaseEvent.Suspended -> event.leaseId
+      is LeaseEvent.Expired -> event.leaseId
+      is LeaseEvent.Restored -> event.newLeaseId
+      is LeaseEvent.Failed -> event.leaseId
+    }
 }
 
 /**

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchExtensions.kt
@@ -288,9 +288,18 @@ private class ResilientWatcher(
       ?.compactedRevision
 
   private fun emit(event: WatchRecoveryEvent) {
+    resilience.metrics.incrementWatchRecovery(recoveryKind(event), keyName)
     runCatching { recoveryListener?.onRecoveryEvent(event) }
       .onFailure { e -> logger.error(e) { "Watch recovery listener for $keyName threw on $event" } }
   }
+
+  private fun recoveryKind(event: WatchRecoveryEvent): String =
+    when (event) {
+      is WatchRecoveryEvent.Suspended -> "suspended"
+      is WatchRecoveryEvent.Resubscribed -> "resubscribed"
+      is WatchRecoveryEvent.Resynced -> "resynced"
+      is WatchRecoveryEvent.Failed -> "failed"
+    }
 }
 
 @JvmOverloads

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchResilience.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/WatchResilience.kt
@@ -36,7 +36,10 @@ class WatchResilience
      * [io.etcd.jetcd.watch.WatchResponse]s with an empty event list.
      */
     val progressNotify: Boolean = true,
+    val metrics: EtcdMetrics = EtcdMetrics.NoOp,
   ) {
+    fun withMetrics(metrics: EtcdMetrics): WatchResilience = WatchResilience(retryPolicy, progressNotify, metrics)
+
     companion object {
       @JvmField
       val DEFAULT = WatchResilience()

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ResilientWatcherTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ResilientWatcherTests.kt
@@ -99,6 +99,26 @@ class ResilientWatcherTests : StringSpec() {
       }
     }
 
+    "recovery transitions increment the watch-recovery metric" {
+      val mocks = WatchMocks()
+      val kinds = CopyOnWriteArrayList<String>()
+      val metrics =
+        object : EtcdMetrics {
+          override fun incrementWatchRecovery(
+            kind: String,
+            key: String,
+          ) {
+            kinds += kind
+          }
+        }
+      mocks.client.watcher("/rw/metrics", WatchOption.DEFAULT, quickRetries().withMetrics(metrics), { }, null) { }
+        .use {
+          mocks.listeners.first().die()
+          pollUntil(5.seconds) { kinds.contains("resubscribed") } shouldBe true
+          kinds shouldContain "suspended"
+        }
+    }
+
     "resubscribe resumes at last-seen event revision + 1" {
       val mocks = WatchMocks()
       val events = CopyOnWriteArrayList<WatchRecoveryEvent>()

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/RpcMetricsTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/RpcMetricsTests.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.options.GetOption
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration
+
+/**
+ * The metrics SPI threading ([ResilienceConfig.withMetrics]) and RPC-funnel instrumentation
+ * ([retryRpc]) — verified without etcd via a recording [EtcdMetrics] and a mocked client.
+ */
+class RpcMetricsTests : StringSpec() {
+  private class RecordingMetrics : EtcdMetrics {
+    data class Rpc(
+      val opName: String,
+      val attempts: Int,
+      val failed: Boolean,
+    )
+
+    val rpcs = CopyOnWriteArrayList<Rpc>()
+
+    override fun recordRpc(
+      opName: String,
+      duration: Duration,
+      attempts: Int,
+      failed: Boolean,
+    ) {
+      rpcs += Rpc(opName, attempts, failed)
+    }
+  }
+
+  private fun clientThatGets(succeeds: Boolean): Client =
+    mockk {
+      every { kvClient } returns
+        mockk<KV> {
+          if (succeeds) {
+            every { get(any<ByteSequence>(), any<GetOption>()) } returns
+              CompletableFuture.completedFuture(
+                mockk<GetResponse> {
+                  every { kvs } returns emptyList()
+                  every { isMore } returns false
+                },
+              )
+          } else {
+            every { get(any<ByteSequence>(), any<GetOption>()) } throws IllegalStateException("etcd down")
+          }
+        }
+    }
+
+  init {
+    "ResilienceConfig.withMetrics propagates the sink to every sub-config" {
+      val m = RecordingMetrics()
+      val cfg = ResilienceConfig.DEFAULT.withMetrics(m)
+      cfg.metrics shouldBe m
+      cfg.rpc.metrics shouldBe m
+      cfg.watch.metrics shouldBe m
+      cfg.lease.metrics shouldBe m
+      ResilienceConfig.DEFAULT.metrics shouldBe EtcdMetrics.NoOp
+    }
+
+    "a successful RPC records recordRpc once with failed=false" {
+      val m = RecordingMetrics()
+      clientThatGets(succeeds = true)
+        .getResponse("k", getOption { withCountOnly(true) }, RpcResilience.DEFAULT.withMetrics(m))
+      m.rpcs.size shouldBe 1
+      m.rpcs.first() shouldBe RecordingMetrics.Rpc("getResponse(k)", attempts = 1, failed = false)
+    }
+
+    "a non-retriable RPC failure records recordRpc with failed=true and rethrows" {
+      val m = RecordingMetrics()
+      shouldThrow<IllegalStateException> {
+        clientThatGets(succeeds = false)
+          .getResponse("k", getOption { withCountOnly(true) }, RpcResilience.DEFAULT.withMetrics(m))
+      }
+      m.rpcs.size shouldBe 1
+      m.rpcs.first().failed shouldBe true
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/SelfHealingKeepAliveTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/SelfHealingKeepAliveTests.kt
@@ -28,6 +28,7 @@ import io.etcd.jetcd.support.CloseableClient
 import io.grpc.stub.StreamObserver
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -112,6 +113,26 @@ class SelfHealingKeepAliveTests : StringSpec() {
         restored.oldLeaseId shouldBe 100L
         restored.newLeaseId shouldBe 101L
       }
+    }
+
+    "keep-alive lease transitions increment the keep-alive metric" {
+      val mocks = HealMocks()
+      val kinds = CopyOnWriteArrayList<String>()
+      val metrics =
+        object : EtcdMetrics {
+          override fun incrementKeepAlive(
+            kind: String,
+            leaseId: Long,
+          ) {
+            kinds += kind
+          }
+        }
+      mocks.client.selfHealingKeepAlive(2.seconds, quickHeals().withMetrics(metrics), null) { true }
+        .use {
+          mocks.observers.first().onCompleted() // expiry → heal → restore
+          pollUntil(10.seconds) { kinds.contains("restored") } shouldBe true
+          kinds shouldContain "expired"
+        }
     }
 
     "NOT_FOUND stream error heals like an expiry" {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueueWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueueWatchRecoveryTests.kt
@@ -42,7 +42,6 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.thread
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -114,12 +113,14 @@ class QueueWatchRecoveryTests : StringSpec() {
 
   init {
     "waitForFirstChild anchors its PUT-watch at the observed empty-queue revision" {
-      // The head-poll saw the queue empty at OBSERVED_REV; a PUT landing before the
-      // watch goes live would be lost by an un-anchored watch. The watch must start
-      // at OBSERVED_REV + 1 so any later PUT is (re)delivered.
-      val mocks = QueueMocks(emptyGets = Int.MAX_VALUE)
+      // The head read (GET #1) sees the queue empty at OBSERVED_REV and drops into
+      // waitForFirstChild, which subscribes; the pre-live poll (GET #2) then returns an item
+      // so poll() completes promptly — with no reliance on a wait timeout that a slow CI
+      // could exhaust before the watch ever subscribes. A PUT landing before the watch goes
+      // live would be lost by an un-anchored watch, so it must start at OBSERVED_REV + 1.
+      val mocks = QueueMocks(emptyGets = 1)
       DistributedQueue(mocks.client, "/queue/recovery").use { queue ->
-        queue.poll(500.milliseconds) // empty → subscribes, parks briefly, returns null
+        queue.poll(30.seconds) // GET #1 empty → subscribe; GET #2 returns the item → returns
         mocks.options.size shouldBe 1
         mocks.options.first().revision shouldBe QueueMocks.OBSERVED_REV + 1
         mocks.options.first().isPrefix shouldBe true


### PR DESCRIPTION
## Problem

The library has no metrics. **Phase 2a of 3** of the observability layer (product idea #7)
adds a dependency-free instrumentation SPI and wires it into the three connection funnels
every recipe already shares, so a single backend captures RPC, watch-recovery, and lease
activity across the whole library. (Phase 1 = push callbacks + health, #69.)

**No new dependency**, and it's usable immediately — install any `EtcdMetrics` (or, in a
later release, a Micrometer binding) via `ResilienceConfig.withMetrics(...)`; the default
sink records nothing, so off means zero overhead.

## What's added

- **`EtcdMetrics`** (`common/EtcdMetrics.kt`) — the SPI: `recordRpc`,
  `incrementWatchRecovery`, `incrementKeepAlive`. Every method has an empty default body and
  `EtcdMetrics.NoOp` is the default, so a backend overrides only what it wants.
- **Threading:** a `metrics` field + `withMetrics(m)` on `RpcResilience` / `WatchResilience`
  / `LeaseResilience` (defaulted, backward-compatible), plus `ResilienceConfig.withMetrics(m)`
  (stamps one instance onto all three) and `ResilienceConfig.metrics` to read it back.
- **Instrumentation** at the three shared funnels:
  - `retryRpc` / `awaitRpc` record each blocking RPC once — duration, attempts, and outcome —
    via a single `try/finally` (extracted an `awaitBounded` helper for the timeout-bounded
    await, keeping nesting within detekt limits).
  - `ResilientWatcher.emit` increments a watch-recovery counter per transition
    (suspended / resubscribed / resynced / failed).
  - `SelfHealingKeepAlive` increments a keep-alive counter on each renewal tick and on each
    lease event (suspended / expired / restored / failed).

## Verification

- `RpcMetricsTests` (SPI threading + RPC recording) written RED-first; metrics cases added to
  the existing `ResilientWatcherTests` / `SelfHealingKeepAliveTests` mock harnesses; the
  existing funnel tests are unchanged (behavior preserved).
- Frozen `design.*` oracle green. Full `make tests-tc` gate: **392/392**. `lintKotlin` +
  `detekt` clean.

## Follow-ups (later PRs)

- A Micrometer binding module (`etcd-recipes-micrometer` + `MicrometerEtcdMetrics`).
- Recipe-level seams: lock wait/hold, queue, election transitions, cache sync + gauges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP

---

**Also folded in:** a deflake of the `QueueWatchRecoveryTests` anchor case (a pre-existing 500ms-deadline timing flake from #68 that a slow CI could trip before the watch subscribed) — unrelated to the metrics change, but it surfaced on this PR's CI.
