### PR TITLE
Instrument the queue and cache recipes with metrics (observability phase 2d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ non-blocking consumption on the existing queues.
   RPC latency / attempts / outcome (`recordRpc`), resilient-watcher recovery transitions
   (`incrementWatchRecovery`), and self-healing-lease events (`incrementKeepAlive`).
 
+### Added (observability: queue + cache metrics)
+
+- More recipe metric seams via the `EtcdMetrics` SPI: the queues record dequeue latency
+  (`recordQueue`, measured call→item-in-hand), and `PathChildrenCache` / `ServiceCache` record
+  each snapshot (re)sync (`recordCacheSync`, with the resulting entry count). The Micrometer
+  binding maps these to an `etcd.queue` timer and an `etcd.cache.sync` timer plus an
+  `etcd.cache.size` distribution.
+
 ### Added (observability: lock + election metrics)
 
 - Recipe-level metric seams via the `EtcdMetrics` SPI: `DistributedMutex`,

--- a/etcd-recipes-micrometer/src/main/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetrics.kt
+++ b/etcd-recipes-micrometer/src/main/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetrics.kt
@@ -17,6 +17,7 @@
 package io.etcd.recipes.micrometer
 
 import io.etcd.recipes.common.EtcdMetrics
+import io.micrometer.core.instrument.DistributionSummary
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import kotlin.time.Duration
@@ -36,7 +37,10 @@ import kotlin.time.toJavaDuration
  *   (`acquired`/`timeout`);
  * - `etcd.lock.hold` — a [Timer] of lock/permit hold durations;
  * - `etcd.election.transitions` — a counter of leadership changes, tagged `transition`
- *   (`acquired`/`relinquished`).
+ *   (`acquired`/`relinquished`);
+ * - `etcd.queue` — a [Timer] of queue operations, tagged `op` (`enqueue`/`dequeue`);
+ * - `etcd.cache.sync` — a [Timer] of cache snapshot loads, and `etcd.cache.size` a
+ *   [DistributionSummary] of the resulting entry counts.
  *
  * Tag cardinality is kept low on purpose: the etcd key, lock path, and lease id are used only
  * for the (low-cardinality) `operation`/`kind`/`outcome` dimensions, never as tags themselves.
@@ -101,5 +105,25 @@ class MicrometerEtcdMetrics(
   ) {
     registry.counter("etcd.election.transitions", "transition", if (becameLeader) "acquired" else "relinquished")
       .increment()
+  }
+
+  override fun recordQueue(
+    op: String,
+    path: String,
+    duration: Duration,
+  ) {
+    Timer.builder("etcd.queue")
+      .tag("op", op)
+      .register(registry)
+      .record(duration.toJavaDuration())
+  }
+
+  override fun recordCacheSync(
+    path: String,
+    duration: Duration,
+    size: Int,
+  ) {
+    Timer.builder("etcd.cache.sync").register(registry).record(duration.toJavaDuration())
+    DistributionSummary.builder("etcd.cache.size").register(registry).record(size.toDouble())
   }
 }

--- a/etcd-recipes-micrometer/src/test/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetricsTests.kt
+++ b/etcd-recipes-micrometer/src/test/kotlin/io/etcd/recipes/micrometer/MicrometerEtcdMetricsTests.kt
@@ -85,6 +85,19 @@ class MicrometerEtcdMetricsTests : StringSpec() {
       registry.find("etcd.election.transitions").tag("transition", "relinquished").counter()!!.count() shouldBe 1.0
     }
 
+    "queue ops register a timer tagged by op, and cache sync a timer plus a size summary" {
+      val registry = SimpleMeterRegistry()
+      val metrics = MicrometerEtcdMetrics(registry)
+      metrics.recordQueue("dequeue", "/q", 5.milliseconds)
+      metrics.recordCacheSync("/c", 10.milliseconds, size = 3)
+
+      registry.find("etcd.queue").tag("op", "dequeue").timer()!!.count() shouldBe 1L
+      registry.find("etcd.cache.sync").timer()!!.count() shouldBe 1L
+      val size = registry.find("etcd.cache.size").summary()!!
+      size.count() shouldBe 1L
+      size.max() shouldBe 3.0
+    }
+
     "installed via ResilienceConfig.withMetrics it records real RPC activity" {
       val registry = SimpleMeterRegistry()
       val client: Client =

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -51,6 +51,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
+import kotlin.time.TimeSource
 
 @JvmOverloads
 fun <T> withPathChildrenCache(
@@ -189,6 +190,7 @@ class PathChildrenCache
   @Suppress("TooGenericExceptionCaught")
   private fun loadDataAndStartWatcher() {
     try {
+      val start = TimeSource.Monotonic.markNow()
       val getOption = getOption {
         isPrefix(true)
         withSortField(GetOption.SortTarget.KEY)
@@ -202,6 +204,7 @@ class PathChildrenCache
         cacheMap[s] = kv.value
       }
 
+      resilience.metrics.recordCacheSync(cachePath, start.elapsedNow(), cacheMap.size)
       setupWatcher(anchorRevision)
     } catch (e: Throwable) {
       logger.error(e) { "Exception in loadDataAndStartWatcher()" }
@@ -305,6 +308,7 @@ class PathChildrenCache
   // reconciliation is safe on the ConcurrentMap, and watch events are serialized on
   // the same dispatcher thread anyway.
   private fun reconcile(): Long {
+    val start = TimeSource.Monotonic.markNow()
     val getOption = getOption {
       isPrefix(true)
       withSortField(GetOption.SortTarget.KEY)
@@ -313,6 +317,7 @@ class PathChildrenCache
     val fresh = resp.kvs.associate { kv -> kv.key.asString.substring(trailingPath.length) to kv.value }
     cacheMap.keys.retainAll(fresh.keys)
     cacheMap.putAll(fresh)
+    resilience.metrics.recordCacheSync(cachePath, start.elapsedNow(), cacheMap.size)
     return resp.header.revision + 1
   }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdMetrics.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdMetrics.kt
@@ -74,6 +74,20 @@ interface EtcdMetrics {
     becameLeader: Boolean,
   ) {}
 
+  /** A queue operation ([op] is enqueue / dequeue) at [path] and how long it took. */
+  fun recordQueue(
+    op: String,
+    path: String,
+    duration: Duration,
+  ) {}
+
+  /** A cache (re)sync of [path]: how long the snapshot load took and the resulting entry [size]. */
+  fun recordCacheSync(
+    path: String,
+    duration: Duration,
+    size: Int,
+  ) {}
+
   companion object {
     /** The default: records nothing. Selected unless a backend is installed via [ResilienceConfig.withMetrics]. */
     val NoOp: EtcdMetrics = object : EtcdMetrics {}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceCache.kt
@@ -39,6 +39,7 @@ import io.etcd.recipes.common.watcher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.ConcurrentMap
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.TimeSource
 
 class ServiceCache
   @JvmOverloads
@@ -141,6 +142,7 @@ class ServiceCache
   // revision + 1). Runs during start() and, on the watch dispatcher thread, during
   // compaction resync — deliberately not synchronized (see PathChildrenCache.reconcile).
   private fun reconcile(): Long {
+    val start = TimeSource.Monotonic.markNow()
     val trailingServicePath = servicePath.ensureSuffix("/")
     val trailingNamesPath = namesPath.ensureSuffix("/")
     val getOption = getOption {
@@ -152,6 +154,7 @@ class ServiceCache
       resp.kvs.associate { kv -> kv.key.asString.substring(trailingNamesPath.length) to kv.value.asString }
     serviceMap.keys.retainAll(fresh.keys)
     serviceMap.putAll(fresh)
+    resilience.metrics.recordCacheSync(servicePath, start.elapsedNow(), serviceMap.size)
     return resp.header.revision + 1
   }
 

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -86,6 +86,7 @@ abstract class AbstractQueue(
   @Suppress("LoopWithTooManyJumpStatements", "ReturnCount")
   private fun takeWithDeadline(deadline: ComparableTimeMark?): ByteSequence? {
     checkCloseNotCalled()
+    val start = TimeSource.Monotonic.markNow() // dequeue latency = call → item in hand
 
     // Loop instead of recursing on CAS-conflict retries: a recursive frame per
     // retry could allocate a new watcher (with its own dispatcher executor).
@@ -96,6 +97,7 @@ abstract class AbstractQueue(
       if (childList.isNotEmpty()) {
         val child = childList.first()
         if (deleteRevKey(child)) {
+          resilience.metrics.recordQueue("dequeue", queuePath, start.elapsedNow())
           return child.value
         }
         logger.debug { "Lost CAS to concurrent consumer, retrying without watcher" }
@@ -111,7 +113,10 @@ abstract class AbstractQueue(
       // in the watch-establishment window is still delivered (the pre-live poll
       // then only shortcuts the already-arrived case).
       val winner = waitForFirstChild(deadline, firstChild.header.revision) ?: continue
-      if (deleteRevKey(winner)) return winner.value
+      if (deleteRevKey(winner)) {
+        resilience.metrics.recordQueue("dequeue", queuePath, start.elapsedNow())
+        return winner.value
+      }
     }
   }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/RecipeMetricsTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/RecipeMetricsTests.kt
@@ -18,17 +18,22 @@
 
 package io.etcd.recipes.lock
 
+import io.etcd.recipes.cache.PathChildrenCache
 import io.etcd.recipes.common.EtcdMetrics
 import io.etcd.recipes.common.ResilienceConfig
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.putValue
 import io.etcd.recipes.common.urls
 import io.etcd.recipes.election.LeaderSelector
+import io.etcd.recipes.queue.DistributedQueue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * End-to-end proof that the recipes actually drive the [EtcdMetrics] seams: a mutex,
@@ -42,6 +47,8 @@ class RecipeMetricsTests : StringSpec() {
     val lockWaits = CopyOnWriteArrayList<Boolean>()
     val lockHolds = AtomicInteger(0)
     val leadership = CopyOnWriteArrayList<Boolean>()
+    val queueOps = CopyOnWriteArrayList<String>()
+    val cacheSyncs = CopyOnWriteArrayList<Int>()
 
     override fun recordLockWait(
       path: String,
@@ -63,6 +70,22 @@ class RecipeMetricsTests : StringSpec() {
       becameLeader: Boolean,
     ) {
       leadership += becameLeader
+    }
+
+    override fun recordQueue(
+      op: String,
+      path: String,
+      duration: Duration,
+    ) {
+      queueOps += op
+    }
+
+    override fun recordCacheSync(
+      path: String,
+      duration: Duration,
+      size: Int,
+    ) {
+      cacheSyncs += size
     }
   }
 
@@ -109,6 +132,35 @@ class RecipeMetricsTests : StringSpec() {
           selector.waitOnLeadershipComplete()
         }
         metrics.leadership shouldBe listOf(true, false)
+      }
+    }
+
+    "a queue dequeue records a dequeue op" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val metrics = RecordingMetrics()
+        DistributedQueue(client, "$base/queue", resilience = ResilienceConfig.DEFAULT.withMetrics(metrics))
+          .use { queue ->
+            queue.enqueue("hello")
+            queue.dequeue()
+          }
+        metrics.queueOps shouldBe listOf("dequeue")
+      }
+    }
+
+    "a path-children cache records an initial sync with the entry count" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val cachePath = "$base/cache"
+        client.putValue("$cachePath/a", "1")
+        client.putValue("$cachePath/b", "2")
+        val metrics = RecordingMetrics()
+        PathChildrenCache(client, cachePath, resilience = ResilienceConfig.DEFAULT.withMetrics(metrics))
+          .use { cache ->
+            cache.start(buildInitial = true)
+            pollUntil(10.seconds) { metrics.cacheSyncs.isNotEmpty() } shouldBe true
+          }
+        metrics.cacheSyncs.first() shouldBe 2
       }
     }
   }


### PR DESCRIPTION
## Summary

**Phase 2d of the observability layer** (product idea #7) — rounds out the recipe-level metric
seams for the data-flow recipes. Builds on the `EtcdMetrics` SPI (#70), the Micrometer binding
(#71), and the lock/election seams (#72).

## What's added

- **SPI** (`EtcdMetrics`): `recordQueue(op, path, duration)` and
  `recordCacheSync(path, duration, size)` — each with an empty default body (backward-compatible).
- **Queues** — `AbstractQueue` records **dequeue latency** (call → item in hand) at both success
  returns, covering `DistributedQueue`, `DistributedPriorityQueue`, and `DistributedWorkQueue`.
  (Enqueue is a single `putValue` already captured by the RPC funnel metric, so it isn't
  double-counted here.)
- **Caches** — `PathChildrenCache` and `ServiceCache` record each snapshot **(re)sync** — both
  the initial load and the compaction resync — with the resulting entry count.
- **Micrometer** — `MicrometerEtcdMetrics` maps these to an `etcd.queue` timer (tagged `op`), an
  `etcd.cache.sync` timer, and an `etcd.cache.size` distribution summary.

## Verification

- Micrometer unit test for the new meters, plus real-etcd integration tests (extending
  `RecipeMetricsTests`) that dequeue from a queue and build a cache and assert the recorded events.
- Queue/cache regression green; the frozen source assertions (`dequeue()` appears once,
  `while (true)`, the `PathChildrenCache` start/close ordering) are intact.
- Ran the exact CI command locally (`check koverXmlReport -PuseTestcontainers`): green. `lintKotlin`
  + `detekt` clean.

Remaining observability work: live-state **gauges** (queue depth, cache size, available permits,
current leader — poll-based, so a small `MeterBinder`-style bind API rather than the push SPI),
then a **structured-logging** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP
