### PR TITLE
Add live-state Micrometer gauges for the recipes (observability phase 2e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,16 @@ non-blocking consumption on the existing queues.
   RPC latency / attempts / outcome (`recordRpc`), resilient-watcher recovery transitions
   (`incrementWatchRecovery`), and self-healing-lease events (`incrementKeepAlive`).
 
+### Added (observability: live-state gauges)
+
+- Micrometer gauges bound to a specific recipe instance (via the new
+  `etcd-recipes-micrometer` binders): `MeterRegistry.bindQueueDepth`, `bindCacheSize` /
+  `bindServiceCacheSize`, `bindAvailablePermits`, and `bindLeadership` register
+  `etcd.queue.depth`, `etcd.cache.entries`, `etcd.semaphore.available`, and
+  `etcd.election.leader`. Cache size and leadership are in-memory reads; queue depth and
+  available permits poll a range-count RPC on **each scrape** (documented on the binders).
+  Adds a public `AbstractQueue.size` accessor for the queue-depth gauge.
+
 ### Added (observability: queue + cache metrics)
 
 - More recipe metric seams via the `EtcdMetrics` SPI: the queues record dequeue latency

--- a/etcd-recipes-micrometer/src/main/kotlin/io/etcd/recipes/micrometer/EtcdGauges.kt
+++ b/etcd-recipes-micrometer/src/main/kotlin/io/etcd/recipes/micrometer/EtcdGauges.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.micrometer
+
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.discovery.ServiceCache
+import io.etcd.recipes.election.LeaderLatch
+import io.etcd.recipes.lock.DistributedSemaphore
+import io.etcd.recipes.queue.AbstractQueue
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Tags
+
+/*
+ * Live-state gauges. Unlike the push [io.etcd.recipes.common.EtcdMetrics] SPI, a gauge polls its
+ * source on every metrics scrape — so bind one to a specific recipe instance you already hold.
+ * Micrometer keeps only a weak reference to the recipe, so a bound gauge does not keep it alive.
+ * Binding several instances of the same gauge to one registry needs distinguishing [tags].
+ */
+
+/**
+ * A gauge of [queue]'s current item count. NOTE: [AbstractQueue.size] issues a range-count RPC,
+ * so this gauge polls etcd on **every scrape** — mind the load on a hot queue / frequent scrape.
+ */
+fun MeterRegistry.bindQueueDepth(
+  queue: AbstractQueue,
+  tags: Tags = Tags.empty(),
+): Gauge = Gauge.builder("etcd.queue.depth", queue) { it.size.toDouble() }.tags(tags).register(this)
+
+/** A gauge of [cache]'s live entry count (an in-memory read; no RPC). */
+fun MeterRegistry.bindCacheSize(
+  cache: PathChildrenCache,
+  tags: Tags = Tags.empty(),
+): Gauge = Gauge.builder("etcd.cache.entries", cache) { it.currentData.size.toDouble() }.tags(tags).register(this)
+
+/** A gauge of [cache]'s live instance count (an in-memory read; no RPC). */
+fun MeterRegistry.bindServiceCacheSize(
+  cache: ServiceCache,
+  tags: Tags = Tags.empty(),
+): Gauge = Gauge.builder("etcd.cache.entries", cache) { it.instances.size.toDouble() }.tags(tags).register(this)
+
+/**
+ * A gauge of [semaphore]'s available permits. NOTE: [DistributedSemaphore.availablePermits] issues
+ * a range-count RPC, so this gauge polls etcd on **every scrape**.
+ */
+fun MeterRegistry.bindAvailablePermits(
+  semaphore: DistributedSemaphore,
+  tags: Tags = Tags.empty(),
+): Gauge =
+  Gauge.builder("etcd.semaphore.available", semaphore) { it.availablePermits().toDouble() }.tags(tags).register(this)
+
+/** A gauge that is 1.0 while [latch] holds leadership and 0.0 otherwise (an in-memory read; no RPC). */
+fun MeterRegistry.bindLeadership(
+  latch: LeaderLatch,
+  tags: Tags = Tags.empty(),
+): Gauge = Gauge.builder("etcd.election.leader", latch) { if (it.hasLeadership) 1.0 else 0.0 }.tags(tags).register(this)

--- a/etcd-recipes-micrometer/src/test/kotlin/io/etcd/recipes/micrometer/MicrometerGaugesTests.kt
+++ b/etcd-recipes-micrometer/src/test/kotlin/io/etcd/recipes/micrometer/MicrometerGaugesTests.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.micrometer
+
+import io.etcd.recipes.cache.PathChildrenCache
+import io.etcd.recipes.discovery.ServiceCache
+import io.etcd.recipes.election.LeaderLatch
+import io.etcd.recipes.lock.DistributedSemaphore
+import io.etcd.recipes.queue.AbstractQueue
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+
+/**
+ * The live-state gauge binders. Each recipe is mocked so its accessor returns a fixed value,
+ * and the registered gauge is asserted to report it — the gauge supplier polls the accessor on
+ * each read, so the binding is what's under test, not etcd.
+ */
+class MicrometerGaugesTests : StringSpec() {
+  init {
+    "bindQueueDepth reports the queue size" {
+      val registry = SimpleMeterRegistry()
+      registry.bindQueueDepth(mockk<AbstractQueue> { every { size } returns 5 })
+      registry.find("etcd.queue.depth").gauge().shouldNotBeNull().value() shouldBe 5.0
+    }
+
+    "bindCacheSize reports the path-children-cache entry count" {
+      val registry = SimpleMeterRegistry()
+      registry.bindCacheSize(
+        mockk<PathChildrenCache> {
+        every { currentData } returns listOf(mockk(), mockk(), mockk())
+      },
+      )
+      registry.find("etcd.cache.entries").gauge().shouldNotBeNull().value() shouldBe 3.0
+    }
+
+    "bindServiceCacheSize reports the service-cache instance count" {
+      val registry = SimpleMeterRegistry()
+      registry.bindServiceCacheSize(mockk<ServiceCache> { every { instances } returns listOf(mockk(), mockk()) })
+      registry.find("etcd.cache.entries").gauge().shouldNotBeNull().value() shouldBe 2.0
+    }
+
+    "bindAvailablePermits reports the available permit count" {
+      val registry = SimpleMeterRegistry()
+      registry.bindAvailablePermits(mockk<DistributedSemaphore> { every { availablePermits() } returns 4 })
+      registry.find("etcd.semaphore.available").gauge().shouldNotBeNull().value() shouldBe 4.0
+    }
+
+    "bindLeadership reports 1 while the latch holds leadership" {
+      val registry = SimpleMeterRegistry()
+      registry.bindLeadership(mockk<LeaderLatch> { every { hasLeadership } returns true })
+      registry.find("etcd.election.leader").gauge().shouldNotBeNull().value() shouldBe 1.0
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -32,6 +32,7 @@ import io.etcd.recipes.common.WatchRecoveryEvent
 import io.etcd.recipes.common.WatchRecoveryListener
 import io.etcd.recipes.common.deleteOp
 import io.etcd.recipes.common.equalTo
+import io.etcd.recipes.common.getChildCount
 import io.etcd.recipes.common.getFirstChild
 import io.etcd.recipes.common.transaction
 import io.etcd.recipes.common.watchOption
@@ -80,6 +81,12 @@ abstract class AbstractQueue(
     timeout: Long,
     timeUnit: TimeUnit,
   ): ByteSequence? = poll(timeUnitToDuration(timeout, timeUnit))
+
+  /**
+   * Current number of items in the queue. etcd cannot push a count, so this issues a
+   * range-count RPC on each call — a metrics gauge bound to it polls etcd on every scrape.
+   */
+  val size: Int get() = client.getChildCount(queuePath, resilience.rpc).toInt()
 
   // The single consumption loop: a null [deadline] never expires (the unbounded
   // take), otherwise the wait is bounded and an expired deadline yields null.


### PR DESCRIPTION
## Summary

**Phase 2e of the observability layer** (product idea #7) — adds point-in-time gauges,
rounding out the metrics. Unlike the push `EtcdMetrics` SPI, a gauge polls its source on every
metrics scrape, so these are Micrometer-side binders attached to a specific recipe instance you
already hold. Micrometer keeps only a **weak** reference, so a bound gauge does not keep the
recipe alive.

## What's added (in `etcd-recipes-micrometer`)

| Binder | Meter | Cost |
|---|---|---|
| `MeterRegistry.bindQueueDepth(queue)` | `etcd.queue.depth` | **range-count RPC per scrape** |
| `MeterRegistry.bindCacheSize(cache)` | `etcd.cache.entries` | in-memory |
| `MeterRegistry.bindServiceCacheSize(cache)` | `etcd.cache.entries` | in-memory |
| `MeterRegistry.bindAvailablePermits(semaphore)` | `etcd.semaphore.available` | **range-count RPC per scrape** |
| `MeterRegistry.bindLeadership(latch)` | `etcd.election.leader` | in-memory |

The RPC-per-scrape cost of the queue-depth and available-permits gauges is called out in each
binder's KDoc. Binding several instances of the same gauge to one registry needs distinguishing
`tags` (a param on every binder).

Also adds a public `AbstractQueue.size` accessor (a live range-count) to back the queue-depth
gauge.

## Verification

- `MicrometerGaugesTests`: each recipe is mocked so its accessor returns a fixed value, and the
  registered gauge is asserted to report it (RED-first).
- Ran the exact CI command locally (`check koverXmlReport -PuseTestcontainers`): green. `lintKotlin`
  + `detekt` clean; the queue's frozen source assertions intact.

Structured logging (MDC) is the last remaining observability piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP
