### PR TITLE
Build tooling: dependency bumps, dep-DSL cleanup, and etcd start/stop helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default help clean clean-all stop build tests tests-tc tests-container all-tests coverage kdocs \
+.PHONY: default help clean clean-all stop etcd etcd-stop build tests tests-tc tests-container all-tests coverage kdocs \
         lint detekt detekt-baseline refresh versions publish-local publish-local-snapshot \
         publish-snapshot publish-maven-central upgrade-wrapper \
         _check-gpg-env _require-version _require-gradle-version
@@ -34,6 +34,12 @@ stop: ## Stop running Gradle daemons
 
 build: clean ## Clean and run a full build, skipping tests
 	./gradlew build -x test
+
+etcd: ## Start a local etcd at localhost:2379 (foreground; Ctrl-C to stop)
+	./etcd.sh
+
+etcd-stop: ## Gracefully stop the local etcd started by `make etcd`
+	./etcd-stop.sh
 
 tests: ## Run the full test suite against a local etcd at localhost:2379
 	./gradlew check --rerun-tasks --no-build-cache

--- a/etcd-recipes-examples/build.gradle.kts
+++ b/etcd-recipes-examples/build.gradle.kts
@@ -1,3 +1,3 @@
 dependencies {
-  "implementation"(project(":etcd-recipes"))
+  implementation(project(":etcd-recipes"))
 }

--- a/etcd-recipes-jackson/build.gradle.kts
+++ b/etcd-recipes-jackson/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
-  "implementation"(project(":etcd-recipes"))
+  implementation(project(":etcd-recipes"))
   // Declared inline rather than in the version catalog: this is the only module that
   // needs Jackson, and the catalog is otherwise reserved for shared dependencies.
-  "api"("com.fasterxml.jackson.core:jackson-databind:2.22.1")
+  api("com.fasterxml.jackson.core:jackson-databind:2.22.1")
 }

--- a/etcd-recipes-micrometer/build.gradle.kts
+++ b/etcd-recipes-micrometer/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
-  "implementation"(project(":etcd-recipes"))
+  implementation(project(":etcd-recipes"))
   // Declared inline rather than in the version catalog: this is the only module that
   // needs Micrometer, and the catalog is otherwise reserved for shared dependencies.
-  "api"("io.micrometer:micrometer-core:1.14.2")
+  api("io.micrometer:micrometer-core:1.17.0")
 }

--- a/etcd-recipes-test-runners/build.gradle.kts
+++ b/etcd-recipes-test-runners/build.gradle.kts
@@ -1,9 +1,11 @@
+import org.gradle.kotlin.dsl.implementation
+
 plugins {
     alias(libs.plugins.shadow)
 }
 
 dependencies {
-    "implementation"(project(":etcd-recipes"))
+    implementation(project(":etcd-recipes"))
 }
 
 tasks.shadowJar {
@@ -13,5 +15,10 @@ tasks.shadowJar {
     manifest {
         attributes["Main-Class"] = "io.etcd.recipes.runners.MainKt"
     }
+    // Let all duplicate entries reach the transformers so they merge correctly. With the
+    // default EXCLUDE strategy, Gradle drops duplicate META-INF/*.kotlin_module and
+    // META-INF/services/* entries before the Kotlin-module/service-file transformers can
+    // merge them (Shadow 9 warns about this).
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
 }

--- a/etcd-stop.sh
+++ b/etcd-stop.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# etcd-stop.sh — gracefully stop the local etcd started by etcd.sh
+
+# Match the exact etcd we launch in etcd.sh (avoids killing unrelated etcd procs)
+PIDS=$(pgrep -f 'etcd --listen-client-urls=http://localhost:2379')
+
+if [ -z "$PIDS" ]; then
+  echo "No matching etcd process is running."
+  exit 0
+fi
+
+echo "Stopping etcd (PID: $PIDS) ..."
+kill -TERM $PIDS  # SIGTERM: graceful shutdown, flushes WAL
+
+# Wait up to 10s for a clean exit
+for _ in $(seq 1 20); do
+  pgrep -f 'etcd --listen-client-urls=http://localhost:2379' >/dev/null 2>&1 || {
+    echo "etcd stopped cleanly."
+    exit 0
+  }
+  sleep 0.5
+done
+
+echo "etcd did not exit after SIGTERM; sending SIGKILL ..."
+kill -KILL $PIDS 2>/dev/null
+echo "etcd killed."

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ gradle-wrapper = "9.6.1"
 jvm = "17"
 
 # Kotlin language and runtime
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 coroutines = "1.11.0"
 serialization = "1.11.0"
 
@@ -12,7 +12,7 @@ serialization = "1.11.0"
 jetcd = "0.8.6"
 
 # Runtime libraries
-common-utils = "3.1.0"
+common-utils = "3.2.0"
 guava = "33.6.0-jre"
 kotlin-logging = "8.0.4"
 logback = "1.5.38"


### PR DESCRIPTION
## Summary

Build and dev-tooling housekeeping — no library source changes.

- **Dependency bumps** (`gradle/libs.versions.toml`): kotlin `2.4.0 → 2.4.10`, common-utils `3.1.0 → 3.2.0`; and micrometer-core `1.14.2 → 1.17.0` in the micrometer module.
- **Dependency-DSL cleanup**: normalize the leaf modules to the unquoted type-safe form (`implementation(...)` / `api(...)`) across `etcd-recipes-examples`, `etcd-recipes-micrometer`, `etcd-recipes-jackson`, and `etcd-recipes-test-runners`. (These modules apply their Kotlin/Java plugins via the root `subprojects { apply(...) }` block; the unquoted form resolves via Gradle's generic `org.gradle.kotlin.dsl` dependency extensions.)
- **shadowJar fix** (`etcd-recipes-test-runners`): `duplicatesStrategy = DuplicatesStrategy.INCLUDE` so duplicate `META-INF/*.kotlin_module` and `META-INF/services/*` entries reach the transformers to be merged, silencing the Shadow 9 warning.
- **etcd start/stop helpers**: add `make etcd` / `make etcd-stop` targets and `etcd-stop.sh`, which gracefully stops the local etcd started by `etcd.sh` (SIGTERM, then SIGKILL after a 10s grace period; matches the exact `etcd --listen-client-urls=...` process so it won't kill unrelated etcd instances).

## Verification

These changes were already exercised by every full `-PuseTestcontainers` gate run during the typed-recipe work, which compiled against a working tree that included all of them (kotlin 2.4.10, common-utils 3.2.0, micrometer 1.17.0, the unquoted DSL) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP