### PR TITLE
Add typed KV extensions and an optional Jackson codec module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,17 @@ non-blocking consumption on the existing queues.
   `NodeCache<T>` decodes its payload through it; the other recipes gain typed variants in a
   later pass.
 
+### Added (typed KV extensions + Jackson codec)
+
+- **Typed KV extensions** — `Client.putValue(key, value, codec)` and `Client.getValue(key, codec)`
+  encode / decode through any `EtcdCodec<T>`, removing the hand-marshalling that the raw
+  `ByteSequence` overloads leave to the caller. Purely additive — the existing overloads are
+  unchanged.
+- **`etcd-recipes-jackson`** — a new optional module providing a Jackson-backed `JacksonCodec<T>`
+  (`Class` / `TypeReference` constructors for Java callers, plus a reified `jacksonCodec<T>()` for
+  Kotlin) for projects that prefer Jackson to kotlinx-serialization. Published as its own Maven
+  Central artifact.
+
 ### Added (observability: push errors + health)
 
 - **Push-based background-exception callback** on `EtcdConnector`: register a

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ what [Curator](https://curator.apache.org) provides for [ZooKeeper](https://zook
 | `io.etcd.recipes.keyvalue` | `TransientKeyValue` (lease-backed key/value) |
 | `io.etcd.recipes.lock` | `DistributedMutex`, `DistributedReadWriteLock`, `DistributedSemaphore` |
 | `io.etcd.recipes.queue` | `DistributedQueue`, `DistributedPriorityQueue`, `DistributedWorkQueue` (at-least-once) |
-| `io.etcd.recipes.common` | Kotlin extensions over jetcd `Client`, `KV`, `Lease`, `Watch`, `Txn` |
+| `io.etcd.recipes.common` | Kotlin extensions over jetcd `Client`, `KV`, `Lease`, `Watch`, `Txn`; `EtcdCodec<T>` typed values |
 | `io.etcd.recipes.coroutines` | Suspending twins of the `common` extensions, `Flow`-based watches |
 
 ## Usage
@@ -47,6 +47,28 @@ connectToEtcd(urls) { client ->
     client.delete("test_key")
 }
 ```
+
+Read and write typed values through an `EtcdCodec<T>` instead of hand-marshalling bytes:
+
+```kotlin
+import io.etcd.recipes.common.getValue
+import io.etcd.recipes.common.jsonCodec
+import io.etcd.recipes.common.putValue
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Config(val name: String, val count: Int)
+
+connectToEtcd(urls) { client ->
+    val codec = jsonCodec<Config>()
+    client.putValue("/config/app", Config("svc", 3), codec)
+    val config: Config? = client.getValue("/config/app", codec)
+}
+```
+
+Built-in codecs are `StringCodec`, `ByteSequenceCodec`, and `jsonCodec<T>()`
+(kotlinx-serialization). Java projects can add the optional `etcd-recipes-jackson`
+module for a `JacksonCodec<T>`. The same codecs type `NodeCache<T>`.
 
 Run a single-leader election across a cluster of processes:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ val libraryName = "etcd-recipes"
 val libraryModule = ":$libraryName"
 val examplesModule = ":$libraryName-examples"
 val micrometerModule = ":$libraryName-micrometer"
+val jacksonModule = ":$libraryName-jackson"
 val repoUrl = "https://github.com/pambrose/$libraryName"
 
 val envDockerHost = "DOCKER_HOST"
@@ -60,6 +61,7 @@ dependencies {
     dokka(project(libraryModule))
     dokka(project(examplesModule))
     dokka(project(micrometerModule))
+    dokka(project(jacksonModule))
 
     kover(project(libraryModule))
 }
@@ -98,8 +100,13 @@ subprojects {
         }
     }
 
-    // The library and its Micrometer binding are published; the examples and test-runners aren't.
-    if (name == libraryName || name == "$libraryName-micrometer") configurePublishing()
+    // The library and its Micrometer/Jackson bindings are published; the examples and test-runners aren't.
+    if (name == libraryName ||
+        name == "$libraryName-micrometer" ||
+        name == "$libraryName-jackson"
+    ) {
+        configurePublishing()
+    }
 
     configure<KotlinJvmProjectExtension> {
         jvmToolchain(rootProject.libs.versions.jvm.get().toInt())

--- a/etcd-recipes-jackson/build.gradle.kts
+++ b/etcd-recipes-jackson/build.gradle.kts
@@ -1,0 +1,6 @@
+dependencies {
+  "implementation"(project(":etcd-recipes"))
+  // Declared inline rather than in the version catalog: this is the only module that
+  // needs Jackson, and the catalog is otherwise reserved for shared dependencies.
+  "api"("com.fasterxml.jackson.core:jackson-databind:2.22.1")
+}

--- a/etcd-recipes-jackson/src/main/kotlin/io/etcd/recipes/jackson/JacksonCodec.kt
+++ b/etcd-recipes-jackson/src/main/kotlin/io/etcd/recipes/jackson/JacksonCodec.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.jackson
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.etcd.jetcd.ByteSequence
+import io.etcd.recipes.common.EtcdCodec
+
+/**
+ * A Jackson-backed [EtcdCodec] that marshals values to and from JSON bytes. This is the Java-facing
+ * counterpart to the library's built-in `KotlinxJsonCodec`; it lives in its own optional module so
+ * only projects that want Jackson pull it in.
+ *
+ * Construct it with either a [Class] token (`new JacksonCodec<>(Config.class)`) or a
+ * [TypeReference] for generic payloads (`new JacksonCodec<>(new TypeReference<List<Config>>() {})`).
+ * Kotlin callers can use the reified [jacksonCodec] helper.
+ *
+ * The default [ObjectMapper] is a vanilla instance — suitable for Java beans and any type Jackson
+ * can construct out of the box. To marshal Kotlin data classes (which have no no-arg constructor),
+ * pass a mapper configured with `jackson-module-kotlin`.
+ */
+class JacksonCodec<T>
+  private constructor(
+    private val reader: (ByteArray) -> T,
+    private val mapper: ObjectMapper,
+  ) : EtcdCodec<T> {
+    /** Marshals values of [type] with the given [mapper] (a vanilla [ObjectMapper] by default). */
+    @JvmOverloads
+    constructor(type: Class<T>, mapper: ObjectMapper = ObjectMapper()) : this({ mapper.readValue(it, type) }, mapper)
+
+    /** Marshals a generic [type] (e.g. `List<Config>`) with the given [mapper]. */
+    @JvmOverloads
+    constructor(
+      type: TypeReference<T>,
+      mapper: ObjectMapper = ObjectMapper(),
+    ) : this({ mapper.readValue(it, type) }, mapper)
+
+    override fun encode(value: T): ByteSequence = ByteSequence.from(mapper.writeValueAsBytes(value))
+
+    override fun decode(bytes: ByteSequence): T = reader(bytes.bytes)
+  }
+
+/** A [JacksonCodec] for any [T], resolving its type via a reified [TypeReference] at the call site. */
+inline fun <reified T> jacksonCodec(mapper: ObjectMapper = ObjectMapper()): EtcdCodec<T> =
+  JacksonCodec(object : TypeReference<T>() {}, mapper)

--- a/etcd-recipes-jackson/src/test/kotlin/io/etcd/recipes/jackson/JacksonCodecTests.kt
+++ b/etcd-recipes-jackson/src/test/kotlin/io/etcd/recipes/jackson/JacksonCodecTests.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.jackson
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.core.type.TypeReference
+import io.etcd.recipes.common.asString
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * The Jackson backend for [io.etcd.recipes.common.EtcdCodec], verified with a vanilla
+ * [com.fasterxml.jackson.databind.ObjectMapper]. The `@JsonCreator` annotation keeps the sample
+ * type constructable without the optional `jackson-module-kotlin`, mirroring a Java POJO.
+ */
+class JacksonCodecTests : StringSpec() {
+  data class Point
+    @JsonCreator
+    constructor(
+      @param:JsonProperty("x") val x: Int,
+      @param:JsonProperty("y") val y: Int,
+    )
+
+  init {
+    "JacksonCodec round-trips via a Class token" {
+      val codec = JacksonCodec(Point::class.java)
+      val value = Point(1, 2)
+      codec.decode(codec.encode(value)) shouldBe value
+    }
+
+    "jacksonCodec reified helper round-trips" {
+      val codec = jacksonCodec<Point>()
+      val value = Point(3, 4)
+      codec.decode(codec.encode(value)) shouldBe value
+    }
+
+    "JacksonCodec round-trips a generic type via TypeReference" {
+      val codec = JacksonCodec(object : TypeReference<List<Point>>() {})
+      val value = listOf(Point(1, 1), Point(2, 2))
+      codec.decode(codec.encode(value)) shouldBe value
+    }
+
+    "JacksonCodec encodes to JSON bytes" {
+      JacksonCodec(Point::class.java).encode(Point(5, 6)).asString shouldBe """{"x":5,"y":6}"""
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/TypedKVExtensions.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/common/TypedKVExtensions.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("TypedKVUtils")
+
+package io.etcd.recipes.common
+
+import io.etcd.jetcd.Client
+import io.etcd.jetcd.kv.PutResponse
+import io.etcd.jetcd.options.PutOption
+
+/**
+ * Writes [value] encoded through [codec], removing the hand-marshalling that the raw
+ * `putValue(key, ByteSequence)` overload leaves to the caller. Composes the existing
+ * [ByteSequence][io.etcd.jetcd.ByteSequence] put, so it inherits its retry semantics.
+ *
+ * `client.putValue("cfg", config, jsonCodec<Config>())`
+ */
+fun <T> Client.putValue(
+  keyName: String,
+  value: T,
+  codec: EtcdCodec<T>,
+  option: PutOption = PutOption.DEFAULT,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): PutResponse = putValue(keyName, codec.encode(value), option, rpc)
+
+/**
+ * Reads [keyName] and decodes it through [codec], or null when the key is absent. The counterpart
+ * to the typed [putValue]. Use `?: default` for a fallback.
+ *
+ * `client.getValue("cfg", jsonCodec<Config>())`
+ */
+fun <T> Client.getValue(
+  keyName: String,
+  codec: EtcdCodec<T>,
+  rpc: RpcResilience = RpcResilience.DEFAULT,
+): T? = getValue(keyName, rpc)?.let(codec::decode)

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/TypedKVExtensionsTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/TypedKVExtensionsTests.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.common
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+
+/**
+ * The typed [Client.putValue] / [Client.getValue] extensions: a value round-trips through any
+ * [EtcdCodec], and a read of an absent key is null.
+ */
+class TypedKVExtensionsTests : StringSpec() {
+  private val base = "/common/${javaClass.simpleName}"
+
+  @Serializable
+  data class Config(
+    val name: String,
+    val count: Int,
+  )
+
+  init {
+    "putValue and getValue round-trip a value through a JSON codec" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val key = "$base/config"
+        val codec = jsonCodec<Config>()
+        val value = Config("svc", 7)
+        client.putValue(key, value, codec)
+        client.getValue(key, codec) shouldBe value
+      }
+    }
+
+    "getValue returns null for an absent key" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        client.getValue("$base/missing", jsonCodec<Config>()).shouldBeNull()
+      }
+    }
+
+    "putValue and getValue round-trip via StringCodec" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val key = "$base/str"
+        client.putValue(key, "hello", StringCodec)
+        client.getValue(key, StringCodec) shouldBe "hello"
+      }
+    }
+
+    "putValue and getValue round-trip via ByteSequenceCodec" {
+      connectToEtcd(urls) { client ->
+        client.deleteChildren(base)
+        val key = "$base/bytes"
+        val bytes = "raw".asByteSequence
+        client.putValue(key, bytes, ByteSequenceCodec)
+        client.getValue(key, ByteSequenceCodec) shouldBe bytes
+      }
+    }
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,4 +21,5 @@ rootProject.name = "etcd-recipes"
 include("etcd-recipes")
 include("etcd-recipes-examples")
 include("etcd-recipes-micrometer")
+include("etcd-recipes-jackson")
 include("etcd-recipes-test-runners")


### PR DESCRIPTION
## Summary

First pass of the typed recipe layer (**product idea #6**), building on the `EtcdCodec<T>` foundation that shipped with NodeCache (#9). Scope this pass: the stateless typed KV API + a second codec-implementation module. No stateful recipe is generified, so the existing public API and the frozen-test surface are untouched.

## What's included

- **Typed KV extensions** (`common/TypedKVExtensions.kt`) — `Client.putValue(key, value, codec)` and `Client.getValue(key, codec): T?` encode / decode through any `EtcdCodec<T>`, removing the hand-marshalling the raw `ByteSequence` overloads leave to the caller. They compose the existing `ByteSequence` put/get (inheriting retry semantics) and are **purely additive**: the codec parameter disambiguates them from the existing `String`/`Int`/`Long` overloads, so no existing call site changes (verified — the full test suite, which calls the untyped overloads heavily, compiles and passes).
- **`etcd-recipes-jackson`** — a new optional module (mirroring `etcd-recipes-micrometer`) with a Jackson-backed `JacksonCodec<T>` for projects that prefer Jackson to kotlinx-serialization. `Class<T>` and `TypeReference<T>` constructors serve Java callers (including generic payloads via `TypeReference`); a reified `jacksonCodec<T>()` serves Kotlin. Depends only on base `jackson-databind:2.22.1`.
- **Docs** — README typed-values snippet + `common` package row; CHANGELOG entry under `[Unreleased]`.

## Tests

- `JacksonCodecTests` (pure) — round-trip via a `Class` token, via the reified `jacksonCodec<T>()`, and a generic `List<T>` via `TypeReference`; plus JSON-bytes assertion.
- `TypedKVExtensionsTests` (real etcd) — put/get round-trip through a JSON codec, `StringCodec`, and `ByteSequenceCodec`; `getValue` on an absent key → null.

## Release note

Wiring `etcd-recipes-jackson` into `configurePublishing()` means the next release publishes a **third** Maven Central artifact, alongside `etcd-recipes` and `etcd-recipes-micrometer`.

## Verification

Full CI-equivalent gate (`clean check koverXmlReport -PuseTestcontainers`) passes locally: **BUILD SUCCESSFUL**, including the new module's `test`/detekt, the library's `koverVerify`, and the frozen `design.*` oracle. Both new test classes ran in the full suite (8/8), zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP