### PR TITLE
Add typed NodeCache<T> single-key cache and EtcdCodec foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ leases self-heal and leaders step down on lease loss (part 2), and blocking RPCs
 gain timeouts and retries (part 3). Plus reliable-queue groundwork: bounded and
 non-blocking consumption on the existing queues.
 
+### Added (cache: typed NodeCache + codec layer)
+
+- **`NodeCache<T>`** — a watch-backed cache of a **single** etcd key, the counterpart to
+  `PathChildrenCache` (which caches a prefix) for the "keep one config value hot, notify on
+  change" case. `start()` snapshots the key and anchors the watch at the snapshot revision + 1
+  (no establishment-race gap); `current` / `currentBytes` read the live value; a
+  `NodeCacheListener` is notified of CREATED / UPDATED / DELETED; compaction of the watched
+  revision re-syncs transparently. Plus a `withNodeCache { }` DSL and coroutine
+  `eventsAsFlow()` / `recoveryEventsAsFlow()`.
+- **`EtcdCodec<T>`** — a small pluggable-serialization SPI (`encode`/`decode`) with built-ins
+  `ByteSequenceCodec`, `StringCodec`, and `KotlinxJsonCodec` (reified `jsonCodec<T>()`).
+  `NodeCache<T>` decodes its payload through it; the other recipes gain typed variants in a
+  later pass.
+
 ### Added (observability: push errors + health)
 
 - **Push-based background-exception callback** on `EtcdConnector`: register a

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ what [Curator](https://curator.apache.org) provides for [ZooKeeper](https://zook
 | Package | Recipes |
 |---|---|
 | `io.etcd.recipes.barrier` | `DistributedBarrier`, `DistributedBarrierWithCount`, `DistributedDoubleBarrier` |
-| `io.etcd.recipes.cache` | `PathChildrenCache` (key-prefix cache with PUT/UPDATE/DELETE listeners) |
+| `io.etcd.recipes.cache` | `PathChildrenCache` (key-prefix cache), `NodeCache<T>` (typed single-key cache) |
 | `io.etcd.recipes.counter` | `DistributedAtomicLong` |
 | `io.etcd.recipes.discovery` | `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`, `ServiceProvider`, `ProviderStrategy` |
 | `io.etcd.recipes.election` | `LeaderSelector`, `LeaderLatch`, `LeaderObserver`, `LeaderSelectorListener`, `Participant` |
@@ -162,6 +162,7 @@ collector unregisters it, and collection never starts or closes the recipe:
 |---|---|
 | `Client` watches | `watchAsFlow(...)` / `watchEventsAsFlow(...)` |
 | `PathChildrenCache` child events | `eventsAsFlow()` / `recoveryEventsAsFlow()` |
+| `NodeCache` key changes | `eventsAsFlow()` / `recoveryEventsAsFlow()` |
 | `ServiceCache` changes | `eventsAsFlow()` / `recoveryEventsAsFlow()` |
 | Any recipe's connection state | `connectionStateAsFlow()` |
 | Lease events (`TransientKeyValue`, `DistributedWorkQueue`, `ServiceRegistry`) | `leaseEventsAsFlow()` |

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/cache/NodeCacheExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/cache/NodeCacheExample.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.cache
+
+import com.pambrose.common.util.sleep
+import io.etcd.recipes.cache.NodeCache
+import io.etcd.recipes.common.StringCodec
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteKey
+import io.etcd.recipes.common.putValue
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Keep a single config key hot with a [NodeCache]: `current` tracks the live value and a
+ * listener is notified of each CREATED / UPDATED / DELETED change. Uses [StringCodec];
+ * swap in `jsonCodec<T>()` for a typed payload.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val key = "/config/node-example/greeting"
+
+  connectToEtcd(urls) { client ->
+    client.putValue(key, "hello")
+
+    NodeCache(client, key, StringCodec).use { cache ->
+      cache.addListener { event -> logger.info { "Change: ${event.type} -> ${event.value}" } }
+      cache.start()
+      logger.info { "Initial value: ${cache.current}" }
+
+      client.putValue(key, "world")
+      sleep(500.milliseconds)
+      logger.info { "After update: ${cache.current}" }
+
+      client.deleteKey(key)
+      sleep(500.milliseconds)
+      logger.info { "After delete: ${cache.current}" }
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/NodeCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/NodeCache.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.cache
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.watch.WatchEvent
+import io.etcd.recipes.common.EtcdCodec
+import io.etcd.recipes.common.EtcdConnector
+import io.etcd.recipes.common.EtcdRecipeRuntimeException
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.WatchRecoveryListener
+import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.watchOption
+import io.etcd.recipes.common.watcher
+import io.github.oshai.kotlinlogging.KotlinLogging
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.TimeSource
+
+@JvmOverloads
+fun <T, R> withNodeCache(
+  client: Client,
+  key: String,
+  codec: EtcdCodec<T>,
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  receiver: NodeCache<T>.() -> R,
+): R = NodeCache(client, key, codec, resilience).use { it.receiver() }
+
+/**
+ * A watch-backed cache of a **single** etcd key, decoded through [codec]. The counterpart to
+ * [PathChildrenCache] (which caches a whole prefix) for the "keep one config value hot, tell me
+ * when it changes" case.
+ *
+ * [start] snapshots the key and anchors the watch at the snapshot revision + 1, so the stream has
+ * zero gap and zero overlap with the snapshot (the standard etcd bootstrap, and the same
+ * establishment-race fix applied elsewhere in this library). Thereafter [current] reflects the
+ * live value and registered [NodeCacheListener]s are notified of each change. Compaction of the
+ * watched revision re-syncs transparently.
+ */
+class NodeCache<T>
+  @JvmOverloads
+  constructor(
+    client: Client,
+    val key: String,
+    private val codec: EtcdCodec<T>,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : EtcdConnector(client, resilience) {
+    // Plain var guarded by @Synchronized start()/doClose() (mirrors ServiceCache's `watcher`).
+    private var watcher: Watch.Watcher? = null
+
+    @Volatile
+    private var latestBytes: ByteSequence? = null
+    private val listeners: MutableList<NodeCacheListener<T>> = CopyOnWriteArrayList()
+    private val recoveryListeners: MutableList<WatchRecoveryListener> = CopyOnWriteArrayList()
+
+    init {
+      require(key.isNotEmpty()) { "Node cache key cannot be empty" }
+    }
+
+    override val exceptionContext get() = "NodeCache[$key]"
+
+    /** Snapshots the key and starts the watch. One-shot; throws if called twice or after close. */
+    @Synchronized
+    @Suppress("TooGenericExceptionCaught")
+    fun start(): NodeCache<T> {
+      if (startCalled.load()) throw EtcdRecipeRuntimeException("start() already called")
+      checkCloseNotCalled()
+
+      val anchorRevision = reconcile()
+
+      // Single-key watch (no isPrefix), anchored just past the snapshot revision.
+      val watchOption = watchOption { withRevision(anchorRevision) }
+
+      watcher =
+        client.watcher(
+          key,
+          watchOption,
+          resilience.watch,
+          recoveryListener = { event -> onRecoveryEvent(event) },
+          resyncWith = { reconcile() },
+        ) { watchResponse ->
+          withRecipeLoggingContext {
+            watchResponse.events.forEach { event ->
+              when (event.eventType) {
+                WatchEvent.EventType.PUT -> {
+                  val created = latestBytes == null
+                  latestBytes = event.keyValue.value
+                  fire(if (created) NodeCacheEvent.Type.CREATED else NodeCacheEvent.Type.UPDATED, event.keyValue.value)
+                }
+
+                WatchEvent.EventType.DELETE -> {
+                  latestBytes = null
+                  fire(NodeCacheEvent.Type.DELETED, null)
+                }
+
+                WatchEvent.EventType.UNRECOGNIZED -> {
+                  logger.error { "Unrecognized error with $key watch" }
+                }
+
+                else -> {
+                  logger.error { "Unknown error with $key watch" }
+                }
+              }
+            }
+          }
+        }
+
+      startCalled.store(true)
+      startThreadComplete.set(true)
+      return this
+    }
+
+    /** The current decoded value, or null when the key is absent. Decodes on read (may throw on a malformed value). */
+    val current: T? get() = latestBytes?.let { codec.decode(it) }
+
+    /** The current raw value, or null when the key is absent. */
+    val currentBytes: ByteSequence? get() = latestBytes
+
+    fun addListener(listener: NodeCacheListener<T>) {
+      listeners += listener
+    }
+
+    fun removeListener(listener: NodeCacheListener<T>) {
+      listeners -= listener
+    }
+
+    fun clearListeners() = listeners.clear()
+
+    fun addRecoveryListener(listener: WatchRecoveryListener) {
+      recoveryListeners += listener
+    }
+
+    fun removeRecoveryListener(listener: WatchRecoveryListener) {
+      recoveryListeners -= listener
+    }
+
+    // Snapshot the key, capturing the revision so the watch can anchor at revision + 1. Reused as
+    // the compaction resync hook (deliberately not synchronized — runs on the watch dispatcher).
+    private fun reconcile(): Long {
+      val start = TimeSource.Monotonic.markNow()
+      val resp = client.getResponse(key, rpc = resilience.rpc)
+      latestBytes = resp.kvs.firstOrNull()?.value
+      resilience.metrics.recordCacheSync(key, start.elapsedNow(), if (latestBytes == null) 0 else 1)
+      return resp.header.revision + 1
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun fire(
+      type: NodeCacheEvent.Type,
+      bytes: ByteSequence?,
+    ) {
+      // A malformed payload is recorded and the event skipped, rather than killing the dispatcher.
+      val value = bytes?.let {
+        runCatching { codec.decode(it) }.getOrElse { e ->
+        recordException(e)
+        return
+      }
+      }
+      listeners.forEach { listener ->
+        try {
+          listener.nodeChanged(NodeCacheEvent(type, value))
+        } catch (e: Throwable) {
+          logger.error(e) { "Exception in nodeChanged()" }
+          recordException(e)
+        }
+      }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun onRecoveryEvent(event: WatchRecoveryEvent) {
+      withRecipeLoggingContext {
+        reportRecoveryEvent(event)
+        if (event is WatchRecoveryEvent.Failed) {
+          recordException(
+            event.cause ?: EtcdRecipeRuntimeException("Watch on $key abandoned; node cache is no longer updating"),
+          )
+        }
+        recoveryListeners.forEach { listener ->
+          try {
+            listener.onRecoveryEvent(event)
+          } catch (e: Throwable) {
+            logger.error(e) { "Exception in recovery listener" }
+            recordException(e)
+          }
+        }
+      }
+    }
+
+    @Synchronized
+    override fun doClose() {
+      checkStartCalled()
+      watcher?.close()
+      watcher = null
+      listeners.clear()
+    }
+
+    companion object {
+      private val logger = KotlinLogging.logger {}
+    }
+  }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/NodeCacheEvent.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/NodeCacheEvent.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.cache
+
+/**
+ * A change to the single key watched by a [NodeCache]: the decoded [value] on a [Type.CREATED] or
+ * [Type.UPDATED] event, or null on [Type.DELETED].
+ */
+data class NodeCacheEvent<T>(
+  val type: Type,
+  val value: T?,
+) {
+  enum class Type { CREATED, UPDATED, DELETED }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/NodeCacheListener.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/NodeCacheListener.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.cache
+
+/** Notified on each change ([NodeCacheEvent]) to a [NodeCache]'s watched key. */
+fun interface NodeCacheListener<T> {
+  fun nodeChanged(event: NodeCacheEvent<T>)
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdCodec.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/EtcdCodec.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.ByteSequence
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+
+/**
+ * Converts a typed value to and from the raw [ByteSequence] etcd stores. Recipes that traffic in
+ * a typed payload (starting with [io.etcd.recipes.cache.NodeCache]) take an [EtcdCodec] so callers
+ * choose their own wire format instead of hand-marshalling. Built-ins: [ByteSequenceCodec],
+ * [StringCodec], and [KotlinxJsonCodec] (via [jsonCodec]).
+ */
+interface EtcdCodec<T> {
+  fun encode(value: T): ByteSequence
+
+  fun decode(bytes: ByteSequence): T
+}
+
+/** The identity codec: the payload is already a [ByteSequence]. */
+object ByteSequenceCodec : EtcdCodec<ByteSequence> {
+  override fun encode(value: ByteSequence): ByteSequence = value
+
+  override fun decode(bytes: ByteSequence): ByteSequence = bytes
+}
+
+/** UTF-8 string payloads. */
+object StringCodec : EtcdCodec<String> {
+  override fun encode(value: String): ByteSequence = value.asByteSequence
+
+  override fun decode(bytes: ByteSequence): String = bytes.asString
+}
+
+/**
+ * `kotlinx-serialization` JSON payloads. Prefer the reified [jsonCodec] factory; construct this
+ * directly only when you already hold a [serializer] or a customized [Json].
+ */
+class KotlinxJsonCodec<T>(
+  private val serializer: KSerializer<T>,
+  private val json: Json = Json,
+) : EtcdCodec<T> {
+  override fun encode(value: T): ByteSequence = json.encodeToString(serializer, value).asByteSequence
+
+  override fun decode(bytes: ByteSequence): T = json.decodeFromString(serializer, bytes.asString)
+}
+
+/** A [KotlinxJsonCodec] for any `@Serializable` [T], resolving its serializer at the call site. */
+inline fun <reified T> jsonCodec(json: Json = Json): EtcdCodec<T> = KotlinxJsonCodec(serializer(), json)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/CacheFlows.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/CacheFlows.kt
@@ -16,6 +16,9 @@
 
 package io.etcd.recipes.coroutines
 
+import io.etcd.recipes.cache.NodeCache
+import io.etcd.recipes.cache.NodeCacheEvent
+import io.etcd.recipes.cache.NodeCacheListener
 import io.etcd.recipes.cache.PathChildrenCache
 import io.etcd.recipes.cache.PathChildrenCacheEvent
 import io.etcd.recipes.cache.PathChildrenCacheListener
@@ -48,6 +51,26 @@ fun PathChildrenCache.eventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<Path
 
 /** The cache's watch-recovery transitions as a [Flow]; see [eventsAsFlow] for lifecycle. */
 fun PathChildrenCache.recoveryEventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<WatchRecoveryEvent> =
+  callbackFlow {
+    val listener = WatchRecoveryListener { event -> trySendBlocking(event) }
+    addRecoveryListener(listener)
+    awaitClose { removeRecoveryListener(listener) }
+  }.buffer(capacity)
+
+/**
+ * The single-key cache's changes ([NodeCacheEvent], CREATED / UPDATED / DELETED) as a [Flow].
+ * Collection registers a listener and cancellation removes it; it never starts or closes the
+ * cache. The default unlimited [capacity] keeps a slow collector from stalling the watch dispatcher.
+ */
+fun <T> NodeCache<T>.eventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<NodeCacheEvent<T>> =
+  callbackFlow {
+    val listener = NodeCacheListener<T> { event -> trySendBlocking(event) }
+    addListener(listener)
+    awaitClose { removeListener(listener) }
+  }.buffer(capacity)
+
+/** The single-key cache's watch-recovery transitions as a [Flow]; see [eventsAsFlow] for lifecycle. */
+fun NodeCache<*>.recoveryEventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<WatchRecoveryEvent> =
   callbackFlow {
     val listener = WatchRecoveryListener { event -> trySendBlocking(event) }
     addRecoveryListener(listener)

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/NodeCacheResyncTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/NodeCacheResyncTests.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.cache
+
+import io.etcd.jetcd.ByteSequence
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.KV
+import io.etcd.jetcd.KeyValue
+import io.etcd.jetcd.Watch
+import io.etcd.jetcd.common.exception.EtcdExceptionFactory
+import io.etcd.jetcd.kv.GetResponse
+import io.etcd.jetcd.options.WatchOption
+import io.etcd.recipes.common.StringCodec
+import io.etcd.recipes.common.WatchRecoveryEvent
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.pollUntil
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Drives [NodeCache] through a compaction-killed watch with a mocked jetcd [Client] (in the
+ * style of [PathChildrenCacheResyncTests]): the cache must re-read the key from a fresh
+ * snapshot and re-anchor the replacement watch at the snapshot's revision, so `current`
+ * converges despite the lost history. No etcd required.
+ */
+class NodeCacheResyncTests : StringSpec() {
+  private class CacheMocks(
+    val key: String,
+  ) {
+    val listeners = CopyOnWriteArrayList<Watch.Listener>()
+    val options = CopyOnWriteArrayList<WatchOption>()
+    private val getCount = AtomicInteger(0)
+
+    private fun kv(value: String): KeyValue =
+      mockk {
+        every { this@mockk.value } returns value.asByteSequence
+      }
+
+    // GET #1 (initial snapshot): value "1" at revision 10. Every later GET (resync): "2" at 20.
+    private fun getResponse(): GetResponse {
+      val first = getCount.incrementAndGet() == 1
+      return mockk {
+        every { kvs } returns listOf(kv(if (first) "1" else "2"))
+        every { isMore } returns false
+        every { header } returns mockk { every { revision } returns if (first) 10L else 20L }
+      }
+    }
+
+    val client: Client =
+      mockk {
+        every { kvClient } returns
+          mockk<KV> {
+            every { get(any<ByteSequence>(), any()) } answers {
+              CompletableFuture.completedFuture(getResponse())
+            }
+          }
+        every { watchClient } returns
+          mockk<Watch> {
+            every { watch(any<ByteSequence>(), any<WatchOption>(), any<Watch.Listener>()) } answers {
+              options += secondArg<WatchOption>()
+              listeners += thirdArg<Watch.Listener>()
+              mockk<Watch.Watcher>(relaxed = true)
+            }
+          }
+      }
+  }
+
+  init {
+    "compaction-killed node watch re-reads the value and re-anchors past the snapshot" {
+      val mocks = CacheMocks("/cache/node")
+      val recovery = CopyOnWriteArrayList<WatchRecoveryEvent>()
+
+      NodeCache(mocks.client, mocks.key, StringCodec).use { cache ->
+        cache.addRecoveryListener { recovery += it }
+        cache.start()
+
+        cache.current shouldBe "1"
+        mocks.options.first().revision shouldBe 11 // snapshot revision + 1
+
+        // etcd compacted away the watch anchor: jetcd reports a fatal death
+        mocks.listeners.first().onError(EtcdExceptionFactory.newCompactedException(15))
+        mocks.listeners.first().onCompleted()
+
+        pollUntil(10.seconds) { recovery.any { it is WatchRecoveryEvent.Resynced } } shouldBe true
+        val resync = recovery.filterIsInstance<WatchRecoveryEvent.Resynced>().first()
+        resync.compactRevision shouldBe 15
+        resync.anchorRevision shouldBe 21 // resync snapshot revision + 1
+
+        pollUntil(10.seconds) { mocks.options.size == 2 && mocks.options[1].revision == 21L } shouldBe true
+        cache.current shouldBe "2"
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/NodeCacheTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/NodeCacheTests.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.cache
+
+import io.etcd.recipes.common.StringCodec
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.deleteKey
+import io.etcd.recipes.common.jsonCodec
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
+
+class NodeCacheTests : StringSpec() {
+  private val base = "/cache/${javaClass.simpleName}"
+
+  @Serializable
+  data class Config(
+    val name: String,
+    val count: Int,
+  )
+
+  init {
+    "current reflects the initial value, then UPDATED and DELETED events fire" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val key = "$base/node"
+        client.putValue(key, "v1")
+        val events = CopyOnWriteArrayList<NodeCacheEvent<String>>()
+
+        NodeCache(client, key, StringCodec).use { cache ->
+          cache.addListener { events += it }
+          cache.start()
+          cache.current shouldBe "v1"
+
+          client.putValue(key, "v2")
+          pollUntil(10.seconds) { events.any { it.type == NodeCacheEvent.Type.UPDATED } } shouldBe true
+          cache.current shouldBe "v2"
+
+          client.deleteKey(key)
+          pollUntil(10.seconds) { events.any { it.type == NodeCacheEvent.Type.DELETED } } shouldBe true
+          cache.current shouldBe null
+        }
+      }
+    }
+
+    "a key that appears after start fires CREATED" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val key = "$base/late"
+        val events = CopyOnWriteArrayList<NodeCacheEvent<String>>()
+
+        NodeCache(client, key, StringCodec).use { cache ->
+          cache.addListener { events += it }
+          cache.start()
+          cache.current shouldBe null
+
+          client.putValue(key, "hello")
+          pollUntil(10.seconds) { events.any { it.type == NodeCacheEvent.Type.CREATED } } shouldBe true
+          cache.current shouldBe "hello"
+        }
+      }
+    }
+
+    "a JSON-typed node cache round-trips a data class" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val key = "$base/json"
+        val codec = jsonCodec<Config>()
+        client.putValue(key, codec.encode(Config("svc", 1)))
+
+        NodeCache(client, key, codec).use { cache ->
+          cache.start()
+          cache.current shouldBe Config("svc", 1)
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdCodecTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/EtcdCodecTests.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+
+class EtcdCodecTests : StringSpec() {
+  @Serializable
+  data class Config(
+    val name: String,
+    val count: Int,
+  )
+
+  init {
+    "StringCodec round-trips" {
+      StringCodec.decode(StringCodec.encode("hello")) shouldBe "hello"
+    }
+
+    "ByteSequenceCodec is the identity" {
+      val bytes = "raw".asByteSequence
+      ByteSequenceCodec.encode(bytes) shouldBe bytes
+      ByteSequenceCodec.decode(bytes) shouldBe bytes
+    }
+
+    "jsonCodec round-trips a @Serializable type" {
+      val codec = jsonCodec<Config>()
+      val value = Config("svc", 3)
+      codec.decode(codec.encode(value)) shouldBe value
+    }
+
+    "jsonCodec encodes to JSON bytes" {
+      jsonCodec<Config>().encode(Config("a", 1)).asString shouldBe """{"name":"a","count":1}"""
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/EventFlowTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/EventFlowTests.kt
@@ -19,11 +19,15 @@
 package io.etcd.recipes.coroutines
 
 import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.cache.NodeCache
+import io.etcd.recipes.cache.NodeCacheEvent
 import io.etcd.recipes.cache.PathChildrenCache
 import io.etcd.recipes.cache.PathChildrenCacheEvent
+import io.etcd.recipes.common.StringCodec
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.deleteKey
 import io.etcd.recipes.common.getResponse
 import io.etcd.recipes.common.putValue
 import io.etcd.recipes.common.urls
@@ -88,6 +92,35 @@ class EventFlowTests : StringSpec() {
                 PathChildrenCacheEvent.Type.CHILD_ADDED,
                 PathChildrenCacheEvent.Type.CHILD_UPDATED,
                 PathChildrenCacheEvent.Type.CHILD_REMOVED,
+              )
+          }
+        }
+      }
+    }
+
+    "nodeCache eventsAsFlow delivers CREATED, UPDATED, and DELETED in order" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val key = "$base/node"
+        val seen = CopyOnWriteArrayList<NodeCacheEvent.Type>()
+
+        NodeCache(client, key, StringCodec).use { cache ->
+          cache.start()
+
+          withScope { scope ->
+            scope.launch { cache.eventsAsFlow().collect { e -> seen += e.type } }
+            delay(1_000) // let the collector subscribe
+
+            client.putValue(key, "v1")
+            client.putValue(key, "v2")
+            client.deleteKey(key)
+
+            untilTrue(15.seconds) { seen.size == 3 } shouldBe true
+            seen shouldContainExactly
+              listOf(
+                NodeCacheEvent.Type.CREATED,
+                NodeCacheEvent.Type.UPDATED,
+                NodeCacheEvent.Type.DELETED,
               )
           }
         }


### PR DESCRIPTION
## Summary

Implements product idea **#9** (single-key cache) and brings forward the **#6** typed-codec foundation.

`PathChildrenCache` covers the "watch a prefix" shape — and in etcd's flat keyspace it already caches the entire subtree under a prefix. The genuinely missing shape is the **single exact key**: "keep this one config value hot and tell me when it changes." Users hand-roll a GET + watch and get the race between them wrong. `NodeCache<T>` fills that gap; a "TreeCache" would only duplicate `PathChildrenCache`, so it is out of scope.

## What's included

- **`common/EtcdCodec.kt`** — a minimal `EtcdCodec<T>` SPI (`encode`/`decode`) plus built-in codecs: identity `ByteSequenceCodec`, `StringCodec`, a kotlinx-serialization `KotlinxJsonCodec`, and a `jsonCodec<T>()` reified helper. This is the foundation for the broader typed-recipe work (idea #6); `NodeCache` is its first consumer.
- **`cache/NodeCache.kt`** — a typed, watch-updated single-key cache (`NodeCache<T>`), with the `withNodeCache { }` scope function. It snapshots the key and anchors the watch at **snapshot revision + 1**, so the stream has zero gap and zero overlap with the snapshot (the same watch-establishment-race fix hardened elsewhere in this library). Compaction re-syncs transparently via the `resyncWith` hook. Malformed payloads are recorded and the event skipped, rather than killing the watch dispatcher.
- **`cache/NodeCacheEvent.kt` / `cache/NodeCacheListener.kt`** — the event (`CREATED`/`UPDATED`/`DELETED`) and listener twins, mirroring `PathChildrenCache` conventions.
- **`coroutines/CacheFlows.kt`** — `eventsAsFlow()` / `recoveryEventsAsFlow()` Flow twins.
- **Example** — `examples/cache/NodeCacheExample.kt`, mirroring `PathChildrenCacheExample`.
- **Docs** — README cache row + coroutines Flow table; CHANGELOG entry under `[Unreleased]`.

## Tests

- `EtcdCodecTests` — pure round-trip: String, a `@Serializable` data class via `jsonCodec<T>()`, ByteSequence identity.
- `NodeCacheResyncTests` — mock harness: asserts the initial watch is anchored at `snapshotRev + 1`, drives a compaction, asserts a `Resynced` recovery event and that `current` converges to the resync snapshot.
- `NodeCacheTests` — real etcd: initial value + `UPDATED` + `DELETED`; late-key `CREATED`; JSON-typed round-trip.
- `EventFlowTests` — `nodeCache eventsAsFlow` delivers `CREATED`, `UPDATED`, `DELETED` in order.

The frozen `PathChildrenCache`/`ServiceCache` source assertions in `DesignFixesTests`/`BugFixesTests` are untouched — `NodeCache` is a new, unconstrained class.

## Verification

Full CI-equivalent gate (`clean check koverXmlReport -PuseTestcontainers`) passes locally: **BUILD SUCCESSFUL**, including every module's `koverVerify` and the `design.*` frozen-source oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP