### PR TITLE
Carry recipe identity in the SLF4J MDC across recipe background threads (observability phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ non-blocking consumption on the existing queues.
   RPC latency / attempts / outcome (`recordRpc`), resilient-watcher recovery transitions
   (`incrementWatchRecovery`), and self-healing-lease events (`incrementKeepAlive`).
 
+### Added (observability: structured logging)
+
+- Recipe background-thread logging now carries an `etcd.recipe` MDC key (the recipe's identity,
+  e.g. `DistributedMutex[/lock/x]`), so logs emitted on healer / watch-dispatcher /
+  election-worker threads can be correlated to the recipe that produced them. Applied across
+  the recipes' async runnables and their lease / lock-loss / watch-recovery handlers via a new
+  protected `EtcdConnector.withRecipeLoggingContext { }`; `EtcdConnector.RECIPE_MDC_KEY` exposes
+  the key name.
+
 ### Added (observability: live-state gauges)
 
 - Micrometer gauges bound to a specific recipe instance (via the new

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -237,23 +237,25 @@ constructor(
     watchFailure: AtomicReference<Throwable?>,
   ): WatchRecoveryListener =
     WatchRecoveryListener { event ->
-      reportRecoveryEvent(event)
-      when (event) {
-        is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
-          if (!isBarrierSet() && (barrierPresentAtStart || !waitOnMissingBarriers))
+      withRecipeLoggingContext {
+        reportRecoveryEvent(event)
+        when (event) {
+          is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+            if (!isBarrierSet() && (barrierPresentAtStart || !waitOnMissingBarriers))
+              waitLatch.countDown()
+          }
+
+          is WatchRecoveryEvent.Failed -> {
+            val cause = event.cause
+              ?: EtcdRecipeRuntimeException("Watch on $barrierPath abandoned while waiting on barrier")
+            watchFailure.set(cause)
+            recordException(cause)
             waitLatch.countDown()
-        }
+          }
 
-        is WatchRecoveryEvent.Failed -> {
-          val cause = event.cause
-            ?: EtcdRecipeRuntimeException("Watch on $barrierPath abandoned while waiting on barrier")
-          watchFailure.set(cause)
-          recordException(cause)
-          waitLatch.countDown()
-        }
-
-        is WatchRecoveryEvent.Suspended -> {
-          // jetcd (transient) or the recovery loop (fatal) is already on it
+          is WatchRecoveryEvent.Suspended -> {
+            // jetcd (transient) or the recovery loop (fatal) is already on it
+          }
         }
       }
     }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCount.kt
@@ -257,22 +257,24 @@ constructor(
             // the failure recorded so the caller errors out instead of parking.
             val recoveryListener =
               WatchRecoveryListener { event ->
-                reportRecoveryEvent(event)
-                when (event) {
-                  is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
-                    checkWaiterCount()
-                  }
+                withRecipeLoggingContext {
+                  reportRecoveryEvent(event)
+                  when (event) {
+                    is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+                      checkWaiterCount()
+                    }
 
-                  is WatchRecoveryEvent.Failed -> {
-                    val cause = event.cause
-                      ?: EtcdRecipeRuntimeException("Watch on $barrierPath abandoned while waiting on barrier")
-                    watchFailure.set(cause)
-                    recordException(cause)
-                    closeKeepAlive()
-                  }
+                    is WatchRecoveryEvent.Failed -> {
+                      val cause = event.cause
+                        ?: EtcdRecipeRuntimeException("Watch on $barrierPath abandoned while waiting on barrier")
+                      watchFailure.set(cause)
+                      recordException(cause)
+                      closeKeepAlive()
+                    }
 
-                  is WatchRecoveryEvent.Suspended -> {
-                    // jetcd (transient) or the recovery loop (fatal) is already on it
+                    is WatchRecoveryEvent.Suspended -> {
+                      // jetcd (transient) or the recovery loop (fatal) is already on it
+                    }
                   }
                 }
               }
@@ -332,20 +334,22 @@ constructor(
   // Record lease trouble on the exceptions list, drive connection state, and log
   // healing outcomes.
   private fun onWaiterLeaseEvent(event: LeaseEvent) {
-    reportLeaseEvent(event)
-    when (event) {
-      is LeaseEvent.Suspended -> recordException(event.cause)
+    withRecipeLoggingContext {
+      reportLeaseEvent(event)
+      when (event) {
+        is LeaseEvent.Suspended -> recordException(event.cause)
 
-      is LeaseEvent.Expired -> recordException(
-        event.cause ?: EtcdRecipeRuntimeException("Waiter lease for $barrierPath expired; healing"),
-      )
+        is LeaseEvent.Expired -> recordException(
+          event.cause ?: EtcdRecipeRuntimeException("Waiter lease for $barrierPath expired; healing"),
+        )
 
-      is LeaseEvent.Failed -> recordException(
-        event.cause ?: EtcdRecipeRuntimeException("Waiter lease healing for $barrierPath abandoned"),
-      )
+        is LeaseEvent.Failed -> recordException(
+          event.cause ?: EtcdRecipeRuntimeException("Waiter lease healing for $barrierPath abandoned"),
+        )
 
-      is LeaseEvent.Restored -> logger.info {
-        "Waiter lease for $barrierPath healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+        is LeaseEvent.Restored -> logger.info {
+          "Waiter lease for $barrierPath healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+        }
       }
     }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/PathChildrenCache.kt
@@ -127,28 +127,30 @@ class PathChildrenCache
 
     if (mode == StartMode.BUILD_INITIAL_CACHE || mode == StartMode.POST_INITIALIZED_EVENT) {
       executor.execute {
-        try {
-          // Snapshot then watch with the snapshot's revision as the watch
-          // anchor: the watcher receives every event that occurred after the
-          // snapshot revision, with no overlap and no gap. Without anchoring
-          // a PUT could land between watch-registration and snapshot-load,
-          // and the snapshot would silently overwrite the newer value.
-          loadDataAndStartWatcher()
-        } finally {
-          if (mode == StartMode.POST_INITIALIZED_EVENT)
-            listeners.forEach { listener ->
-              try {
-                val cacheEvent =
-                  PathChildrenCacheEvent("", PathChildrenCacheEvent.Type.INITIALIZED, null).apply {
-                    initialDataVal = currentData
-                  }
-                listener.childEvent(cacheEvent)
-              } catch (e: Throwable) {
-                logger.error(e) { "Exception in cacheChanged()" }
-                recordException(e)
+        withRecipeLoggingContext {
+          try {
+            // Snapshot then watch with the snapshot's revision as the watch
+            // anchor: the watcher receives every event that occurred after the
+            // snapshot revision, with no overlap and no gap. Without anchoring
+            // a PUT could land between watch-registration and snapshot-load,
+            // and the snapshot would silently overwrite the newer value.
+            loadDataAndStartWatcher()
+          } finally {
+            if (mode == StartMode.POST_INITIALIZED_EVENT)
+              listeners.forEach { listener ->
+                try {
+                  val cacheEvent =
+                    PathChildrenCacheEvent("", PathChildrenCacheEvent.Type.INITIALIZED, null).apply {
+                      initialDataVal = currentData
+                    }
+                  listener.childEvent(cacheEvent)
+                } catch (e: Throwable) {
+                  logger.error(e) { "Exception in cacheChanged()" }
+                  recordException(e)
+                }
               }
-            }
-          startThreadComplete.set(true)
+            startThreadComplete.set(true)
+          }
         }
       }
     } else {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdConnector.kt
@@ -22,6 +22,7 @@ import com.pambrose.common.concurrent.BooleanMonitor
 import com.pambrose.common.util.randomId
 import io.etcd.jetcd.Client
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.slf4j.MDC
 import java.io.Closeable
 import java.util.Collections.synchronizedList
 import java.util.concurrent.CopyOnWriteArrayList
@@ -79,6 +80,21 @@ open class EtcdConnector(
 
   /** Records [throwable] under this connector's [exceptionContext]. */
   protected fun recordException(throwable: Throwable) = recordException(exceptionContext, throwable)
+
+  /**
+   * Runs [body] with this recipe's identity ([exceptionContext]) in the SLF4J MDC under
+   * [RECIPE_MDC_KEY], restoring any prior value afterward. Recipes wrap their background-thread
+   * runnables with this so logs emitted far from the calling code still carry recipe context.
+   */
+  protected inline fun <T> withRecipeLoggingContext(body: () -> T): T {
+    val prior = MDC.get(RECIPE_MDC_KEY)
+    MDC.put(RECIPE_MDC_KEY, exceptionContext)
+    return try {
+      body()
+    } finally {
+      if (prior == null) MDC.remove(RECIPE_MDC_KEY) else MDC.put(RECIPE_MDC_KEY, prior)
+    }
+  }
 
   /**
    * The single sink for background failures: records [throwable] in [exceptions] and pushes
@@ -191,6 +207,9 @@ open class EtcdConnector(
     internal const val TOKEN_LENGTH = 7
     internal const val DEFAULT_TTL_SECS = 2L
     private const val PING_PROBE_KEY = "health-check-probe"
+
+    /** SLF4J MDC key under which [withRecipeLoggingContext] publishes the recipe's identity. */
+    const val RECIPE_MDC_KEY = "etcd.recipe"
 
     internal fun defaultClientId(prefix: String) = "$prefix:${randomId(TOKEN_LENGTH)}"
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceRegistry.kt
@@ -152,36 +152,38 @@ constructor(
     instancePath: String,
     event: LeaseEvent,
   ) {
-    reportLeaseEvent(event)
-    when (event) {
-      is LeaseEvent.Suspended -> {
-        recordException(event.cause)
-      }
+    withRecipeLoggingContext {
+      reportLeaseEvent(event)
+      when (event) {
+        is LeaseEvent.Suspended -> {
+          recordException(event.cause)
+        }
 
-      is LeaseEvent.Expired -> {
-        event.cause?.let { recordException(it) }
-        ?: run { recordException(EtcdRecipeRuntimeException("Lease for $instancePath expired; healing")) }
-      }
+        is LeaseEvent.Expired -> {
+          event.cause?.let { recordException(it) }
+          ?: run { recordException(EtcdRecipeRuntimeException("Lease for $instancePath expired; healing")) }
+        }
 
-      is LeaseEvent.Failed -> {
-        recordException(
-          event.cause
-            ?: EtcdRecipeRuntimeException("Lease healing for $instancePath abandoned; instance is unregistered"),
-        )
-      }
+        is LeaseEvent.Failed -> {
+          recordException(
+            event.cause
+              ?: EtcdRecipeRuntimeException("Lease healing for $instancePath abandoned; instance is unregistered"),
+          )
+        }
 
-      is LeaseEvent.Restored -> {
-        logger.info {
-        "Lease for $instancePath healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+        is LeaseEvent.Restored -> {
+          logger.info {
+          "Lease for $instancePath healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+        }
+        }
       }
-      }
-    }
-    leaseListeners.forEach { listener ->
-      try {
-        listener.onLeaseEvent(event)
-      } catch (e: Throwable) {
-        logger.error(e) { "Exception in lease listener" }
-        recordException(e)
+      leaseListeners.forEach { listener ->
+        try {
+          listener.onLeaseEvent(event)
+        } catch (e: Throwable) {
+          logger.error(e) { "Exception in lease listener" }
+          recordException(e)
+        }
       }
     }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderLatch.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderLatch.kt
@@ -114,7 +114,9 @@ class LeaderLatch
       if (!startCalled.compareAndSet(false, true))
         throw EtcdRecipeRuntimeException("start() already called")
       worker =
-        thread(start = true, isDaemon = true, name = "leader-latch-$clientId") { runTermLoop() }
+        thread(start = true, isDaemon = true, name = "leader-latch-$clientId") {
+          withRecipeLoggingContext { runTermLoop() }
+        }
       // Block until the first candidacy is registered (or the worker exited early).
       firstTermStarted.waitUntilTrue()
       return this
@@ -207,12 +209,14 @@ class LeaderLatch
       val snapshot = listeners.toList()
       try {
         notifyExecutor.execute {
-          snapshot.forEach { listener ->
-            try {
-              listener.call()
-            } catch (e: Throwable) {
-              logger.error(e) { "Exception in LeaderLatch listener" }
-              recordException(e)
+          withRecipeLoggingContext {
+            snapshot.forEach { listener ->
+              try {
+                listener.call()
+              } catch (e: Throwable) {
+                logger.error(e) { "Exception in LeaderLatch listener" }
+                recordException(e)
+              }
             }
           }
         }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderSelector.kt
@@ -206,95 +206,105 @@ constructor(
     }
 
     executor.execute {
-      try {
-        val watchStarted = BooleanMonitor(false)
-        val watchComplete = BooleanMonitor(false)
-        val advertiseComplete = BooleanMonitor(false)
+      withRecipeLoggingContext {
+        try {
+          val watchStarted = BooleanMonitor(false)
+          val watchComplete = BooleanMonitor(false)
+          val advertiseComplete = BooleanMonitor(false)
 
-        executor.execute {
-          try {
-            val watchOption = watchOption { withNoPut(true) }
+          executor.execute {
+            withRecipeLoggingContext {
+              try {
+                val watchOption = watchOption { withNoPut(true) }
 
-            // The leader-key DELETE is this node's only re-election trigger. If it
-            // is lost while the watch stream is fatally dead (compaction resync, or
-            // a death before any event), the node would never run for leader again —
-            // so after each recovery, re-probe the leader key and run if it is gone.
-            // attemptToBecomeLeader CAS-guards against a concurrent winner.
-            val recoveryListener =
-              WatchRecoveryListener { event ->
-                reportRecoveryEvent(event)
-                when (event) {
-                  is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
-                    if (client.isKeyNotPresent(leaderPath, resilience.rpc))
-                      attemptToBecomeLeader(client)
+                // The leader-key DELETE is this node's only re-election trigger. If it
+                // is lost while the watch stream is fatally dead (compaction resync, or
+                // a death before any event), the node would never run for leader again —
+                // so after each recovery, re-probe the leader key and run if it is gone.
+                // attemptToBecomeLeader CAS-guards against a concurrent winner.
+                val recoveryListener =
+                  WatchRecoveryListener { event ->
+                    withRecipeLoggingContext {
+                      reportRecoveryEvent(event)
+                      when (event) {
+                        is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+                          if (client.isKeyNotPresent(leaderPath, resilience.rpc))
+                            attemptToBecomeLeader(client)
+                        }
+
+                        is WatchRecoveryEvent.Failed -> {
+                          val cause = event.cause
+                            ?: EtcdRecipeRuntimeException(
+                              "Watch on $leaderPath abandoned; no further re-election attempts",
+                            )
+                          logger.error(cause) { "Leader watch on $leaderPath abandoned" }
+                          recordException(cause)
+                        }
+
+                        is WatchRecoveryEvent.Suspended -> {
+                          // jetcd (transient) or the recovery loop (fatal) is already on it
+                        }
+                      }
+                    }
                   }
 
-                  is WatchRecoveryEvent.Failed -> {
-                    val cause = event.cause
-                      ?: EtcdRecipeRuntimeException("Watch on $leaderPath abandoned; no further re-election attempts")
-                    logger.error(cause) { "Leader watch on $leaderPath abandoned" }
-                    recordException(cause)
-                  }
-
-                  is WatchRecoveryEvent.Suspended -> {
-                    // jetcd (transient) or the recovery loop (fatal) is already on it
-                  }
+                client.withWatcher(
+                  leaderPath,
+                  watchOption,
+                  resilience.watch,
+                  recoveryListener,
+                  resyncWith = null,
+                  { watchResponse ->
+                    for (event in watchResponse.events) {
+                      if (event.eventType == DELETE) {
+                        // Run for leader whenever leader key is deleted
+                        attemptToBecomeLeader(client)
+                      }
+                    }
+                  },
+                ) {
+                  watchStarted.set(true)
+                  terminateWatch.waitUntilTrue()
                 }
+              } catch (e: Throwable) {
+                logger.error(e) { "In withWatchClient()" }
+                recordException(e)
+              } finally {
+                watchComplete.set(true)
               }
-
-            client.withWatcher(
-              leaderPath,
-              watchOption,
-              resilience.watch,
-              recoveryListener,
-              resyncWith = null,
-              { watchResponse ->
-                for (event in watchResponse.events) {
-                  if (event.eventType == DELETE) {
-                    // Run for leader whenever leader key is deleted
-                    attemptToBecomeLeader(client)
-                  }
-                }
-              },
-            ) {
-              watchStarted.set(true)
-              terminateWatch.waitUntilTrue()
             }
-          } catch (e: Throwable) {
-            logger.error(e) { "In withWatchClient()" }
-            recordException(e)
-          } finally {
-            watchComplete.set(true)
           }
-        }
 
-        executor.execute {
-          try {
-            advertiseParticipation()
-          } catch (e: Throwable) {
-            logger.error(e) { "In advertiseParticipation()" }
-            recordException(e)
-          } finally {
-            advertiseComplete.set(true)
+          executor.execute {
+            withRecipeLoggingContext {
+              try {
+                advertiseParticipation()
+              } catch (e: Throwable) {
+                logger.error(e) { "In advertiseParticipation()" }
+                recordException(e)
+              } finally {
+                advertiseComplete.set(true)
+              }
+            }
           }
+
+          // Wait for the watcher to start
+          watchStarted.waitUntilTrue()
+
+          electionSetup.set(true)
+
+          // Clients should run for leader in case they are the first to run
+          attemptToBecomeLeader(client)
+
+          leadershipComplete.waitUntilTrue()
+          watchComplete.waitUntilTrue()
+          advertiseComplete.waitUntilTrue()
+        } catch (e: Throwable) {
+          logger.error(e) { "In start()" }
+          recordException(e)
+        } finally {
+          startThreadComplete.set(true)
         }
-
-        // Wait for the watcher to start
-        watchStarted.waitUntilTrue()
-
-        electionSetup.set(true)
-
-        // Clients should run for leader in case they are the first to run
-        attemptToBecomeLeader(client)
-
-        leadershipComplete.waitUntilTrue()
-        watchComplete.waitUntilTrue()
-        advertiseComplete.waitUntilTrue()
-      } catch (e: Throwable) {
-        logger.error(e) { "In start()" }
-        recordException(e)
-      } finally {
-        startThreadComplete.set(true)
       }
     }
 
@@ -407,20 +417,22 @@ constructor(
   }
 
   private fun onParticipationLeaseEvent(event: LeaseEvent) {
-    reportLeaseEvent(event)
-    when (event) {
-      is LeaseEvent.Suspended -> recordException(event.cause)
+    withRecipeLoggingContext {
+      reportLeaseEvent(event)
+      when (event) {
+        is LeaseEvent.Suspended -> recordException(event.cause)
 
-      is LeaseEvent.Expired -> recordException(
-        event.cause ?: EtcdRecipeRuntimeException("Participation lease for $clientId expired; healing"),
-      )
+        is LeaseEvent.Expired -> recordException(
+          event.cause ?: EtcdRecipeRuntimeException("Participation lease for $clientId expired; healing"),
+        )
 
-      is LeaseEvent.Failed -> recordException(
-        event.cause ?: EtcdRecipeRuntimeException("Participation lease healing for $clientId abandoned"),
-      )
+        is LeaseEvent.Failed -> recordException(
+          event.cause ?: EtcdRecipeRuntimeException("Participation lease healing for $clientId abandoned"),
+        )
 
-      is LeaseEvent.Restored -> logger.info {
-        "Participation lease for $clientId healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+        is LeaseEvent.Restored -> logger.info {
+          "Participation lease for $clientId healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+        }
       }
     }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TransientKeyValue.kt
@@ -101,35 +101,37 @@ constructor(
     checkCloseNotCalled()
 
     executor.execute {
-      var healer: SelfHealingKeepAlive? = null
-      try {
-        val leaseTtl = leaseTtlSecs.seconds
-        logger.debug { "$leaseTtl keep-alive started for $clientId $keyPath" }
-        // Self-healing: if the lease expires (partition longer than the TTL), the
-        // healer re-grants it and re-puts the key, instead of the key silently
-        // vanishing while this recipe still looks healthy.
-        healer = client.selfHealingKeepAlive(
-          leaseTtl,
-          resilience.lease,
-          leaseListener = { event -> onLeaseEvent(event) },
-        ) { lease ->
-          client.putValue(keyPath, keyValue, putOption { withLeaseId(lease.id) }, resilience.rpc)
-          true
+      withRecipeLoggingContext {
+        var healer: SelfHealingKeepAlive? = null
+        try {
+          val leaseTtl = leaseTtlSecs.seconds
+          logger.debug { "$leaseTtl keep-alive started for $clientId $keyPath" }
+          // Self-healing: if the lease expires (partition longer than the TTL), the
+          // healer re-grants it and re-puts the key, instead of the key silently
+          // vanishing while this recipe still looks healthy.
+          healer = client.selfHealingKeepAlive(
+            leaseTtl,
+            resilience.lease,
+            leaseListener = { event -> onLeaseEvent(event) },
+          ) { lease ->
+            client.putValue(keyPath, keyValue, putOption { withLeaseId(lease.id) }, resilience.rpc)
+            true
+          }
+          keepAliveStartedLatch.countDown()
+          keepAliveWaitLatch.await()
+          logger.debug { "$leaseTtl keep-alive terminated for $clientId $keyPath" }
+        } catch (e: Throwable) {
+          logger.error(e) { "In start()" }
+          recordException(e)
+        } finally {
+          runCatching { healer?.close() }
+          // Always release the start() caller, even on failure. The previous
+          // version only counted down inside the keepAlive callback, so if the
+          // initial put / lease grant threw, start() would block on
+          // keepAliveStartedLatch forever.
+          keepAliveStartedLatch.countDown()
+          startThreadComplete.set(true)
         }
-        keepAliveStartedLatch.countDown()
-        keepAliveWaitLatch.await()
-        logger.debug { "$leaseTtl keep-alive terminated for $clientId $keyPath" }
-      } catch (e: Throwable) {
-        logger.error(e) { "In start()" }
-        recordException(e)
-      } finally {
-        runCatching { healer?.close() }
-        // Always release the start() caller, even on failure. The previous
-        // version only counted down inside the keepAlive callback, so if the
-        // initial put / lease grant threw, start() would block on
-        // keepAliveStartedLatch forever.
-        keepAliveStartedLatch.countDown()
-        startThreadComplete.set(true)
       }
     }
 
@@ -166,34 +168,36 @@ constructor(
   // trouble), drive connection state, and forward to user listeners.
   @Suppress("TooGenericExceptionCaught")
   private fun onLeaseEvent(event: LeaseEvent) {
-    reportLeaseEvent(event)
-    when (event) {
-      is LeaseEvent.Suspended -> {
-        recordException(event.cause)
-      }
+    withRecipeLoggingContext {
+      reportLeaseEvent(event)
+      when (event) {
+        is LeaseEvent.Suspended -> {
+          recordException(event.cause)
+        }
 
-      is LeaseEvent.Expired -> {
-        event.cause?.let { recordException(it) }
-        ?: run { recordException(EtcdRecipeRuntimeException("Lease for $keyPath expired; healing")) }
-      }
+        is LeaseEvent.Expired -> {
+          event.cause?.let { recordException(it) }
+          ?: run { recordException(EtcdRecipeRuntimeException("Lease for $keyPath expired; healing")) }
+        }
 
-      is LeaseEvent.Failed -> {
-        recordException(
-          event.cause
-            ?: EtcdRecipeRuntimeException("Lease healing for $keyPath abandoned; key is gone"),
-        )
-      }
+        is LeaseEvent.Failed -> {
+          recordException(
+            event.cause
+              ?: EtcdRecipeRuntimeException("Lease healing for $keyPath abandoned; key is gone"),
+          )
+        }
 
-      is LeaseEvent.Restored -> {
-        logger.info { "Lease for $keyPath healed: ${event.oldLeaseId} -> ${event.newLeaseId}" }
+        is LeaseEvent.Restored -> {
+          logger.info { "Lease for $keyPath healed: ${event.oldLeaseId} -> ${event.newLeaseId}" }
+        }
       }
-    }
-    leaseListeners.forEach { listener ->
-      try {
-        listener.onLeaseEvent(event)
-      } catch (e: Throwable) {
-        logger.error(e) { "Exception in lease listener" }
-        recordException(e)
+      leaseListeners.forEach { listener ->
+        try {
+          listener.onLeaseEvent(event)
+        } catch (e: Throwable) {
+          logger.error(e) { "Exception in lease listener" }
+          recordException(e)
+        }
       }
     }
   }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedMutex.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedMutex.kt
@@ -284,21 +284,23 @@ class DistributedMutex
     thread: Thread,
     cause: Throwable?,
   ) {
-    val data = threadData.remove(thread) ?: return
-    dispossessed[thread] = data.holdCount
-    logger.warn(cause) { "Lock on $lockPath lost by $clientId (lease expired)" }
-    recordException(cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
-    reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
-    lockLostListeners.forEach { listener ->
-      try {
-        listener.onLockLost(cause)
-      } catch (e: Throwable) {
-        logger.error(e) { "Exception in lock-lost listener" }
-        recordException(e)
+    withRecipeLoggingContext {
+      val data = threadData.remove(thread) ?: return
+      dispossessed[thread] = data.holdCount
+      logger.warn(cause) { "Lock on $lockPath lost by $clientId (lease expired)" }
+      recordException(cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
+      reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
+      lockLostListeners.forEach { listener ->
+        try {
+          listener.onLockLost(cause)
+        } catch (e: Throwable) {
+          logger.error(e) { "Exception in lock-lost listener" }
+          recordException(e)
+        }
       }
+      if (interruptOnLockLoss) thread.interrupt()
+      data.acquisitionLease.closeWithoutRevoke() // lease already gone; no RPC on this thread
     }
-    if (interruptOnLockLoss) thread.interrupt()
-    data.acquisitionLease.closeWithoutRevoke() // lease already gone; no RPC on this thread
   }
 
   private fun releaseHold(data: LockData) {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedReadWriteLock.kt
@@ -378,21 +378,23 @@ class DistributedReadWriteLock
     thread: Thread,
     cause: Throwable?,
   ) {
-    val data = holdsFor(side).remove(thread) ?: return
-    dispossessedFor(side)[thread] = data.holdCount
-    logger.warn(cause) { "${side.entryPrefix} lock on $lockPath lost by $clientId (lease expired)" }
-    recordException(cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
-    reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
-    listenersFor(side).forEach { listener ->
-      try {
-        listener.onLockLost(cause)
-      } catch (e: Throwable) {
-        logger.error(e) { "Exception in lock-lost listener" }
-        recordException(e)
+    withRecipeLoggingContext {
+      val data = holdsFor(side).remove(thread) ?: return
+      dispossessedFor(side)[thread] = data.holdCount
+      logger.warn(cause) { "${side.entryPrefix} lock on $lockPath lost by $clientId (lease expired)" }
+      recordException(cause ?: EtcdRecipeRuntimeException("Lock lease for $lockPath expired; lock lost"))
+      reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
+      listenersFor(side).forEach { listener ->
+        try {
+          listener.onLockLost(cause)
+        } catch (e: Throwable) {
+          logger.error(e) { "Exception in lock-lost listener" }
+          recordException(e)
+        }
       }
+      if (interruptOnLockLoss) thread.interrupt()
+      data.lease.closeWithoutRevoke() // lease already gone; no RPC on this thread
     }
-    if (interruptOnLockLoss) thread.interrupt()
-    data.lease.closeWithoutRevoke() // lease already gone; no RPC on this thread
   }
 
   override fun doClose() {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
@@ -362,22 +362,24 @@ class DistributedSemaphore
     attempt: Attempt,
     cause: Throwable?,
   ) {
-    val data = attempt.holdData ?: return
-    if (!holds.remove(data)) return // already released, or close() took it
-    dispossessedCount.incrementAndGet()
-    logger.warn(cause) { "Permit on $semaphorePath lost by $clientId (lease expired)" }
-    recordException(cause ?: EtcdRecipeRuntimeException("Permit lease for $semaphorePath expired; permit lost"))
-    reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
-    lostListeners.forEach { listener ->
-      try {
-        listener.onPermitLost(cause)
-      } catch (e: Throwable) {
-        logger.error(e) { "Exception in permit-lost listener" }
-        recordException(e)
+    withRecipeLoggingContext {
+      val data = attempt.holdData ?: return
+      if (!holds.remove(data)) return // already released, or close() took it
+      dispossessedCount.incrementAndGet()
+      logger.warn(cause) { "Permit on $semaphorePath lost by $clientId (lease expired)" }
+      recordException(cause ?: EtcdRecipeRuntimeException("Permit lease for $semaphorePath expired; permit lost"))
+      reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
+      lostListeners.forEach { listener ->
+        try {
+          listener.onPermitLost(cause)
+        } catch (e: Throwable) {
+          logger.error(e) { "Exception in permit-lost listener" }
+          recordException(e)
+        }
       }
+      if (interruptOnPermitLoss) attempt.owner.interrupt()
+      data.lease.closeWithoutRevoke() // lease already gone; no RPC on this thread
     }
-    if (interruptOnPermitLoss) attempt.owner.interrupt()
-    data.lease.closeWithoutRevoke() // lease already gone; no RPC on this thread
   }
 
   override fun doClose() {

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -213,30 +213,32 @@ abstract class AbstractQueue(
     watchFailure: AtomicReference<Throwable?>,
   ): WatchRecoveryListener =
     WatchRecoveryListener { event ->
-      reportRecoveryEvent(event)
-      when (event) {
-        is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
-          val children = client.getFirstChild(queuePath, target, resilience.rpc).kvs
-          if (children.isNotEmpty()) {
+      withRecipeLoggingContext {
+        reportRecoveryEvent(event)
+        when (event) {
+          is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+            val children = client.getFirstChild(queuePath, target, resilience.rpc).kvs
+            if (children.isNotEmpty()) {
+              synchronized(watchLatch) {
+                keyFound.compareAndSet(null, children.first())
+                if (watchLatch.count > 0) watchLatch.countDown()
+              }
+            }
+          }
+
+          is WatchRecoveryEvent.Failed -> {
+            val cause = event.cause
+              ?: EtcdRecipeRuntimeException("Watch on $queuePath abandoned while waiting for an item")
+            watchFailure.set(cause)
+            recordException(cause)
             synchronized(watchLatch) {
-              keyFound.compareAndSet(null, children.first())
               if (watchLatch.count > 0) watchLatch.countDown()
             }
           }
-        }
 
-        is WatchRecoveryEvent.Failed -> {
-          val cause = event.cause
-            ?: EtcdRecipeRuntimeException("Watch on $queuePath abandoned while waiting for an item")
-          watchFailure.set(cause)
-          recordException(cause)
-          synchronized(watchLatch) {
-            if (watchLatch.count > 0) watchLatch.countDown()
+          is WatchRecoveryEvent.Suspended -> {
+            // jetcd (transient) or the recovery loop (fatal) is already on it
           }
-        }
-
-        is WatchRecoveryEvent.Suspended -> {
-          // jetcd (transient) or the recovery loop (fatal) is already on it
         }
       }
     }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
@@ -438,24 +438,26 @@ class DistributedWorkQueue
     val watchFailure = AtomicReference<Throwable?>()
     val recoveryListener =
       WatchRecoveryListener { event ->
-        reportRecoveryEvent(event)
-        when (event) {
-          is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
-            if (client.getFirstChild(itemsPath, SortTarget.KEY, resilience.rpc).kvs.isNotEmpty()) {
+        withRecipeLoggingContext {
+          reportRecoveryEvent(event)
+          when (event) {
+            is WatchRecoveryEvent.Resubscribed, is WatchRecoveryEvent.Resynced -> {
+              if (client.getFirstChild(itemsPath, SortTarget.KEY, resilience.rpc).kvs.isNotEmpty()) {
+                latch.countDown()
+              }
+            }
+
+            is WatchRecoveryEvent.Failed -> {
+              val cause = event.cause
+                ?: EtcdRecipeRuntimeException("Watch on $itemsPath abandoned while waiting for work")
+              watchFailure.set(cause)
+              recordException(cause)
               latch.countDown()
             }
-          }
 
-          is WatchRecoveryEvent.Failed -> {
-            val cause = event.cause
-              ?: EtcdRecipeRuntimeException("Watch on $itemsPath abandoned while waiting for work")
-            watchFailure.set(cause)
-            recordException(cause)
-            latch.countDown()
-          }
-
-          is WatchRecoveryEvent.Suspended -> {
-            // jetcd (transient) or the recovery loop (fatal) is already on it
+            is WatchRecoveryEvent.Suspended -> {
+              // jetcd (transient) or the recovery loop (fatal) is already on it
+            }
           }
         }
       }
@@ -494,28 +496,30 @@ class DistributedWorkQueue
 
   @Suppress("TooGenericExceptionCaught")
   private fun onLeaseEvent(event: LeaseEvent) {
-    reportLeaseEvent(event)
-    when (event) {
-      is LeaseEvent.Suspended -> recordException(event.cause)
+    withRecipeLoggingContext {
+      reportLeaseEvent(event)
+      when (event) {
+        is LeaseEvent.Suspended -> recordException(event.cause)
 
-      is LeaseEvent.Expired -> recordException(
-        event.cause ?: EtcdRecipeRuntimeException("Consumer lease expired; outstanding claims are reclaimable"),
-      )
+        is LeaseEvent.Expired -> recordException(
+          event.cause ?: EtcdRecipeRuntimeException("Consumer lease expired; outstanding claims are reclaimable"),
+        )
 
-      is LeaseEvent.Failed -> recordException(
-        event.cause ?: EtcdRecipeRuntimeException("Consumer lease healing abandoned; claims will not renew"),
-      )
+        is LeaseEvent.Failed -> recordException(
+          event.cause ?: EtcdRecipeRuntimeException("Consumer lease healing abandoned; claims will not renew"),
+        )
 
-      is LeaseEvent.Restored -> logger.info {
-        "Consumer lease healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+        is LeaseEvent.Restored -> logger.info {
+          "Consumer lease healed: ${event.oldLeaseId} -> ${event.newLeaseId}"
+        }
       }
-    }
-    leaseListeners.forEach { listener ->
-      try {
-        listener.onLeaseEvent(event)
-      } catch (e: Throwable) {
-        logger.error(e) { "Exception in lease listener" }
-        recordException(e)
+      leaseListeners.forEach { listener ->
+        try {
+          listener.onLeaseEvent(event)
+        } catch (e: Throwable) {
+          logger.error(e) { "Exception in lease listener" }
+          recordException(e)
+        }
       }
     }
   }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdConnectorObservabilityTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdConnectorObservabilityTests.kt
@@ -27,6 +27,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.slf4j.MDC
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -40,6 +41,8 @@ class EtcdConnectorObservabilityTests : StringSpec() {
   private class TestConnector(
     client: Client,
   ) : EtcdConnector(client) {
+    override val exceptionContext get() = "test-recipe"
+
     fun record(
       context: String,
       t: Throwable,
@@ -48,6 +51,8 @@ class EtcdConnectorObservabilityTests : StringSpec() {
     fun reportRecovery(event: WatchRecoveryEvent) = reportRecoveryEvent(event)
 
     fun reportLease(event: LeaseEvent) = reportLeaseEvent(event)
+
+    fun <T> wrap(body: () -> T): T = withRecipeLoggingContext(body)
   }
 
   /** A mock client whose probe GET either completes or fails, for [EtcdConnector.ping]. */
@@ -128,6 +133,14 @@ class EtcdConnectorObservabilityTests : StringSpec() {
 
     "ping returns false when the probe GET fails" {
       TestConnector(clientWithProbe(succeeds = false)).ping() shouldBe false
+    }
+
+    "withRecipeLoggingContext stamps the recipe MDC key inside the block and restores it after" {
+      val connector = TestConnector(mockk())
+      MDC.remove(EtcdConnector.RECIPE_MDC_KEY) // ensure a clean baseline
+      val inside = connector.wrap { MDC.get(EtcdConnector.RECIPE_MDC_KEY) }
+      inside shouldBe "test-recipe"
+      MDC.get(EtcdConnector.RECIPE_MDC_KEY) shouldBe null
     }
   }
 }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderLatchTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderLatchTests.kt
@@ -47,7 +47,12 @@ class LeaderLatchTests : StringSpec() {
         try {
           latch.await(20.seconds) shouldBe true
           latch.hasLeadership shouldBe true
-          LeaderSelector.getParticipants(client, "$path/lone").single { it.isLeader }.clientId shouldBe "solo"
+          // Participant advertisement is async, so poll rather than reading it point-in-time.
+          pollUntil(10.seconds) {
+            runCatching {
+              LeaderSelector.getParticipants(client, "$path/lone").single { it.isLeader }.clientId == "solo"
+            }.getOrDefault(false)
+          } shouldBe true
         } finally {
           latch.close()
         }


### PR DESCRIPTION
## Summary

**Phase 3 — the final piece of the observability layer** (product idea #7). Logs emitted on a
recipe's background threads (lease healer, watch dispatcher, election worker, notify executor)
had no structured link back to the recipe that produced them; this adds one.

## What's added

- **`protected inline fun EtcdConnector.withRecipeLoggingContext { }`** — stamps an `etcd.recipe`
  SLF4J MDC key (the recipe's identity, e.g. `DistributedMutex[/lock/x]`) for the duration of a
  block and restores any prior value. `inline` so wrapping a body that uses a non-local return
  (`return@execute` / `?: return`) is fine. `EtcdConnector.RECIPE_MDC_KEY` exposes the key name.
- Wrapped **20 async sites across 12 recipes** — the `executor.execute` / `thread` runnables and
  the lease / lock-loss / watch-recovery handlers — across caches, keyvalue, discovery, queues,
  barriers, locks, and election.
- A few sites can't carry recipe context by construction and were left as-is: the internal
  `WaiterSupport` object, `LeaderSelector`'s static/companion helpers, and the coroutine Flow
  bridges — none run with a recipe instance in scope.

## Verification

- Helper test asserts the MDC key is set inside the block and restored after.
- Design oracle green — the frozen source assertions (`PathChildrenCache` start/close ordering,
  `dequeue()` once, `while (true)`, lease markers) are intact after the wraps.
- Full `check koverXmlReport -PuseTestcontainers` gate green (398 tests). `lintKotlin` + `detekt`
  clean.

## Also folded in

A deflake of `LeaderLatchTests > a lone latch acquires leadership...` — a **pre-existing** race
unrelated to this change (it read the async-advertised participant list point-in-time right after
`await()`; now it polls). Verified 5/5 after the fix; it surfaced on this PR's gate run.

With this merged, idea #7 (observability: push callbacks, health, RPC/watch/lease/lock/election/
queue/cache metrics, gauges, and structured logging) is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP
