### PR TITLE
Add typed variants of the queue, cache, ServiceInstance, and TransientKeyValue recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,23 @@ non-blocking consumption on the existing queues.
   Kotlin) for projects that prefer Jackson to kotlinx-serialization. Published as its own Maven
   Central artifact.
 
+### Added (typed recipe variants)
+
+- Typed wrappers for the remaining raw-payload recipes, each marshalling through an `EtcdCodec<T>`
+  so callers stop hand-encoding `ByteSequence`/`String`:
+  - **`TypedDistributedQueue<T>`** / **`TypedDistributedPriorityQueue<T>`** — `enqueue(T)` /
+    `dequeue(): T` / typed `poll`, over the existing queues.
+  - **`TypedPathChildrenCache<T>`** — typed `currentData` / `getCurrentData` (`TypedChildData<T>`)
+    and decoded `TypedPathChildrenCacheEvent`s via `TypedPathChildrenCacheListener` (plus a
+    coroutine `eventsAsFlow()`).
+  - **`TypedTransientKeyValue<T>`** — publishes a value encoded once through a codec.
+  - **`ServiceInstance`** typed payload — additive `payload<T>(codec)` / `setPayload` extensions and
+    a typed `serviceInstance(name, payload, codec)` builder, keeping the `jsonPayload` JSON string as
+    the unchanged wire format.
+- Each typed recipe is a composition wrapper exposing the underlying recipe as `untyped`, so the full
+  `EtcdConnector` API stays reachable; no existing class changed. Codecs for the `String`-valued
+  surfaces (`ServiceInstance`, `TransientKeyValue`) must emit UTF-8 text.
+
 ### Added (observability: push errors + health)
 
 - **Push-based background-exception callback** on `EtcdConnector`: register a

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ what [Curator](https://curator.apache.org) provides for [ZooKeeper](https://zook
 | Package | Recipes |
 |---|---|
 | `io.etcd.recipes.barrier` | `DistributedBarrier`, `DistributedBarrierWithCount`, `DistributedDoubleBarrier` |
-| `io.etcd.recipes.cache` | `PathChildrenCache` (key-prefix cache), `NodeCache<T>` (typed single-key cache) |
+| `io.etcd.recipes.cache` | `PathChildrenCache` (key-prefix cache), `TypedPathChildrenCache<T>`, `NodeCache<T>` (typed single-key cache) |
 | `io.etcd.recipes.counter` | `DistributedAtomicLong` |
-| `io.etcd.recipes.discovery` | `ServiceDiscovery`, `ServiceCache`, `ServiceInstance`, `ServiceProvider`, `ProviderStrategy` |
+| `io.etcd.recipes.discovery` | `ServiceDiscovery`, `ServiceCache`, `ServiceInstance` (typed `payload<T>()`), `ServiceProvider`, `ProviderStrategy` |
 | `io.etcd.recipes.election` | `LeaderSelector`, `LeaderLatch`, `LeaderObserver`, `LeaderSelectorListener`, `Participant` |
-| `io.etcd.recipes.keyvalue` | `TransientKeyValue` (lease-backed key/value) |
+| `io.etcd.recipes.keyvalue` | `TransientKeyValue` (lease-backed key/value), `TypedTransientKeyValue<T>` |
 | `io.etcd.recipes.lock` | `DistributedMutex`, `DistributedReadWriteLock`, `DistributedSemaphore` |
-| `io.etcd.recipes.queue` | `DistributedQueue`, `DistributedPriorityQueue`, `DistributedWorkQueue` (at-least-once) |
+| `io.etcd.recipes.queue` | `DistributedQueue`, `DistributedPriorityQueue`, `DistributedWorkQueue` (at-least-once), `TypedDistributedQueue<T>` / `TypedDistributedPriorityQueue<T>` |
 | `io.etcd.recipes.common` | Kotlin extensions over jetcd `Client`, `KV`, `Lease`, `Watch`, `Txn`; `EtcdCodec<T>` typed values |
 | `io.etcd.recipes.coroutines` | Suspending twins of the `common` extensions, `Flow`-based watches |
 
@@ -68,7 +68,10 @@ connectToEtcd(urls) { client ->
 
 Built-in codecs are `StringCodec`, `ByteSequenceCodec`, and `jsonCodec<T>()`
 (kotlinx-serialization). Java projects can add the optional `etcd-recipes-jackson`
-module for a `JacksonCodec<T>`. The same codecs type `NodeCache<T>`.
+module for a `JacksonCodec<T>`. The same codecs type the recipes: `NodeCache<T>`,
+`TypedPathChildrenCache<T>`, `TypedDistributedQueue<T>` /
+`TypedDistributedPriorityQueue<T>`, `TypedTransientKeyValue<T>`, and `ServiceInstance`'s
+`payload<T>(codec)` / typed `serviceInstance(name, payload, codec)` builder.
 
 Run a single-leader election across a cluster of processes:
 

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/cache/TypedPathChildrenCacheExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/cache/TypedPathChildrenCacheExample.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.cache
+
+import com.pambrose.common.util.sleep
+import io.etcd.recipes.cache.TypedPathChildrenCache
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.jsonCodec
+import io.etcd.recipes.common.putValue
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Watch a prefix of typed values with a [TypedPathChildrenCache]: `currentData` yields decoded
+ * [Worker]s and a listener is notified with the decoded payload on each child change.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val path = "/cache/typed-example"
+  val codec = jsonCodec<Worker>()
+
+  connectToEtcd(urls) { client ->
+    client.deleteChildren(path)
+    client.putValue("$path/w1", Worker("alpha", 3), codec)
+
+    TypedPathChildrenCache(client, path, codec).use { cache ->
+      cache.addListener { event -> logger.info { "Change: ${event.type} ${event.childName} -> ${event.data}" } }
+      cache.start(buildInitial = true)
+      logger.info { "Initial: ${cache.currentData}" }
+
+      client.putValue("$path/w2", Worker("beta", 7), codec)
+      sleep(500.milliseconds)
+      logger.info { "Now: ${cache.currentData}" }
+    }
+  }
+}

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/cache/Worker.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/cache/Worker.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.cache
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Worker(
+  val name: String,
+  val load: Int,
+)

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/queue/Order.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/queue/Order.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.queue
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Order(
+  val id: Int,
+  val item: String,
+)

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/queue/TypedDistributedQueueExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/queue/TypedDistributedQueueExample.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.examples.queue
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.jsonCodec
+import io.etcd.recipes.queue.TypedDistributedQueue
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+/**
+ * Enqueue and dequeue typed values with a [TypedDistributedQueue]: a `jsonCodec<Order>()` marshals
+ * each [Order] so callers never touch raw bytes.
+ */
+fun main() {
+  val logger = KotlinLogging.logger {}
+  val urls = listOf("http://localhost:2379")
+  val path = "/queue/typed-example"
+
+  connectToEtcd(urls) { client ->
+    TypedDistributedQueue(client, path, jsonCodec<Order>()).use { queue ->
+      queue.enqueue(Order(1, "widget"))
+      queue.enqueueAll(listOf(Order(2, "gadget"), Order(3, "gizmo")))
+
+      repeat(3) {
+        val order: Order = queue.dequeue()
+        logger.info { "Dequeued: $order" }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/TypedChildData.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/TypedChildData.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.cache
+
+/**
+ * A cached child of a [TypedPathChildrenCache]: the child [key] (relative to the cache path) and
+ * its decoded [value]. The typed counterpart to [ChildData] (named distinctly because the raw
+ * `ChildData` is non-generic).
+ */
+data class TypedChildData<T>(
+  val key: String,
+  val value: T,
+)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/TypedPathChildrenCache.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/TypedPathChildrenCache.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.cache
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.EtcdCodec
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.WatchRecoveryListener
+import java.io.Closeable
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+
+/** Scopes a [TypedPathChildrenCache] to [receiver], closing it on exit. */
+@JvmOverloads
+fun <T, R> withTypedPathChildrenCache(
+  client: Client,
+  cachePath: String,
+  codec: EtcdCodec<T>,
+  userExecutor: Executor? = null,
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  receiver: TypedPathChildrenCache<T>.() -> R,
+): R = TypedPathChildrenCache(client, cachePath, codec, userExecutor, resilience).use { it.receiver() }
+
+/**
+ * A typed prefix cache: a [PathChildrenCache] with every child value decoded through [codec].
+ * [currentData] / [getCurrentData] / [currentDataAsMap] return [T], and registered
+ * [TypedPathChildrenCacheListener]s receive decoded [TypedPathChildrenCacheEvent]s.
+ *
+ * A malformed payload is recorded on `untyped`'s exception sink (the underlying cache catches the
+ * decode failure raised in the re-emit path) and that event is skipped; the read accessors decode
+ * lazily and may throw to the caller (as [NodeCache.current] does). The full connector API stays
+ * reachable through [untyped].
+ */
+class TypedPathChildrenCache<T>(
+  val untyped: PathChildrenCache,
+  private val codec: EtcdCodec<T>,
+) : Closeable {
+  @JvmOverloads
+  constructor(
+    client: Client,
+    cachePath: String,
+    codec: EtcdCodec<T>,
+    userExecutor: Executor? = null,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : this(PathChildrenCache(client, cachePath, userExecutor, resilience), codec)
+
+  private val listeners: MutableList<TypedPathChildrenCacheListener<T>> = CopyOnWriteArrayList()
+
+  // A single adapter on the underlying cache decodes each event and re-emits to the typed
+  // listeners. A decode failure here propagates into the underlying cache's per-listener
+  // try/catch, which records it (surfaced on untyped.exceptions) and skips the event.
+  private val adapter =
+    PathChildrenCacheListener { event ->
+      val typedEvent =
+        TypedPathChildrenCacheEvent(
+          event.childName,
+          event.type,
+          event.data?.let { codec.decode(it) },
+        ).apply {
+          if (event.type == PathChildrenCacheEvent.Type.INITIALIZED)
+            initialDataVal = event.initialData.map { TypedChildData(it.key, codec.decode(it.value)) }
+        }
+      listeners.forEach { it.childEvent(typedEvent) }
+    }
+
+  init {
+    untyped.addListener(adapter)
+  }
+
+  @JvmOverloads
+  fun start(
+    buildInitial: Boolean = false,
+    waitOnStartComplete: Boolean = true,
+  ): TypedPathChildrenCache<T> {
+    untyped.start(buildInitial, waitOnStartComplete)
+    return this
+  }
+
+  @JvmOverloads
+  fun start(
+    mode: PathChildrenCache.StartMode,
+    waitOnStartComplete: Boolean = true,
+  ): TypedPathChildrenCache<T> {
+    untyped.start(mode, waitOnStartComplete)
+    return this
+  }
+
+  fun waitOnStartComplete(): Boolean = untyped.waitOnStartComplete()
+
+  fun waitOnStartComplete(timeout: Duration): Boolean = untyped.waitOnStartComplete(timeout)
+
+  fun waitOnStartComplete(
+    timeout: Long,
+    timeUnit: TimeUnit,
+  ): Boolean = untyped.waitOnStartComplete(timeout, timeUnit)
+
+  val currentData: List<TypedChildData<T>>
+    get() = untyped.currentData.map { TypedChildData(it.key, codec.decode(it.value)) }
+
+  fun getCurrentData(childName: String): T? = untyped.getCurrentData(childName)?.let(codec::decode)
+
+  val currentDataAsMap: Map<String, T>
+    get() = untyped.currentDataAsMap.mapValues { (_, v) -> codec.decode(v) }
+
+  fun addListener(listener: TypedPathChildrenCacheListener<T>) {
+    listeners += listener
+  }
+
+  fun removeListener(listener: TypedPathChildrenCacheListener<T>) {
+    listeners -= listener
+  }
+
+  fun clearListeners() = listeners.clear()
+
+  fun addRecoveryListener(listener: WatchRecoveryListener) = untyped.addRecoveryListener(listener)
+
+  fun removeRecoveryListener(listener: WatchRecoveryListener) = untyped.removeRecoveryListener(listener)
+
+  fun rebuild() = untyped.rebuild()
+
+  fun clear() = untyped.clear()
+
+  override fun close() = untyped.close()
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/TypedPathChildrenCacheEvent.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/TypedPathChildrenCacheEvent.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.cache
+
+/**
+ * A [TypedPathChildrenCache] change: the decoded counterpart to [PathChildrenCacheEvent]. [data]
+ * is the child's decoded value (null on `CHILD_REMOVED` when the prior value is absent), and
+ * [initialData] carries the decoded snapshot on an `INITIALIZED` event. Reuses
+ * [PathChildrenCacheEvent.Type].
+ */
+class TypedPathChildrenCacheEvent<T>(
+  val childName: String,
+  val type: PathChildrenCacheEvent.Type,
+  val data: T?,
+) {
+  internal var initialDataVal: List<TypedChildData<T>> = emptyList()
+
+  val initialData: List<TypedChildData<T>> get() = initialDataVal
+
+  override fun toString() = "TypedPathChildrenCacheEvent{type=$type, childName=$childName, data=$data}"
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/TypedPathChildrenCacheListener.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/cache/TypedPathChildrenCacheListener.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.cache
+
+/** Notified of decoded [TypedPathChildrenCache] child changes. The typed peer of [PathChildrenCacheListener]. */
+fun interface TypedPathChildrenCacheListener<T> {
+  fun childEvent(event: TypedPathChildrenCacheEvent<T>)
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/CacheFlows.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/coroutines/CacheFlows.kt
@@ -22,6 +22,9 @@ import io.etcd.recipes.cache.NodeCacheListener
 import io.etcd.recipes.cache.PathChildrenCache
 import io.etcd.recipes.cache.PathChildrenCacheEvent
 import io.etcd.recipes.cache.PathChildrenCacheListener
+import io.etcd.recipes.cache.TypedPathChildrenCache
+import io.etcd.recipes.cache.TypedPathChildrenCacheEvent
+import io.etcd.recipes.cache.TypedPathChildrenCacheListener
 import io.etcd.recipes.common.WatchRecoveryEvent
 import io.etcd.recipes.common.WatchRecoveryListener
 import kotlinx.coroutines.channels.Channel
@@ -71,6 +74,27 @@ fun <T> NodeCache<T>.eventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<NodeC
 
 /** The single-key cache's watch-recovery transitions as a [Flow]; see [eventsAsFlow] for lifecycle. */
 fun NodeCache<*>.recoveryEventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<WatchRecoveryEvent> =
+  callbackFlow {
+    val listener = WatchRecoveryListener { event -> trySendBlocking(event) }
+    addRecoveryListener(listener)
+    awaitClose { removeRecoveryListener(listener) }
+  }.buffer(capacity)
+
+/**
+ * The typed prefix cache's decoded child events ([TypedPathChildrenCacheEvent]) as a [Flow]. The
+ * typed peer of [PathChildrenCache.eventsAsFlow]; see it for lifecycle.
+ */
+fun <T> TypedPathChildrenCache<T>.eventsAsFlow(
+  capacity: Int = Channel.UNLIMITED,
+): Flow<TypedPathChildrenCacheEvent<T>> =
+  callbackFlow {
+    val listener = TypedPathChildrenCacheListener<T> { event -> trySendBlocking(event) }
+    addListener(listener)
+    awaitClose { removeListener(listener) }
+  }.buffer(capacity)
+
+/** The typed prefix cache's watch-recovery transitions as a [Flow]; see [eventsAsFlow] for lifecycle. */
+fun TypedPathChildrenCache<*>.recoveryEventsAsFlow(capacity: Int = Channel.UNLIMITED): Flow<WatchRecoveryEvent> =
   callbackFlow {
     val listener = WatchRecoveryListener { event -> trySendBlocking(event) }
     addRecoveryListener(listener)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/TypedServiceInstance.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/TypedServiceInstance.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("TypedServiceInstances")
+
+package io.etcd.recipes.discovery
+
+import io.etcd.recipes.common.EtcdCodec
+import io.etcd.recipes.common.asByteSequence
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.discovery.ServiceInstance.Companion.ServiceInstanceBuilder
+
+// The typed payload layers over the opaque `jsonPayload` String, so the ServiceInstance wire format
+// (the whole-instance JSON produced by toJson()) is byte-for-byte unchanged. Because jsonPayload is
+// a String, these require a UTF-8 text codec (StringCodec, jsonCodec, the JSON JacksonCodec) — a
+// binary codec is unsupported here.
+
+/** Decodes this instance's opaque [ServiceInstance.jsonPayload] through [codec]. */
+fun <T> ServiceInstance.payload(codec: EtcdCodec<T>): T = codec.decode(jsonPayload.asByteSequence)
+
+/** Encodes [value] into this instance's [ServiceInstance.jsonPayload] through [codec], in place. */
+fun <T> ServiceInstance.setPayload(
+  value: T,
+  codec: EtcdCodec<T>,
+) {
+  jsonPayload = codec.encode(value).asString
+}
+
+/** Builds a [ServiceInstance] whose `jsonPayload` is [payload] encoded through [codec]. */
+@JvmOverloads
+fun <T> serviceInstance(
+  name: String,
+  payload: T,
+  codec: EtcdCodec<T>,
+  initReceiver: ServiceInstanceBuilder.() -> ServiceInstanceBuilder = { this },
+): ServiceInstance = ServiceInstance.newBuilder(name, codec.encode(payload).asString).initReceiver().build()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TypedTransientKeyValue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/keyvalue/TypedTransientKeyValue.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.keyvalue
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.EtcdCodec
+import io.etcd.recipes.common.EtcdConnector
+import io.etcd.recipes.common.LeaseListener
+import io.etcd.recipes.common.ResilienceConfig
+import io.etcd.recipes.common.asString
+import io.etcd.recipes.keyvalue.TransientKeyValue.Companion.defaultClientId
+import java.io.Closeable
+import java.util.concurrent.Executor
+
+/** Scopes a [TypedTransientKeyValue] to [receiver], closing it on exit. */
+@JvmOverloads
+fun <T, R> withTypedTransientKeyValue(
+  client: Client,
+  keyPath: String,
+  value: T,
+  codec: EtcdCodec<T>,
+  leaseTtlSecs: Long = EtcdConnector.DEFAULT_TTL_SECS,
+  autoStart: Boolean = true,
+  userExecutor: Executor? = null,
+  clientId: String = defaultClientId(),
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  receiver: TypedTransientKeyValue<T>.() -> R,
+): R =
+  TypedTransientKeyValue(client, keyPath, value, codec, leaseTtlSecs, autoStart, userExecutor, clientId, resilience)
+    .use { it.receiver() }
+
+/**
+ * A typed lease-backed key/value: a [TransientKeyValue] whose (immutable) [value] is encoded once
+ * through [codec] and published under the lease. Because the published value is a `String`, this
+ * requires a UTF-8 text codec (`StringCodec`, `jsonCodec`, the JSON `JacksonCodec`). Read it back
+ * with the typed `getValue(key, codec)`. The full connector API stays reachable through [untyped].
+ */
+class TypedTransientKeyValue<T>
+  @JvmOverloads
+  constructor(
+    client: Client,
+    keyPath: String,
+    value: T,
+    codec: EtcdCodec<T>,
+    leaseTtlSecs: Long = EtcdConnector.DEFAULT_TTL_SECS,
+    autoStart: Boolean = true,
+    userExecutor: Executor? = null,
+    clientId: String = defaultClientId(),
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : Closeable {
+    val untyped: TransientKeyValue =
+      TransientKeyValue(
+        client,
+        keyPath,
+        codec.encode(value).asString,
+        leaseTtlSecs,
+        autoStart,
+        userExecutor,
+        clientId,
+        resilience,
+      )
+
+    /** Starts publishing (for `autoStart = false`); a no-op-safe delegate to the underlying recipe. */
+    fun start(): TypedTransientKeyValue<T> {
+      untyped.start()
+      return this
+    }
+
+    fun addLeaseListener(listener: LeaseListener) = untyped.addLeaseListener(listener)
+
+    fun removeLeaseListener(listener: LeaseListener) = untyped.removeLeaseListener(listener)
+
+    override fun close() = untyped.close()
+  }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/TypedDistributedPriorityQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/TypedDistributedPriorityQueue.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.queue
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.EtcdCodec
+import io.etcd.recipes.common.ResilienceConfig
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/** Scopes a [TypedDistributedPriorityQueue] to [receiver], closing it on exit. */
+@JvmOverloads
+fun <T, R> withTypedDistributedPriorityQueue(
+  client: Client,
+  queuePath: String,
+  codec: EtcdCodec<T>,
+  minimumWaitTime: Duration = 0.milliseconds,
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  receiver: TypedDistributedPriorityQueue<T>.() -> R,
+): R = TypedDistributedPriorityQueue(client, queuePath, codec, minimumWaitTime, resilience).use { it.receiver() }
+
+/**
+ * A typed priority queue: a [DistributedPriorityQueue] with values marshalled through [codec], so
+ * callers enqueue and dequeue [T] instead of raw `ByteSequence`. The full connector API stays
+ * reachable through [untyped].
+ */
+class TypedDistributedPriorityQueue<T>(
+  val untyped: DistributedPriorityQueue,
+  private val codec: EtcdCodec<T>,
+) : Closeable {
+  @JvmOverloads
+  constructor(
+    client: Client,
+    queuePath: String,
+    codec: EtcdCodec<T>,
+    minimumWaitTime: Duration = 0.milliseconds,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : this(DistributedPriorityQueue(client, queuePath, minimumWaitTime, resilience), codec)
+
+  fun enqueue(
+    value: T,
+    priority: Int,
+  ) = untyped.enqueue(codec.encode(value), priority)
+
+  fun enqueue(
+    value: T,
+    priority: UShort,
+  ) = untyped.enqueue(codec.encode(value), priority)
+
+  fun dequeue(): T = codec.decode(untyped.dequeue())
+
+  fun tryDequeue(): T? = untyped.tryDequeue()?.let(codec::decode)
+
+  fun poll(timeout: Duration): T? = untyped.poll(timeout)?.let(codec::decode)
+
+  fun poll(
+    timeout: Long,
+    timeUnit: TimeUnit,
+  ): T? = untyped.poll(timeout, timeUnit)?.let(codec::decode)
+
+  val size: Int get() = untyped.size
+
+  override fun close() = untyped.close()
+}

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/TypedDistributedQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/TypedDistributedQueue.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.etcd.recipes.queue
+
+import io.etcd.jetcd.Client
+import io.etcd.recipes.common.EtcdCodec
+import io.etcd.recipes.common.ResilienceConfig
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+
+/** Scopes a [TypedDistributedQueue] to [receiver], closing it on exit. */
+@JvmOverloads
+fun <T, R> withTypedDistributedQueue(
+  client: Client,
+  queuePath: String,
+  codec: EtcdCodec<T>,
+  resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  receiver: TypedDistributedQueue<T>.() -> R,
+): R = TypedDistributedQueue(client, queuePath, codec, resilience).use { it.receiver() }
+
+/**
+ * A typed FIFO queue: a [DistributedQueue] with values marshalled through [codec], so callers
+ * enqueue and dequeue [T] instead of raw `ByteSequence`. The full connector API (`exceptions`,
+ * `isHealthy()`, background-exception listeners) stays reachable through [untyped].
+ */
+class TypedDistributedQueue<T>(
+  val untyped: DistributedQueue,
+  private val codec: EtcdCodec<T>,
+) : Closeable {
+  @JvmOverloads
+  constructor(
+    client: Client,
+    queuePath: String,
+    codec: EtcdCodec<T>,
+    resilience: ResilienceConfig = ResilienceConfig.DEFAULT,
+  ) : this(DistributedQueue(client, queuePath, resilience), codec)
+
+  fun enqueue(value: T) = untyped.enqueue(codec.encode(value))
+
+  fun enqueueAll(values: Collection<T>) = untyped.enqueueAll(values.map(codec::encode))
+
+  fun dequeue(): T = codec.decode(untyped.dequeue())
+
+  fun tryDequeue(): T? = untyped.tryDequeue()?.let(codec::decode)
+
+  fun poll(timeout: Duration): T? = untyped.poll(timeout)?.let(codec::decode)
+
+  fun poll(
+    timeout: Long,
+    timeUnit: TimeUnit,
+  ): T? = untyped.poll(timeout, timeUnit)?.let(codec::decode)
+
+  val size: Int get() = untyped.size
+
+  override fun close() = untyped.close()
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/TypedPathChildrenCacheTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/TypedPathChildrenCacheTests.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.cache
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.deleteKey
+import io.etcd.recipes.common.jsonCodec
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.putValue
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The typed prefix cache: the initial snapshot and live child events decode through a codec into
+ * [TypedChildData] / [TypedPathChildrenCacheEvent].
+ */
+class TypedPathChildrenCacheTests : StringSpec() {
+  private val base = "/cache/${javaClass.simpleName}"
+
+  @Serializable
+  data class Node(
+    val n: Int,
+  )
+
+  init {
+    "typed currentData and getCurrentData decode the initial snapshot" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/snapshot"
+        val codec = jsonCodec<Node>()
+        client.deleteChildren(path)
+        client.putValue("$path/a", Node(1), codec)
+        client.putValue("$path/b", Node(2), codec)
+
+        TypedPathChildrenCache(client, path, codec).use { cache ->
+          cache.start(buildInitial = true)
+          cache.currentData shouldContainExactlyInAnyOrder
+            listOf(TypedChildData("a", Node(1)), TypedChildData("b", Node(2)))
+          cache.getCurrentData("a") shouldBe Node(1)
+          cache.currentDataAsMap shouldBe mapOf("a" to Node(1), "b" to Node(2))
+        }
+      }
+    }
+
+    "typed listener receives decoded CHILD_ADDED, CHILD_UPDATED, and CHILD_REMOVED" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/events"
+        val codec = jsonCodec<Node>()
+        client.deleteChildren(path)
+        val events = CopyOnWriteArrayList<TypedPathChildrenCacheEvent<Node>>()
+
+        TypedPathChildrenCache(client, path, codec).use { cache ->
+          cache.addListener { events += it }
+          cache.start(buildInitial = false)
+
+          client.putValue("$path/k", Node(1), codec)
+          pollUntil(10.seconds) { events.any { it.type == PathChildrenCacheEvent.Type.CHILD_ADDED } } shouldBe true
+          events.first { it.type == PathChildrenCacheEvent.Type.CHILD_ADDED }.data shouldBe Node(1)
+
+          client.putValue("$path/k", Node(2), codec)
+          pollUntil(10.seconds) { events.any { it.type == PathChildrenCacheEvent.Type.CHILD_UPDATED } } shouldBe true
+          events.first { it.type == PathChildrenCacheEvent.Type.CHILD_UPDATED }.data shouldBe Node(2)
+
+          client.deleteKey("$path/k")
+          pollUntil(10.seconds) { events.any { it.type == PathChildrenCacheEvent.Type.CHILD_REMOVED } } shouldBe true
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/EventFlowTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/EventFlowTests.kt
@@ -23,12 +23,14 @@ import io.etcd.recipes.cache.NodeCache
 import io.etcd.recipes.cache.NodeCacheEvent
 import io.etcd.recipes.cache.PathChildrenCache
 import io.etcd.recipes.cache.PathChildrenCacheEvent
+import io.etcd.recipes.cache.TypedPathChildrenCache
 import io.etcd.recipes.common.StringCodec
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.deleteChildren
 import io.etcd.recipes.common.deleteKey
 import io.etcd.recipes.common.getResponse
+import io.etcd.recipes.common.jsonCodec
 import io.etcd.recipes.common.putValue
 import io.etcd.recipes.common.urls
 import io.etcd.recipes.discovery.ServiceCache
@@ -45,6 +47,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.time.Duration.Companion.seconds
 
@@ -55,6 +58,11 @@ import kotlin.time.Duration.Companion.seconds
  */
 class EventFlowTests : StringSpec() {
   private val base = "/coroutines/${javaClass.simpleName}"
+
+  @Serializable
+  data class Payload(
+    val v: String,
+  )
 
   private suspend fun <T> withScope(body: suspend (CoroutineScope) -> T): T {
     val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -122,6 +130,39 @@ class EventFlowTests : StringSpec() {
                 NodeCacheEvent.Type.UPDATED,
                 NodeCacheEvent.Type.DELETED,
               )
+          }
+        }
+      }
+    }
+
+    "typed cache eventsAsFlow delivers decoded child add, update, and remove in order" {
+      connectToEtcd(urls).use { client ->
+        client.deleteChildren(base)
+        val path = "$base/typed-cache"
+        val codec = jsonCodec<Payload>()
+        val seen = CopyOnWriteArrayList<Pair<PathChildrenCacheEvent.Type, Payload?>>()
+
+        TypedPathChildrenCache(client, path, codec).use { cache ->
+          cache.start(buildInitial = true)
+          cache.waitOnStartComplete(10.seconds) shouldBe true
+
+          withScope { scope ->
+            scope.launch { cache.eventsAsFlow().collect { e -> seen += e.type to e.data } }
+            delay(1_000) // let the collector subscribe
+
+            client.putValue("$path/k", Payload("v1"), codec)
+            client.putValue("$path/k", Payload("v2"), codec)
+            client.deleteChildren(path)
+
+            untilTrue(15.seconds) { seen.size == 3 } shouldBe true
+            seen.map { it.first } shouldContainExactly
+              listOf(
+                PathChildrenCacheEvent.Type.CHILD_ADDED,
+                PathChildrenCacheEvent.Type.CHILD_UPDATED,
+                PathChildrenCacheEvent.Type.CHILD_REMOVED,
+              )
+            seen[0].second shouldBe Payload("v1")
+            seen[1].second shouldBe Payload("v2")
           }
         }
       }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/TypedServiceInstanceTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/TypedServiceInstanceTests.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.discovery
+
+import io.etcd.recipes.common.StringCodec
+import io.etcd.recipes.common.jsonCodec
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+
+/**
+ * The typed ServiceInstance payload extensions: a value round-trips through the opaque `jsonPayload`
+ * (which stays the unchanged wire form), and survives the full ServiceInstance JSON round-trip.
+ */
+class TypedServiceInstanceTests : StringSpec() {
+  @Serializable
+  data class Meta(
+    val region: String,
+    val weight: Int,
+  )
+
+  init {
+    "serviceInstance builds an instance whose payload decodes back" {
+      val codec = jsonCodec<Meta>()
+      val meta = Meta("us-east", 5)
+      val si = serviceInstance("svc", meta, codec)
+      si.payload(codec) shouldBe meta
+    }
+
+    "payload survives the full ServiceInstance JSON wire round-trip" {
+      val codec = jsonCodec<Meta>()
+      val meta = Meta("eu-west", 9)
+      val si = serviceInstance("svc", meta, codec) { apply { port = 8080 } }
+      val roundTripped = ServiceInstance.toObject(si.toJson())
+      roundTripped.payload(codec) shouldBe meta
+      roundTripped.port shouldBe 8080
+    }
+
+    "setPayload replaces jsonPayload in place" {
+      val codec = jsonCodec<Meta>()
+      val si = serviceInstance("svc", Meta("a", 1), codec)
+      si.setPayload(Meta("b", 2), codec)
+      si.payload(codec) shouldBe Meta("b", 2)
+    }
+
+    "payload reads a raw jsonPayload through StringCodec" {
+      val si = ServiceInstance("svc", "hello")
+      si.payload(StringCodec) shouldBe "hello"
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TypedTransientKeyValueTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TypedTransientKeyValueTests.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.keyvalue
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteKey
+import io.etcd.recipes.common.getValue
+import io.etcd.recipes.common.jsonCodec
+import io.etcd.recipes.common.pollUntil
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * The typed transient key/value: the value is encoded once through a codec and published under the
+ * lease, readable back through the typed [getValue].
+ */
+class TypedTransientKeyValueTests : StringSpec() {
+  private val base = "/keyvalue/${javaClass.simpleName}"
+
+  @Serializable
+  data class Reg(
+    val host: String,
+    val port: Int,
+  )
+
+  init {
+    "typed transient key publishes an encoded value readable through the codec" {
+      connectToEtcd(urls) { client ->
+        val key = "$base/reg"
+        client.deleteKey(key)
+        val codec = jsonCodec<Reg>()
+        val reg = Reg("h1", 8080)
+        TypedTransientKeyValue(client, key, reg, codec).use { tkv ->
+          pollUntil(10.seconds) { client.getValue(key, codec) == reg } shouldBe true
+          tkv.untyped.isHealthy() shouldBe true
+        }
+      }
+    }
+
+    "typed transient key with autoStart=false publishes only after start()" {
+      connectToEtcd(urls) { client ->
+        val key = "$base/manual"
+        client.deleteKey(key)
+        val codec = jsonCodec<Reg>()
+        val reg = Reg("h2", 9090)
+        TypedTransientKeyValue(client, key, reg, codec, autoStart = false).use { tkv ->
+          client.getValue(key, codec) shouldBe null
+          tkv.start()
+          pollUntil(10.seconds) { client.getValue(key, codec) == reg } shouldBe true
+        }
+      }
+    }
+  }
+}

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/TypedDistributedQueueTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/TypedDistributedQueueTests.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2026 Paul Ambrose
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction")
+
+package io.etcd.recipes.queue
+
+import io.etcd.recipes.common.connectToEtcd
+import io.etcd.recipes.common.deleteChildren
+import io.etcd.recipes.common.jsonCodec
+import io.etcd.recipes.common.urls
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+
+/**
+ * The typed queue wrappers: values round-trip through a codec, FIFO order is preserved, and the
+ * priority variant still dequeues by priority.
+ */
+class TypedDistributedQueueTests : StringSpec() {
+  private val base = "/queue/${javaClass.simpleName}"
+
+  @Serializable
+  data class Msg(
+    val id: Int,
+    val body: String,
+  )
+
+  init {
+    "typed queue round-trips a value through a codec" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/roundtrip"
+        client.deleteChildren(path)
+        TypedDistributedQueue(client, path, jsonCodec<Msg>()).use { queue ->
+          val msg = Msg(1, "hello")
+          queue.enqueue(msg)
+          queue.dequeue() shouldBe msg
+        }
+      }
+    }
+
+    "typed queue preserves FIFO order across enqueue and enqueueAll" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/fifo"
+        client.deleteChildren(path)
+        TypedDistributedQueue(client, path, jsonCodec<Msg>()).use { queue ->
+          queue.enqueue(Msg(1, "a"))
+          queue.enqueueAll(listOf(Msg(2, "b"), Msg(3, "c")))
+          queue.dequeue() shouldBe Msg(1, "a")
+          queue.dequeue() shouldBe Msg(2, "b")
+          queue.dequeue() shouldBe Msg(3, "c")
+        }
+      }
+    }
+
+    "typed priority queue dequeues by ascending priority" {
+      connectToEtcd(urls) { client ->
+        val path = "$base/priority"
+        client.deleteChildren(path)
+        TypedDistributedPriorityQueue(client, path, jsonCodec<Msg>()).use { queue ->
+          queue.enqueue(Msg(5, "low"), priority = 5)
+          queue.enqueue(Msg(1, "high"), priority = 1)
+          queue.enqueue(Msg(3, "mid"), priority = 3)
+          queue.dequeue() shouldBe Msg(1, "high")
+          queue.dequeue() shouldBe Msg(3, "mid")
+          queue.dequeue() shouldBe Msg(5, "low")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Finishes the typed recipe layer (**product idea #6**). The foundation — `EtcdCodec<T>`, built-in codecs, `NodeCache<T>`, typed KV extensions, and the `etcd-recipes-jackson` module — already shipped; this pass gives the four remaining raw-payload recipes typed variants so callers stop hand-marshalling `ByteSequence`/`String`.

**Mechanism: composition wrappers.** Each typed recipe is a new class that wraps the existing (frozen) recipe + an `EtcdCodec<T>`, delegates lifecycle, and encodes/decodes at the value boundary. It touches **no** existing class, so every `DesignFixesTests` / `BugFixesTests` assertion stays green, and reuses the battle-tested recipes verbatim. Each wrapper exposes the underlying recipe as a public `untyped` property, so the full `EtcdConnector` API (`exceptions`, `isHealthy()`, background-exception listeners) stays reachable.

## What's included

- **`TypedDistributedQueue<T>` / `TypedDistributedPriorityQueue<T>`** — `enqueue(T)` / `enqueueAll` / `dequeue(): T` / typed `poll`, plus `withTyped…` scope functions.
- **`TypedPathChildrenCache<T>`** — typed `currentData` / `getCurrentData` / `currentDataAsMap` (`TypedChildData<T>`) and decoded `TypedPathChildrenCacheEvent`s via `TypedPathChildrenCacheListener`; a single internal adapter decodes each underlying event (a decode failure is recorded on `untyped`'s sink and the event skipped). Coroutine `eventsAsFlow()` / `recoveryEventsAsFlow()` twins added to `CacheFlows`.
- **`TypedTransientKeyValue<T>`** — publishes a value encoded once through a codec.
- **`ServiceInstance` typed payload** — additive `payload<T>(codec)` / `setPayload` extensions and a typed `serviceInstance(name, payload, codec)` builder. The `jsonPayload` JSON string stays the **unchanged wire format**.
- **Examples** — runnable `TypedDistributedQueueExample` and `TypedPathChildrenCacheExample` (payload types split into their own files per the repo's `IntPayload.kt` convention).
- **Docs** — README recipe rows + typed-values note; CHANGELOG under `[Unreleased]`.

Codecs for the `String`-valued surfaces (`ServiceInstance`, `TransientKeyValue`) must emit UTF-8 text; the queues and cache carry raw `ByteSequence` and accept any codec.

## Tests

- Real-etcd round-trip / event tests per recipe (`TypedDistributedQueueTests`, `TypedPathChildrenCacheTests`, `TypedTransientKeyValueTests`).
- Pure `TypedServiceInstanceTests` incl. a wire-compat case (`ServiceInstance.toObject(si.toJson()).payload(codec)` == original).
- A typed-cache `eventsAsFlow` case in `EventFlowTests`.

## Verification

Full CI-equivalent gate (`clean check koverXmlReport -PuseTestcontainers`) passes locally: **BUILD SUCCESSFUL**, all-module check incl. `koverVerify` and the frozen `design.*` oracle, zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP