### PR TITLE
Add an etcd-recipes-micrometer module binding the metrics SPI to Micrometer (observability phase 2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ non-blocking consumption on the existing queues.
   RPC latency / attempts / outcome (`recordRpc`), resilient-watcher recovery transitions
   (`incrementWatchRecovery`), and self-healing-lease events (`incrementKeepAlive`).
 
+### Added (observability: Micrometer binding)
+
+- New **`etcd-recipes-micrometer`** module: `MicrometerEtcdMetrics(registry)` is a
+  Micrometer backend for the `EtcdMetrics` SPI. Install it with
+  `ResilienceConfig.withMetrics(MicrometerEtcdMetrics(registry))` to record `etcd.rpc`
+  (a timer plus a retry counter, tagged by operation and outcome), `etcd.watch.recovery`,
+  and `etcd.keepalive` (counters tagged by kind), with tag cardinality kept low. Micrometer
+  is an `api` dependency of this module only — the core library stays dependency-free.
+
 ### Fixed (locks: read-write lock / semaphore wait)
 
 - `DistributedReadWriteLock` and `DistributedSemaphore` could park a caller

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 val libraryName = "etcd-recipes"
 val libraryModule = ":$libraryName"
 val examplesModule = ":$libraryName-examples"
+val micrometerModule = ":$libraryName-micrometer"
 val repoUrl = "https://github.com/pambrose/$libraryName"
 
 val envDockerHost = "DOCKER_HOST"
@@ -58,6 +59,7 @@ subprojects {
 dependencies {
     dokka(project(libraryModule))
     dokka(project(examplesModule))
+    dokka(project(micrometerModule))
 
     kover(project(libraryModule))
 }
@@ -96,8 +98,8 @@ subprojects {
         }
     }
 
-    // Examples module isn't published; only the library is.
-    if (name == libraryName) configurePublishing()
+    // The library and its Micrometer binding are published; the examples and test-runners aren't.
+    if (name == libraryName || name == "$libraryName-micrometer") configurePublishing()
 
     configure<KotlinJvmProjectExtension> {
         jvmToolchain(rootProject.libs.versions.jvm.get().toInt())

--- a/etcd-recipes-micrometer/build.gradle.kts
+++ b/etcd-recipes-micrometer/build.gradle.kts
@@ -1,0 +1,6 @@
+dependencies {
+  "implementation"(project(":etcd-recipes"))
+  // Declared inline rather than in the version catalog: this is the only module that
+  // needs Micrometer, and the catalog is otherwise reserved for shared dependencies.
+  "api"("io.micrometer:micrometer-core:1.14.2")
+}

--- a/etcd-recipes-micrometer/src/main/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetrics.kt
+++ b/etcd-recipes-micrometer/src/main/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetrics.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.micrometer
+
+import io.etcd.recipes.common.EtcdMetrics
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+/**
+ * A Micrometer-backed [EtcdMetrics]. Install it on any recipe with
+ * `ResilienceConfig.withMetrics(MicrometerEtcdMetrics(registry))`.
+ *
+ * Meters registered (all sharing whatever common tags [registry] carries):
+ * - `etcd.rpc` — a [Timer] per blocking RPC, tagged `operation` (the op name without its key
+ *   argument) and `outcome` (`success`/`failure`);
+ * - `etcd.rpc.retries` — a counter of extra attempts beyond the first, tagged `operation`;
+ * - `etcd.watch.recovery` — a counter of resilient-watcher transitions, tagged `kind`;
+ * - `etcd.keepalive` — a counter of self-healing-lease events, tagged `kind`.
+ *
+ * Tag cardinality is kept low on purpose: the etcd key and lease id are used only for the
+ * (low-cardinality) `operation`/`kind` dimensions, never as tags themselves.
+ */
+class MicrometerEtcdMetrics(
+  private val registry: MeterRegistry,
+) : EtcdMetrics {
+  override fun recordRpc(
+    opName: String,
+    duration: Duration,
+    attempts: Int,
+    failed: Boolean,
+  ) {
+    val operation = opName.substringBefore('(')
+    Timer.builder("etcd.rpc")
+      .tag("operation", operation)
+      .tag("outcome", if (failed) "failure" else "success")
+      .register(registry)
+      .record(duration.toJavaDuration())
+    if (attempts > 1) {
+      registry.counter("etcd.rpc.retries", "operation", operation).increment((attempts - 1).toDouble())
+    }
+  }
+
+  override fun incrementWatchRecovery(
+    kind: String,
+    key: String,
+  ) {
+    registry.counter("etcd.watch.recovery", "kind", kind).increment()
+  }
+
+  override fun incrementKeepAlive(
+    kind: String,
+    leaseId: Long,
+  ) {
+    registry.counter("etcd.keepalive", "kind", kind).increment()
+  }
+}

--- a/etcd-recipes-micrometer/src/test/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetricsTests.kt
+++ b/etcd-recipes-micrometer/src/test/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetricsTests.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.micrometer
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.options.GetOption
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.getOption
+import io.etcd.recipes.common.getResponse
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * The Micrometer backend for [io.etcd.recipes.common.EtcdMetrics], verified against a
+ * [SimpleMeterRegistry] — both directly and installed end-to-end via
+ * [ResilienceConfig.withMetrics].
+ */
+class MicrometerEtcdMetricsTests : StringSpec() {
+  init {
+    "recordRpc registers a timer tagged by operation (without the key) and outcome" {
+      val registry = SimpleMeterRegistry()
+      MicrometerEtcdMetrics(registry).recordRpc("getResponse(/a/b)", 5.milliseconds, attempts = 1, failed = false)
+
+      val timer = registry.find("etcd.rpc").tag("operation", "getResponse").tag("outcome", "success").timer()
+      timer.shouldNotBeNull()
+      timer.count() shouldBe 1L
+    }
+
+    "recordRpc counts extra attempts as retries" {
+      val registry = SimpleMeterRegistry()
+      MicrometerEtcdMetrics(registry).recordRpc("putValue(/x)", 10.milliseconds, attempts = 3, failed = true)
+
+      registry.find("etcd.rpc").tag("outcome", "failure").timer().shouldNotBeNull()
+      registry.find("etcd.rpc.retries").tag("operation", "putValue").counter()!!.count() shouldBe 2.0
+    }
+
+    "watch-recovery and keep-alive events increment counters tagged by kind" {
+      val registry = SimpleMeterRegistry()
+      val metrics = MicrometerEtcdMetrics(registry)
+      metrics.incrementWatchRecovery("resubscribed", "/k")
+      metrics.incrementKeepAlive("renewal", 7L)
+
+      registry.find("etcd.watch.recovery").tag("kind", "resubscribed").counter()!!.count() shouldBe 1.0
+      registry.find("etcd.keepalive").tag("kind", "renewal").counter()!!.count() shouldBe 1.0
+    }
+
+    "installed via ResilienceConfig.withMetrics it records real RPC activity" {
+      val registry = SimpleMeterRegistry()
+      val client: Client =
+        mockk {
+          every { kvClient } returns
+            mockk<KV> {
+              every { get(any<ByteSequence>(), any<GetOption>()) } returns
+                CompletableFuture.completedFuture(
+                  mockk<GetResponse> {
+                    every { kvs } returns emptyList()
+                    every { isMore } returns false
+                  },
+                )
+            }
+        }
+
+      val rpc = ResilienceConfig.DEFAULT.withMetrics(MicrometerEtcdMetrics(registry)).rpc
+      client.getResponse("/probe", getOption { withCountOnly(true) }, rpc)
+
+      registry.find("etcd.rpc").tag("operation", "getResponse").tag("outcome", "success").timer()!!.count() shouldBe 1L
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,4 +20,5 @@ rootProject.name = "etcd-recipes"
 
 include("etcd-recipes")
 include("etcd-recipes-examples")
+include("etcd-recipes-micrometer")
 include("etcd-recipes-test-runners")


### PR DESCRIPTION
## Summary

**Phase 2b of the observability layer** (product idea #7). Phase 2a (#70) shipped the
dependency-free `EtcdMetrics` SPI and instrumented the RPC/watch/lease funnels; this adds the
batteries-included **Micrometer** backend so users get metrics without writing an adapter —
while the core library stays Micrometer-free.

## What's added

- **New module `etcd-recipes-micrometer`** with `MicrometerEtcdMetrics(registry)`. Install it
  on any recipe:
  ```kotlin
  val metrics = MicrometerEtcdMetrics(meterRegistry)
  DistributedMutex(client, path, resilience = ResilienceConfig.DEFAULT.withMetrics(metrics))
  ```
  Meters registered:
  - `etcd.rpc` — a `Timer` per blocking RPC, tagged `operation` (the op name without its key
    argument) and `outcome`; plus `etcd.rpc.retries` counting extra attempts.
  - `etcd.watch.recovery` — resilient-watcher transitions, tagged `kind`.
  - `etcd.keepalive` — self-healing-lease events, tagged `kind`.

  Tag cardinality is kept low on purpose: the etcd key and lease id feed only the low-cardinality
  `operation`/`kind` dimensions, never the tags themselves.

## Wiring

- `settings.gradle.kts` includes the module; its `build.gradle.kts` adds `micrometer-core` as an
  `api` dependency. The version is declared **inline** rather than in `gradle/libs.versions.toml`
  — this is the only module that needs Micrometer, and it keeps the shared catalog untouched.
- The root build **publishes** the module (extended the `configurePublishing()` guard) and
  includes it in the aggregated Dokka.

## Verification

- `MicrometerEtcdMetricsTests` (4) written RED-first, incl. an end-to-end check that installing
  the backend via `ResilienceConfig.withMetrics` and doing a `getResponse` moves the `etcd.rpc`
  timer.
- Ran the exact CI command locally (`check koverXmlReport -PuseTestcontainers`): green, including
  the new module's `koverVerify`. `lintKotlin` + `detekt` clean.

## Notes for the maintainer

- **Micrometer version is inline** (1.14.2), not in the catalog — trivially movable once the
  catalog is otherwise being touched.
- The module is wired into **Maven Central publishing**, so the next release will publish a
  second artifact (`etcd-recipes-micrometer`).

Recipe-level metric seams (lock wait/hold, queue, election, cache + gauges) follow in a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP
