### PR TITLE
Instrument the lock and election recipes with metrics (observability phase 2c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ non-blocking consumption on the existing queues.
   RPC latency / attempts / outcome (`recordRpc`), resilient-watcher recovery transitions
   (`incrementWatchRecovery`), and self-healing-lease events (`incrementKeepAlive`).
 
+### Added (observability: lock + election metrics)
+
+- Recipe-level metric seams via the `EtcdMetrics` SPI: `DistributedMutex`,
+  `DistributedReadWriteLock`, and `DistributedSemaphore` record acquisition wait time
+  (`recordLockWait`, with the acquired/timed-out outcome) and hold time (`recordLockHold`);
+  `LeaderSelector` (and so `LeaderLatch`, which composes it) records leadership take/relinquish
+  transitions (`incrementLeadershipTransition`). The Micrometer binding maps these to
+  `etcd.lock.wait` / `etcd.lock.hold` timers and an `etcd.election.transitions` counter.
+
 ### Added (observability: Micrometer binding)
 
 - New **`etcd-recipes-micrometer`** module: `MicrometerEtcdMetrics(registry)` is a

--- a/etcd-recipes-micrometer/src/main/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetrics.kt
+++ b/etcd-recipes-micrometer/src/main/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetrics.kt
@@ -31,10 +31,15 @@ import kotlin.time.toJavaDuration
  *   argument) and `outcome` (`success`/`failure`);
  * - `etcd.rpc.retries` — a counter of extra attempts beyond the first, tagged `operation`;
  * - `etcd.watch.recovery` — a counter of resilient-watcher transitions, tagged `kind`;
- * - `etcd.keepalive` — a counter of self-healing-lease events, tagged `kind`.
+ * - `etcd.keepalive` — a counter of self-healing-lease events, tagged `kind`;
+ * - `etcd.lock.wait` — a [Timer] of lock/permit acquisition waits, tagged `outcome`
+ *   (`acquired`/`timeout`);
+ * - `etcd.lock.hold` — a [Timer] of lock/permit hold durations;
+ * - `etcd.election.transitions` — a counter of leadership changes, tagged `transition`
+ *   (`acquired`/`relinquished`).
  *
- * Tag cardinality is kept low on purpose: the etcd key and lease id are used only for the
- * (low-cardinality) `operation`/`kind` dimensions, never as tags themselves.
+ * Tag cardinality is kept low on purpose: the etcd key, lock path, and lease id are used only
+ * for the (low-cardinality) `operation`/`kind`/`outcome` dimensions, never as tags themselves.
  */
 class MicrometerEtcdMetrics(
   private val registry: MeterRegistry,
@@ -68,5 +73,33 @@ class MicrometerEtcdMetrics(
     leaseId: Long,
   ) {
     registry.counter("etcd.keepalive", "kind", kind).increment()
+  }
+
+  override fun recordLockWait(
+    path: String,
+    duration: Duration,
+    acquired: Boolean,
+  ) {
+    Timer.builder("etcd.lock.wait")
+      .tag("outcome", if (acquired) "acquired" else "timeout")
+      .register(registry)
+      .record(duration.toJavaDuration())
+  }
+
+  override fun recordLockHold(
+    path: String,
+    duration: Duration,
+  ) {
+    Timer.builder("etcd.lock.hold")
+      .register(registry)
+      .record(duration.toJavaDuration())
+  }
+
+  override fun incrementLeadershipTransition(
+    path: String,
+    becameLeader: Boolean,
+  ) {
+    registry.counter("etcd.election.transitions", "transition", if (becameLeader) "acquired" else "relinquished")
+      .increment()
   }
 }

--- a/etcd-recipes-micrometer/src/test/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetricsTests.kt
+++ b/etcd-recipes-micrometer/src/test/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetricsTests.kt
@@ -69,6 +69,22 @@ class MicrometerEtcdMetricsTests : StringSpec() {
       registry.find("etcd.keepalive").tag("kind", "renewal").counter()!!.count() shouldBe 1.0
     }
 
+    "lock wait/hold register timers and leadership transitions a counter" {
+      val registry = SimpleMeterRegistry()
+      val metrics = MicrometerEtcdMetrics(registry)
+      metrics.recordLockWait("/lock/a", 3.milliseconds, acquired = true)
+      metrics.recordLockWait("/lock/a", 20.milliseconds, acquired = false)
+      metrics.recordLockHold("/lock/a", 100.milliseconds)
+      metrics.incrementLeadershipTransition("/election/x", becameLeader = true)
+      metrics.incrementLeadershipTransition("/election/x", becameLeader = false)
+
+      registry.find("etcd.lock.wait").tag("outcome", "acquired").timer()!!.count() shouldBe 1L
+      registry.find("etcd.lock.wait").tag("outcome", "timeout").timer()!!.count() shouldBe 1L
+      registry.find("etcd.lock.hold").timer()!!.count() shouldBe 1L
+      registry.find("etcd.election.transitions").tag("transition", "acquired").counter()!!.count() shouldBe 1.0
+      registry.find("etcd.election.transitions").tag("transition", "relinquished").counter()!!.count() shouldBe 1.0
+    }
+
     "installed via ResilienceConfig.withMetrics it records real RPC activity" {
       val registry = SimpleMeterRegistry()
       val client: Client =

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdMetrics.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdMetrics.kt
@@ -55,6 +55,25 @@ interface EtcdMetrics {
     leaseId: Long,
   ) {}
 
+  /** Time a caller spent trying to acquire a lock/permit at [path], and whether it ultimately [acquired] it. */
+  fun recordLockWait(
+    path: String,
+    duration: Duration,
+    acquired: Boolean,
+  ) {}
+
+  /** How long a lock/permit at [path] was held, from grant to release. */
+  fun recordLockHold(
+    path: String,
+    duration: Duration,
+  ) {}
+
+  /** A leadership transition for the election [path]: [becameLeader] true on take, false on relinquish. */
+  fun incrementLeadershipTransition(
+    path: String,
+    becameLeader: Boolean,
+  ) {}
+
   companion object {
     /** The default: records nothing. Selected unless a backend is installed via [ResilienceConfig.withMetrics]. */
     val NoOp: EtcdMetrics = object : EtcdMetrics {}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -465,6 +465,7 @@ constructor(
 
         // Mark elected inside the lock so a concurrent candidate sees isLeader and bails.
         electedLeader.store(true)
+        resilience.metrics.incrementLeadershipTransition(electionPath, becameLeader = true)
         granted
       }
 
@@ -495,6 +496,7 @@ constructor(
       // Leadership is over (relinquished or stepped down): always notify, even when
       // takeLeadership threw, so the listener can release its resources. (Pre-0.12
       // a throw skipped relinquishLeadership.)
+      resilience.metrics.incrementLeadershipTransition(electionPath, becameLeader = false)
       try {
         listener.relinquishLeadership(this)
       } catch (e: Throwable) {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedMutex.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedMutex.kt
@@ -72,6 +72,7 @@ class DistributedMutex
     val ownershipKey: ByteSequence,
   ) {
     var holdCount = 1 // guarded by owner-thread confinement
+    val acquiredAt: ComparableTimeMark = TimeSource.Monotonic.markNow()
   }
 
   private enum class Phase { WAITING, HOLDING, DEAD }
@@ -101,12 +102,19 @@ class DistributedMutex
   override val exceptionContext get() = "DistributedMutex[$lockPath]"
 
   override fun lock() {
+    val timed = !isHeldByCurrentThread // don't time reentrant re-locks
+    val start = TimeSource.Monotonic.markNow()
     check(acquire(null)) { "unbounded acquisition returned without the lock" }
+    if (timed) resilience.metrics.recordLockWait(lockPath, start.elapsedNow(), acquired = true)
   }
 
   override fun tryLock(timeout: Duration): Boolean {
     require(timeout > Duration.ZERO) { "Timeout must be positive: $timeout" }
-    return acquire(TimeSource.Monotonic.markNow() + timeout)
+    val timed = !isHeldByCurrentThread
+    val start = TimeSource.Monotonic.markNow()
+    val acquired = acquire(TimeSource.Monotonic.markNow() + timeout)
+    if (timed) resilience.metrics.recordLockWait(lockPath, start.elapsedNow(), acquired)
+    return acquired
   }
 
   override fun tryLock(
@@ -294,6 +302,7 @@ class DistributedMutex
   }
 
   private fun releaseHold(data: LockData) {
+    resilience.metrics.recordLockHold(lockPath, data.acquiredAt.elapsedNow())
     // Prompt FIFO handoff via the unlock RPC; the revoke below is belt-and-braces
     // (it deletes the ownership key even if the unlock RPC failed).
     runCatching { client.unlock(data.ownershipKey.asString, resilience.rpc) }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
@@ -85,6 +85,7 @@ class DistributedReadWriteLock
     val entryKey: String,
   ) {
     var holdCount = 1 // owner-thread confined
+    val acquiredAt: ComparableTimeMark = TimeSource.Monotonic.markNow()
   }
 
   // One in-flight acquisition; the phase machine arbitrates fatal-vs-win exactly
@@ -125,12 +126,19 @@ class DistributedReadWriteLock
     private val side: Side,
   ) : EtcdLock {
     override fun lock() {
+      val timed = !isHeldByCurrentThread // don't time reentrant re-locks
+      val start = TimeSource.Monotonic.markNow()
       check(acquire(side, null)) { "unbounded acquisition returned without the lock" }
+      if (timed) resilience.metrics.recordLockWait(lockPath, start.elapsedNow(), acquired = true)
     }
 
     override fun tryLock(timeout: Duration): Boolean {
       require(timeout > Duration.ZERO) { "Timeout must be positive: $timeout" }
-      return acquire(side, TimeSource.Monotonic.markNow() + timeout)
+      val timed = !isHeldByCurrentThread
+      val start = TimeSource.Monotonic.markNow()
+      val acquired = acquire(side, TimeSource.Monotonic.markNow() + timeout)
+      if (timed) resilience.metrics.recordLockWait(lockPath, start.elapsedNow(), acquired)
+      return acquired
     }
 
     override fun tryLock(
@@ -171,6 +179,7 @@ class DistributedReadWriteLock
         return true
       }
       holds.remove(me)
+      resilience.metrics.recordLockHold(lockPath, data.acquiredAt.elapsedNow())
       data.lease.close() // revoke deletes the entry, waking successors
       return true
     }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
@@ -101,7 +101,9 @@ class DistributedSemaphore
     val lease: AcquisitionLease,
     val entryKey: String,
     val owner: Thread,
-  )
+  ) {
+    val acquiredAt: ComparableTimeMark = TimeSource.Monotonic.markNow()
+  }
 
   // One in-flight acquisition; the phase machine arbitrates fatal-vs-win exactly
   // like DistributedMutex's.
@@ -134,12 +136,17 @@ class DistributedSemaphore
   override val exceptionContext get() = "DistributedSemaphore[$semaphorePath]"
 
   fun acquire() {
+    val start = TimeSource.Monotonic.markNow()
     check(acquireInternal(null)) { "unbounded acquisition returned without a permit" }
+    resilience.metrics.recordLockWait(semaphorePath, start.elapsedNow(), acquired = true)
   }
 
   fun tryAcquire(timeout: Duration): Boolean {
     require(timeout > Duration.ZERO) { "Timeout must be positive: $timeout" }
-    return acquireInternal(TimeSource.Monotonic.markNow() + timeout)
+    val start = TimeSource.Monotonic.markNow()
+    val acquired = acquireInternal(TimeSource.Monotonic.markNow() + timeout)
+    resilience.metrics.recordLockWait(semaphorePath, start.elapsedNow(), acquired)
+    return acquired
   }
 
   fun tryAcquire(
@@ -155,6 +162,7 @@ class DistributedSemaphore
   fun release(): Boolean {
     val data = holds.pollFirst()
     if (data != null) {
+      resilience.metrics.recordLockHold(semaphorePath, data.acquiredAt.elapsedNow())
       data.lease.close() // revoke deletes the entry, waking waiters
       return true
     }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/RecipeMetricsTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/RecipeMetricsTests.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.lock
+
+import io.etcd.recipes.common.EtcdMetrics
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.urls
+import io.etcd.recipes.election.LeaderSelector
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration
+
+/**
+ * End-to-end proof that the recipes actually drive the [EtcdMetrics] seams: a mutex,
+ * a semaphore, and a leader selector are each run with a recording metrics installed via
+ * [ResilienceConfig.withMetrics], and the recorded events are asserted.
+ */
+class RecipeMetricsTests : StringSpec() {
+  private val base = "/metrics/${javaClass.simpleName}"
+
+  private class RecordingMetrics : EtcdMetrics {
+    val lockWaits = CopyOnWriteArrayList<Boolean>()
+    val lockHolds = AtomicInteger(0)
+    val leadership = CopyOnWriteArrayList<Boolean>()
+
+    override fun recordLockWait(
+      path: String,
+      duration: Duration,
+      acquired: Boolean,
+    ) {
+      lockWaits += acquired
+    }
+
+    override fun recordLockHold(
+      path: String,
+      duration: Duration,
+    ) {
+      lockHolds.incrementAndGet()
+    }
+
+    override fun incrementLeadershipTransition(
+      path: String,
+      becameLeader: Boolean,
+    ) {
+      leadership += becameLeader
+    }
+  }
+
+  init {
+    "mutex lock then unlock records one acquired wait and one hold" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val metrics = RecordingMetrics()
+        DistributedMutex(client, "$base/mutex", resilience = ResilienceConfig.DEFAULT.withMetrics(metrics))
+          .use { mutex ->
+            mutex.lock()
+            mutex.unlock()
+          }
+        metrics.lockWaits shouldBe listOf(true)
+        metrics.lockHolds.get() shouldBe 1
+      }
+    }
+
+    "semaphore acquire then release records one acquired wait and one hold" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val metrics = RecordingMetrics()
+        DistributedSemaphore(client, "$base/sem", 1, resilience = ResilienceConfig.DEFAULT.withMetrics(metrics))
+          .use { semaphore ->
+            semaphore.acquire()
+            semaphore.release()
+          }
+        metrics.lockWaits shouldBe listOf(true)
+        metrics.lockHolds.get() shouldBe 1
+      }
+    }
+
+    "a leadership term records a take then a relinquish transition" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val metrics = RecordingMetrics()
+        LeaderSelector(
+          client,
+          "$base/election",
+          takeLeadershipBlock = { }, // return immediately → relinquish
+          resilience = ResilienceConfig.DEFAULT.withMetrics(metrics),
+        ).use { selector ->
+          selector.start()
+          selector.waitOnLeadershipComplete()
+        }
+        metrics.leadership shouldBe listOf(true, false)
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

**Phase 2c of the observability layer** (product idea #7). Phase 2a shipped the `EtcdMetrics`
SPI + funnel instrumentation (#70) and phase 2b the Micrometer binding (#71); this extends the
SPI to the **coordination primitives** so a backend can see lock contention and leadership churn.

## What's added

- **SPI** (`EtcdMetrics`): `recordLockWait(path, duration, acquired)`,
  `recordLockHold(path, duration)`, `incrementLeadershipTransition(path, becameLeader)` — each
  with an empty default body, so the addition is backward-compatible.
- **Locks** — `DistributedMutex`, `DistributedReadWriteLock`, `DistributedSemaphore`:
  - **wait time**, measured entry→grant on the public `lock`/`tryLock`/`acquire` methods
    (reentrant re-locks are skipped so they don't skew the timer);
  - **hold time**, measured grant→release via a timestamp stored on the hold data.
- **Election** — `LeaderSelector` records the take and relinquish transitions; `LeaderLatch`
  inherits this because it composes a `LeaderSelector` per term.
- **Micrometer** — `MicrometerEtcdMetrics` maps these to `etcd.lock.wait` / `etcd.lock.hold`
  timers (the wait tagged by `outcome`) and an `etcd.election.transitions` counter (tagged
  `transition`).

## Verification

- Micrometer unit tests for the new meters, plus **3 real-etcd integration tests**
  (`RecipeMetricsTests`) that run a mutex, a semaphore, and a leadership term and assert the
  recorded events — proving the recipes actually drive the seams.
- Existing lock/election tests unregressed; `LeaderSelector`'s frozen source assertions intact.
- Ran the exact CI command locally (`check koverXmlReport -PuseTestcontainers`): green. `lintKotlin`
  + `detekt` clean.

Queue/cache metrics and gauges (queue depth, cache size, permits, current leader) follow in a
later PR, then a structured-logging pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP
