### PR TITLE
Convert java.util.concurrent.atomic usages to kotlin.concurrent.atomics

### DIFF
--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/SuspendingLockExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/coroutines/SuspendingLockExample.kt
@@ -29,7 +29,9 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
 
 /**
  * Coroutine-scoped mutual exclusion and concurrency limiting: [withLock] holds a
@@ -43,12 +45,12 @@ fun main() {
   runBlocking {
     connectToEtcd(urls).use { client ->
       DistributedMutex(client, "/examples/coroutines/mutex").use { mutex ->
-        val counter = AtomicInteger(0)
+        val counter = AtomicInt(0)
         coroutineScope {
           repeat(5) { id ->
             launch(Dispatchers.Default) {
               mutex.withLock {
-                val n = counter.incrementAndGet()
+                val n = counter.incrementAndFetch()
                 logger.info { "Worker $id holds the mutex (count=$n)" }
                 delay(100)
               }
@@ -58,15 +60,15 @@ fun main() {
       }
 
       DistributedSemaphore(client, "/examples/coroutines/semaphore", permits = 2).use { semaphore ->
-        val inFlight = AtomicInteger(0)
+        val inFlight = AtomicInt(0)
         coroutineScope {
           repeat(6) { id ->
             launch(Dispatchers.Default) {
               semaphore.withPermit {
-                val now = inFlight.incrementAndGet()
+                val now = inFlight.incrementAndFetch()
                 logger.info { "Worker $id holds a permit ($now of 2 in flight)" }
                 delay(150)
-                inFlight.decrementAndGet()
+                inFlight.decrementAndFetch()
               }
             }
           }

--- a/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/lock/SemaphoreExample.kt
+++ b/etcd-recipes-examples/src/main/kotlin/io/etcd/recipes/examples/lock/SemaphoreExample.kt
@@ -22,7 +22,9 @@ import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.lock.DistributedSemaphore
 import io.etcd.recipes.lock.withPermit
 import io.github.oshai.kotlinlogging.KotlinLogging
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.concurrent.thread
 
 /**
@@ -34,7 +36,7 @@ fun main() {
   val logger = KotlinLogging.logger {}
   val urls = listOf("http://localhost:2379")
   val semaphorePath = "/semaphores/example"
-  val inFlight = AtomicInteger(0)
+  val inFlight = AtomicInt(0)
 
   val workers =
     (1..6).map { worker ->
@@ -42,10 +44,10 @@ fun main() {
         connectToEtcd(urls) { client ->
           DistributedSemaphore(client, semaphorePath, permits = 2).use { semaphore ->
             semaphore.withPermit {
-              val now = inFlight.incrementAndGet()
+              val now = inFlight.incrementAndFetch()
               logger.info { "Worker $worker holds a permit ($now of 2 in flight)" }
               Thread.sleep(500)
-              inFlight.decrementAndGet()
+              inFlight.decrementAndFetch()
             }
           }
         }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/barrier/DistributedBarrier.kt
@@ -43,8 +43,8 @@ import io.etcd.recipes.common.withWatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
@@ -196,7 +196,7 @@ constructor(
           if (observedRevision > 0L) withRevision(observedRevision + 1)
           withNoPut(true)
         }
-      val watchFailure = AtomicReference<Throwable?>()
+      val watchFailure = AtomicReference<Throwable?>(null)
       val recoveryListener = waiterRecoveryListener(barrierPresentAtStart, waitLatch, watchFailure)
 
       client.withWatcher(
@@ -218,7 +218,7 @@ constructor(
           waitLatch.countDown()
 
         val released = waitLatch.await(timeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-        watchFailure.get()?.let { cause ->
+        watchFailure.load()?.let { cause ->
           throw EtcdRecipeRuntimeException("Barrier watch on $barrierPath failed while waiting", cause)
         }
         released
@@ -248,7 +248,7 @@ constructor(
           is WatchRecoveryEvent.Failed -> {
             val cause = event.cause
               ?: EtcdRecipeRuntimeException("Watch on $barrierPath abandoned while waiting on barrier")
-            watchFailure.set(cause)
+            watchFailure.store(cause)
             recordException(cause)
             waitLatch.countDown()
           }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ProviderStrategy.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ProviderStrategy.kt
@@ -18,8 +18,9 @@
 
 package io.etcd.recipes.discovery
 
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.fetchAndIncrement
 
 /**
  * Picks one instance from the currently-available set (a [ServiceProvider]'s live
@@ -40,17 +41,17 @@ object RandomStrategy : ProviderStrategy {
 
 /**
  * Even round-robin via a monotonic cursor. `Math.floorMod` keeps the index non-negative
- * across `AtomicInteger` overflow and adapts automatically to list-size changes.
+ * across `AtomicInt` overflow and adapts automatically to list-size changes.
  *
  * STATEFUL — use a fresh instance per [ServiceProvider]; sharing one across providers
  * interleaves their cursors.
  */
 class RoundRobinStrategy : ProviderStrategy {
-  private val cursor = AtomicInteger(0)
+  private val cursor = AtomicInt(0)
 
   override fun select(instances: List<ServiceInstance>): ServiceInstance? {
     if (instances.isEmpty()) return null
-    return instances[Math.floorMod(cursor.getAndIncrement(), instances.size)]
+    return instances[Math.floorMod(cursor.fetchAndIncrement(), instances.size)]
   }
 }
 
@@ -69,13 +70,13 @@ class StickyStrategy(
   @Suppress("ReturnCount")
   override fun select(instances: List<ServiceInstance>): ServiceInstance? {
     if (instances.isEmpty()) {
-      last.set(null)
+      last.store(null)
       return null
     }
-    val current = last.get()
+    val current = last.load()
     if (current != null && current in instances) return current
     val picked = delegate.select(instances)
-    last.set(picked)
+    last.store(picked)
     return picked
   }
 }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceProvider.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/discovery/ServiceProvider.kt
@@ -27,7 +27,8 @@ import io.etcd.recipes.common.appendToPath
 import io.etcd.recipes.common.asString
 import io.etcd.recipes.common.getChildrenValues
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
@@ -113,9 +114,9 @@ class ServiceProvider
      */
     fun noteError(instance: ServiceInstance) {
       val entry = down.computeIfAbsent(instance) { DownEntry() }
-      if (entry.errors.incrementAndGet() >= errorThreshold) {
+      if (entry.errors.incrementAndFetch() >= errorThreshold) {
         entry.downUntil = TimeSource.Monotonic.markNow() + downPeriod
-        entry.errors.set(0)
+        entry.errors.store(0)
       }
     }
 
@@ -139,7 +140,7 @@ class ServiceProvider
     }
 
     private class DownEntry {
-      val errors = AtomicInteger(0)
+      val errors = AtomicInt(0)
 
       @Volatile
       var downUntil: TimeSource.Monotonic.ValueTimeMark? = null

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderLatch.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderLatch.kt
@@ -28,8 +28,8 @@ import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -146,7 +146,7 @@ class LeaderLatch
         while (true) {
           val sel =
             synchronized(stateLock) {
-              if (closing.get()) return
+              if (closing.load()) return
               LeaderSelector(
                 client,
                 electionPath,
@@ -164,7 +164,7 @@ class LeaderLatch
                 resilience = resilience,
                 interruptOnLeaseLoss = interruptOnLeaseLoss,
               ).also {
-                currentSelector.set(it)
+                currentSelector.store(it)
                 it.start()
               }
             }
@@ -181,7 +181,7 @@ class LeaderLatch
           if (sel.hasExceptions) sel.exceptions.forEach { recordException(it) }
           runCatching { sel.close() }.onFailure { recordException(it) }
 
-          if (closing.get()) return
+          if (closing.load()) return
           // Otherwise the term ended via step-down: loop back and re-contest with a
           // fresh selector (one selector per full term, so no tight spin).
         }
@@ -228,8 +228,8 @@ class LeaderLatch
 
     override fun doClose() {
       synchronized(stateLock) {
-        closing.set(true)
-        currentSelector.get()?.let { runCatching { it.close() } } // unblocks the worker's park
+        closing.store(true)
+        currentSelector.load()?.let { runCatching { it.close() } } // unblocks the worker's park
       }
       worker?.let { w ->
         w.join(closeJoinTimeout.inWholeMilliseconds)

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderObserver.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/election/LeaderObserver.kt
@@ -31,7 +31,7 @@ import io.etcd.recipes.common.getValue
 import io.etcd.recipes.common.watcher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 
 /**
  * Runs [receiver] with a started [LeaderObserver], closing it on exit.
@@ -74,7 +74,7 @@ class LeaderObserver
     private var watcher: Watch.Watcher? = null
 
     /** The current leader's clientId, or null when the election is vacant. */
-    val currentLeader: String? get() = currentLeaderRef.get()
+    val currentLeader: String? get() = currentLeaderRef.load()
 
     fun addListener(listener: LeaderListener) {
       listeners += listener
@@ -91,7 +91,7 @@ class LeaderObserver
         throw EtcdRecipeRuntimeException("start() already called")
       // Seed the snapshot: a listener registered before start() reads currentLeader; only
       // CHANGES (PUT/DELETE) fire callbacks, so no synthetic take/relinquish is emitted.
-      currentLeaderRef.set(readLeader())
+      currentLeaderRef.store(readLeader())
       watcher =
         client.watcher(
           leaderKey,
@@ -117,7 +117,7 @@ class LeaderObserver
 
     @Suppress("TooGenericExceptionCaught")
     private fun setLeader(name: String) {
-      currentLeaderRef.set(name)
+      currentLeaderRef.store(name)
       listeners.forEach { listener ->
         try {
           listener.takeLeadership(name)
@@ -131,7 +131,7 @@ class LeaderObserver
 
     @Suppress("TooGenericExceptionCaught")
     private fun clearLeader() {
-      currentLeaderRef.set(null)
+      currentLeaderRef.store(null)
       listeners.forEach { listener ->
         try {
           listener.relinquishLeadership()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/DistributedSemaphore.kt
@@ -40,9 +40,10 @@ import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.concurrent.atomics.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
 import kotlin.time.TimeSource
@@ -112,14 +113,14 @@ class DistributedSemaphore
     val entryKey: String,
   ) {
     val phase = AtomicReference(Phase.WAITING)
-    val wake = java.util.concurrent.atomic.AtomicReference<CountDownLatch?>(null)
+    val wake = AtomicReference<CountDownLatch?>(null)
 
     @Volatile
     var holdData: PermitData? = null
   }
 
   private val holds = ConcurrentLinkedDeque<PermitData>()
-  private val dispossessedCount = AtomicInteger(0)
+  private val dispossessedCount = AtomicInt(0)
   private val lostListeners = CopyOnWriteArrayList<PermitLostListener>()
   private val attempts = CopyOnWriteArrayList<Attempt>()
   private val permitsValidated = AtomicBoolean(false)
@@ -167,7 +168,7 @@ class DistributedSemaphore
       return true
     }
     while (true) {
-      val slots = dispossessedCount.get()
+      val slots = dispossessedCount.load()
       if (slots <= 0) break
       if (dispossessedCount.compareAndSet(slots, slots - 1)) {
         logger.debug { "release() on $semaphorePath after the permit was lost or released by close()" }
@@ -286,7 +287,7 @@ class DistributedSemaphore
           }
 
           val latch = CountDownLatch(1)
-          attempt.wake.set(latch)
+          attempt.wake.store(latch)
           if (attempt.phase.load() == Phase.DEAD) latch.countDown() // fatal raced the install
           WaiterSupport.awaitPrefixDeletion(
             client,
@@ -302,7 +303,7 @@ class DistributedSemaphore
             reportRecovery = { event -> reportRecoveryEvent(event) },
             recordException = { e -> recordException(e) },
           )
-          attempt.wake.set(null)
+          attempt.wake.store(null)
           // Loop: re-evaluate the rank (it only shrinks while the entry lives)
         }
       } finally {
@@ -351,7 +352,7 @@ class DistributedSemaphore
       recordException(
         cause ?: EtcdRecipeRuntimeException("Semaphore entry lease expired while waiting on $semaphorePath"),
       )
-      attempt.wake.get()?.countDown()
+      attempt.wake.load()?.countDown()
     } else if (attempt.phase.load() == Phase.HOLDING) {
       permitLost(attempt, cause)
     }
@@ -365,7 +366,7 @@ class DistributedSemaphore
     withRecipeLoggingContext {
       val data = attempt.holdData ?: return
       if (!holds.remove(data)) return // already released, or close() took it
-      dispossessedCount.incrementAndGet()
+      dispossessedCount.incrementAndFetch()
       logger.warn(cause) { "Permit on $semaphorePath lost by $clientId (lease expired)" }
       recordException(cause ?: EtcdRecipeRuntimeException("Permit lease for $semaphorePath expired; permit lost"))
       reportLeaseEvent(LeaseEvent.Expired(-1L, cause))
@@ -385,12 +386,12 @@ class DistributedSemaphore
   override fun doClose() {
     while (true) {
       val data = holds.pollFirst() ?: break
-      dispossessedCount.incrementAndGet()
+      dispossessedCount.incrementAndFetch()
       data.lease.close()
     }
     attempts.toList().forEach { attempt ->
       if (attempt.phase.compareAndSet(Phase.WAITING, Phase.DEAD)) {
-        attempt.wake.get()?.countDown()
+        attempt.wake.load()?.countDown()
       }
     }
     lostListeners.clear()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/WaiterSupport.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/lock/WaiterSupport.kt
@@ -30,7 +30,7 @@ import io.etcd.recipes.common.watchOption
 import io.etcd.recipes.common.withWatcher
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
 
@@ -123,7 +123,7 @@ internal object WaiterSupport {
     reportRecovery: (WatchRecoveryEvent) -> Unit,
     recordException: (Throwable) -> Unit,
   ) {
-    val failure = AtomicReference<Throwable?>()
+    val failure = AtomicReference<Throwable?>(null)
     val recoveryListener =
       WatchRecoveryListener { event ->
         reportRecovery(event)
@@ -135,7 +135,7 @@ internal object WaiterSupport {
 
           is WatchRecoveryEvent.Failed -> {
             val cause = event.cause ?: EtcdRecipeRuntimeException("Watch on $watchKey abandoned while waiting")
-            failure.set(cause)
+            failure.store(cause)
             recordException(cause)
             latch.countDown()
           }
@@ -166,7 +166,7 @@ internal object WaiterSupport {
           latch.await(remaining.inWholeMilliseconds, TimeUnit.MILLISECONDS)
         }
       }
-      failure.get()?.let { cause ->
+      failure.load()?.let { cause ->
         throw EtcdRecipeRuntimeException("Lock watch on $watchKey failed while waiting", cause)
       }
     }

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/AbstractQueue.kt
@@ -40,7 +40,7 @@ import io.etcd.recipes.common.withWatcher
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
 import kotlin.time.TimeSource
@@ -138,8 +138,8 @@ abstract class AbstractQueue(
         isPrefix(true)
         withNoDelete(true)
       }
-    val keyFound = AtomicReference<KeyValue?>()
-    val watchFailure = AtomicReference<Throwable?>()
+    val keyFound = AtomicReference<KeyValue?>(null)
+    val watchFailure = AtomicReference<Throwable?>(null)
     val recoveryListener = waiterRecoveryListener(watchLatch, keyFound, watchFailure)
 
     return client.withWatcher(
@@ -170,7 +170,7 @@ abstract class AbstractQueue(
         val waitingChildList = client.getFirstChild(queuePath, target, resilience.rpc).kvs
         if (waitingChildList.isNotEmpty()) {
           synchronized(watchLatch) {
-            keyFound.set(waitingChildList.first())
+            keyFound.store(waitingChildList.first())
             if (watchLatch.count > 0) watchLatch.countDown()
           }
         }
@@ -192,9 +192,9 @@ abstract class AbstractQueue(
       // highest-priority (KEY) / oldest (MOD) item. Fall back to the watcher's event only if the re-query is
       // empty (a concurrent consumer already took the head) — the deleteRevKey CAS and
       // the outer retry loop then still guarantee no loss or duplication.
-      val head = client.getFirstChild(queuePath, target, resilience.rpc).kvs.firstOrNull() ?: keyFound.get()
+      val head = client.getFirstChild(queuePath, target, resilience.rpc).kvs.firstOrNull() ?: keyFound.load()
       if (head == null) {
-        watchFailure.get()?.let { cause ->
+        watchFailure.load()?.let { cause ->
           throw EtcdRecipeRuntimeException("Queue watch on $queuePath failed while waiting for an item", cause)
         }
       }
@@ -229,7 +229,7 @@ abstract class AbstractQueue(
           is WatchRecoveryEvent.Failed -> {
             val cause = event.cause
               ?: EtcdRecipeRuntimeException("Watch on $queuePath abandoned while waiting for an item")
-            watchFailure.set(cause)
+            watchFailure.store(cause)
             recordException(cause)
             synchronized(watchLatch) {
               if (watchLatch.count > 0) watchLatch.countDown()

--- a/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
+++ b/etcd-recipes/src/main/kotlin/io/etcd/recipes/queue/DistributedWorkQueue.kt
@@ -59,7 +59,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.random.Random
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
@@ -435,7 +435,7 @@ class DistributedWorkQueue
   // reclaiming even when nothing is enqueued.
   private fun awaitItem(deadline: ComparableTimeMark?) {
     val latch = CountDownLatch(1)
-    val watchFailure = AtomicReference<Throwable?>()
+    val watchFailure = AtomicReference<Throwable?>(null)
     val recoveryListener =
       WatchRecoveryListener { event ->
         withRecipeLoggingContext {
@@ -450,7 +450,7 @@ class DistributedWorkQueue
             is WatchRecoveryEvent.Failed -> {
               val cause = event.cause
                 ?: EtcdRecipeRuntimeException("Watch on $itemsPath abandoned while waiting for work")
-              watchFailure.set(cause)
+              watchFailure.store(cause)
               recordException(cause)
               latch.countDown()
             }
@@ -488,7 +488,7 @@ class DistributedWorkQueue
       if (wait > Duration.ZERO) {
         latch.await(wait.inWholeMilliseconds, TimeUnit.MILLISECONDS)
       }
-      watchFailure.get()?.let { cause ->
+      watchFailure.load()?.let { cause ->
         throw EtcdRecipeRuntimeException("Work-queue watch on $itemsPath failed while waiting", cause)
       }
     }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierLeaseHealTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierLeaseHealTests.kt
@@ -26,7 +26,7 @@ import io.etcd.recipes.common.pollUntil
 import io.etcd.recipes.common.urls
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -75,8 +75,8 @@ class BarrierLeaseHealTests : StringSpec() {
         val barrierPath = "$path/counted"
         val waitingPath = "$barrierPath/waiting"
         DistributedBarrierWithCount(client, barrierPath, memberCount = 2).use { barrier ->
-          val released = AtomicReference<Boolean?>()
-          val waiter = thread { released.set(barrier.waitOnBarrier(1.minutes)) }
+          val released = AtomicReference<Boolean?>(null)
+          val waiter = thread { released.store(barrier.waitOnBarrier(1.minutes)) }
 
           pollUntil(20.seconds) { client.getChildrenKeys(waitingPath).size == 1 } shouldBe true
           val waiterKey = client.getChildrenKeys(waitingPath).first()
@@ -91,7 +91,7 @@ class BarrierLeaseHealTests : StringSpec() {
           DistributedBarrierWithCount(client, barrierPath, memberCount = 2).use { second ->
             second.waitOnBarrier(1.minutes) shouldBe true
           }
-          pollUntil(20.seconds) { released.get() == true } shouldBe true
+          pollUntil(20.seconds) { released.load() == true } shouldBe true
           waiter.join(5_000)
         }
       }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWatchRecoveryTests.kt
@@ -35,8 +35,9 @@ import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -58,14 +59,14 @@ class BarrierWatchRecoveryTests : StringSpec() {
   ) {
     val listeners = CopyOnWriteArrayList<Watch.Listener>()
     val options = CopyOnWriteArrayList<WatchOption>()
-    private val probeCount = AtomicInteger(0)
+    private val probeCount = AtomicInt(0)
 
     val client: Client =
       mockk {
         every { kvClient } returns
           mockk<KV> {
             every { txn() } answers {
-              val present = probeCount.incrementAndGet() <= presentProbes
+              val present = probeCount.incrementAndFetch() <= presentProbes
               mockk<Txn> {
                 every { If(*anyVararg()) } returns this
                 every { Then(*anyVararg()) } returns this
@@ -117,25 +118,25 @@ class BarrierWatchRecoveryTests : StringSpec() {
     "waiter releases after recovery when the barrier DELETE happened during the outage" {
       // Probe #1 (presence at wait start): present. Later probes (recovery recheck): absent.
       val mocks = BarrierMocks(presentProbes = 1)
-      val released = AtomicReference<Boolean?>()
-      val error = AtomicReference<Throwable?>()
+      val released = AtomicReference<Boolean?>(null)
+      val error = AtomicReference<Throwable?>(null)
 
       DistributedBarrier(mocks.client, "/barrier/recovery").use { barrier ->
         val waiter =
           thread(name = "barrier-waiter") {
             try {
-              released.set(barrier.waitOnBarrier(1.minutes))
+              released.store(barrier.waitOnBarrier(1.minutes))
             } catch (e: Throwable) {
-              error.set(e)
+              error.store(e)
             }
           }
 
         pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
         mocks.listeners.first().die()
 
-        pollUntil(10.seconds) { released.get() != null || error.get() != null } shouldBe true
-        error.get() shouldBe null
-        released.get() shouldBe true
+        pollUntil(10.seconds) { released.load() != null || error.load() != null } shouldBe true
+        error.load() shouldBe null
+        released.load() shouldBe true
         waiter.join(5_000)
       }
     }
@@ -143,8 +144,8 @@ class BarrierWatchRecoveryTests : StringSpec() {
     "waiter fails fast when watch recovery is abandoned" {
       // Barrier stays present; recovery disabled: the wait must error, not park.
       val mocks = BarrierMocks(presentProbes = Int.MAX_VALUE)
-      val released = AtomicReference<Boolean?>()
-      val error = AtomicReference<Throwable?>()
+      val released = AtomicReference<Boolean?>(null)
+      val error = AtomicReference<Throwable?>(null)
 
       DistributedBarrier(
         mocks.client,
@@ -154,18 +155,18 @@ class BarrierWatchRecoveryTests : StringSpec() {
         val waiter =
           thread(name = "barrier-waiter") {
             try {
-              released.set(barrier.waitOnBarrier(1.minutes))
+              released.store(barrier.waitOnBarrier(1.minutes))
             } catch (e: Throwable) {
-              error.set(e)
+              error.store(e)
             }
           }
 
         pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
         mocks.listeners.first().die()
 
-        pollUntil(10.seconds) { error.get() != null } shouldBe true
-        error.get().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
-        released.get() shouldBe null
+        pollUntil(10.seconds) { error.load() != null } shouldBe true
+        error.load().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
+        released.load() shouldBe null
         waiter.join(5_000)
       }
     }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWithCountWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/BarrierWithCountWatchRecoveryTests.kt
@@ -40,8 +40,9 @@ import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -64,14 +65,14 @@ class BarrierWithCountWatchRecoveryTests : StringSpec() {
   ) {
     val listeners = CopyOnWriteArrayList<Watch.Listener>()
     val options = CopyOnWriteArrayList<WatchOption>()
-    private val txnCount = AtomicInteger(0)
+    private val txnCount = AtomicInt(0)
 
     val client: Client =
       mockk {
         every { kvClient } returns
           mockk<KV> {
             every { txn() } answers {
-              val n = txnCount.incrementAndGet()
+              val n = txnCount.incrementAndFetch()
               val succeeded = if (n <= 2) true else (n - 2) <= readyPresentProbes
               mockk<Txn> {
                 every { If(*anyVararg()) } returns this
@@ -138,25 +139,25 @@ class BarrierWithCountWatchRecoveryTests : StringSpec() {
       // Ready-key probes: 2 present (initial checkWaiterCount + pre-park recheck),
       // then absent (deleted during the dead-stream window).
       val mocks = CountBarrierMocks(readyPresentProbes = 2)
-      val released = AtomicReference<Boolean?>()
-      val error = AtomicReference<Throwable?>()
+      val released = AtomicReference<Boolean?>(null)
+      val error = AtomicReference<Throwable?>(null)
 
       DistributedBarrierWithCount(mocks.client, "/barrier/count", memberCount = 2).use { barrier ->
         val waiter =
           thread(name = "count-barrier-waiter") {
             try {
-              released.set(barrier.waitOnBarrier(1.minutes))
+              released.store(barrier.waitOnBarrier(1.minutes))
             } catch (e: Throwable) {
-              error.set(e)
+              error.store(e)
             }
           }
 
         pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
         mocks.listeners.first().die()
 
-        pollUntil(10.seconds) { released.get() != null || error.get() != null } shouldBe true
-        error.get() shouldBe null
-        released.get() shouldBe true
+        pollUntil(10.seconds) { released.load() != null || error.load() != null } shouldBe true
+        error.load() shouldBe null
+        released.load() shouldBe true
         waiter.join(5_000)
       }
     }
@@ -164,8 +165,8 @@ class BarrierWithCountWatchRecoveryTests : StringSpec() {
     "counted waiter fails fast when watch recovery is abandoned" {
       // Ready key stays present; recovery disabled: the wait must error, not park.
       val mocks = CountBarrierMocks(readyPresentProbes = Int.MAX_VALUE)
-      val released = AtomicReference<Boolean?>()
-      val error = AtomicReference<Throwable?>()
+      val released = AtomicReference<Boolean?>(null)
+      val error = AtomicReference<Throwable?>(null)
 
       DistributedBarrierWithCount(
         mocks.client,
@@ -176,18 +177,18 @@ class BarrierWithCountWatchRecoveryTests : StringSpec() {
         val waiter =
           thread(name = "count-barrier-waiter") {
             try {
-              released.set(barrier.waitOnBarrier(1.minutes))
+              released.store(barrier.waitOnBarrier(1.minutes))
             } catch (e: Throwable) {
-              error.set(e)
+              error.store(e)
             }
           }
 
         pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
         mocks.listeners.first().die()
 
-        pollUntil(10.seconds) { error.get() != null } shouldBe true
-        error.get().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
-        released.get() shouldBe null
+        pollUntil(10.seconds) { error.load() != null } shouldBe true
+        error.load().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
+        released.load() shouldBe null
         waiter.join(5_000)
       }
     }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierTests.kt
@@ -34,8 +34,9 @@ import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 class DistributedBarrierTests : StringSpec() {
@@ -52,8 +53,8 @@ class DistributedBarrierTests : StringSpec() {
             val setBarrierLatch = CountDownLatch(1)
             val completeLatch = CountDownLatch(1)
             val removeBarrierTime = AtomicLong(0L)
-            val timeoutCount = AtomicInteger(0)
-            val advancedCount = AtomicInteger(0)
+            val timeoutCount = AtomicInt(0)
+            val advancedCount = AtomicInt(0)
 
             connectToEtcd(urls) { client ->
 
@@ -75,7 +76,7 @@ class DistributedBarrierTests : StringSpec() {
                         sleep(6.seconds)
 
                         logger.info { "Removing Barrier" }
-                        removeBarrierTime.set(System.currentTimeMillis())
+                        removeBarrierTime.store(System.currentTimeMillis())
                         val isRemoved = removeBarrier()
                         isRemoved.shouldBeTrue()
 
@@ -93,14 +94,14 @@ class DistributedBarrierTests : StringSpec() {
                         logger.info { "$i Waiting on Barrier" }
                         waitOnBarrier(1.seconds)
 
-                        timeoutCount.incrementAndGet()
+                        timeoutCount.incrementAndFetch()
 
                         logger.info { "$i Timed out waiting on barrier, waiting again" }
                         waitOnBarrier()
 
                         // Make sure the waiter advanced quickly
-                        System.currentTimeMillis() - removeBarrierTime.get() shouldBeLessThan 500L
-                        advancedCount.incrementAndGet()
+                        System.currentTimeMillis() - removeBarrierTime.load() shouldBeLessThan 500L
+                        advancedCount.incrementAndFetch()
 
                         logger.debug { "$i Done Waiting on Barrier" }
                     }
@@ -109,8 +110,8 @@ class DistributedBarrierTests : StringSpec() {
 
             completeLatch.await()
 
-            timeoutCount.get() shouldBe count
-            advancedCount.get() shouldBe count
+            timeoutCount.load() shouldBe count
+            advancedCount.load() shouldBe count
 
             logger.debug { "Done" }
         }
@@ -119,8 +120,8 @@ class DistributedBarrierTests : StringSpec() {
             val path = "/barriers/earlyDistributedBarrierTests"
             val count = 10
             val removeBarrierTime = AtomicLong(0L)
-            val timeoutCount = AtomicInteger(0)
-            val advancedCount = AtomicInteger(0)
+            val timeoutCount = AtomicInt(0)
+            val advancedCount = AtomicInt(0)
 
             connectToEtcd(urls) { client ->
 
@@ -130,14 +131,14 @@ class DistributedBarrierTests : StringSpec() {
                             logger.debug { "$i Waiting on Barrier" }
                             waitOnBarrier(1, TimeUnit.SECONDS)
 
-                            timeoutCount.incrementAndGet()
+                            timeoutCount.incrementAndFetch()
 
                             logger.debug { "$i Timed out waiting on barrier, waiting again" }
                             waitOnBarrier()
 
                             // Make sure the waiter advanced quickly
-                            System.currentTimeMillis() - removeBarrierTime.get() shouldBeLessThan 500L
-                            advancedCount.incrementAndGet()
+                            System.currentTimeMillis() - removeBarrierTime.load() shouldBeLessThan 500L
+                            advancedCount.incrementAndFetch()
 
                             logger.debug { "$i Done Waiting on Barrier" }
                         }
@@ -161,7 +162,7 @@ class DistributedBarrierTests : StringSpec() {
                     sleep(6.seconds)
 
                     logger.debug { "Removing Barrier" }
-                    removeBarrierTime.set(System.currentTimeMillis())
+                    removeBarrierTime.store(System.currentTimeMillis())
                     removeBarrier()
 
                     sleep(3.seconds)
@@ -172,8 +173,8 @@ class DistributedBarrierTests : StringSpec() {
                 holder.checkForException()
             }
 
-            timeoutCount.get() shouldBe count
-            advancedCount.get() shouldBe count
+            timeoutCount.load() shouldBe count
+            advancedCount.load() shouldBe count
 
             logger.debug { "Done" }
         }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCountTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedBarrierWithCountTests.kt
@@ -30,7 +30,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 class DistributedBarrierWithCountTests : StringSpec() {
@@ -47,8 +48,8 @@ class DistributedBarrierWithCountTests : StringSpec() {
             val count = 30
             val retryAttempts = 5
             val retryLatch = CountDownLatch(count - 1)
-            val retryCounter = AtomicInteger(0)
-            val advancedCounter = AtomicInteger(0)
+            val retryCounter = AtomicInt(0)
+            val advancedCounter = AtomicInt(0)
 
             fun waiter(
               id: Int,
@@ -61,7 +62,7 @@ class DistributedBarrierWithCountTests : StringSpec() {
                 repeat(retryCount) {
                     barrier.waitOnBarrier(1.seconds)
                     logger.debug { "#$id Timed out waiting on barrier, waiting again" }
-                    retryCounter.incrementAndGet()
+                    retryCounter.incrementAndFetch()
                 }
 
                 retryLatch.countDown()
@@ -69,7 +70,7 @@ class DistributedBarrierWithCountTests : StringSpec() {
                 logger.debug { "#$id Waiter count = ${barrier.waiterCount}" }
                 barrier.waitOnBarrier()
 
-                advancedCounter.incrementAndGet()
+                advancedCounter.incrementAndFetch()
 
                 logger.debug { "#$id Done waiting on barrier" }
             }
@@ -99,8 +100,8 @@ class DistributedBarrierWithCountTests : StringSpec() {
                 holder.checkForException()
             }
 
-            retryCounter.get() shouldBe retryAttempts * (count - 1)
-            advancedCounter.get() shouldBe count
+            retryCounter.load() shouldBe retryAttempts * (count - 1)
+            advancedCounter.load() shouldBe count
 
             logger.debug { "Done" }
         }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedDoubleBarrierTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/barrier/DistributedDoubleBarrierTests.kt
@@ -31,7 +31,8 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -52,10 +53,10 @@ class DistributedDoubleBarrierTests : StringSpec() {
             val leaveLatch = CountDownLatch(count - 1)
             val doneLatch = CountDownLatch(count)
 
-            val enterRetryCounter = AtomicInteger(0)
-            val leaveRetryCounter = AtomicInteger(0)
-            val enterCounter = AtomicInteger(0)
-            val leaveCounter = AtomicInteger(0)
+            val enterRetryCounter = AtomicInt(0)
+            val leaveRetryCounter = AtomicInt(0)
+            val enterCounter = AtomicInt(0)
+            val leaveCounter = AtomicInt(0)
 
             fun enterBarrier(
               id: Int,
@@ -68,14 +69,14 @@ class DistributedDoubleBarrierTests : StringSpec() {
                         barrier.enter(1000.random().milliseconds)
                     else
                         barrier.enter(1000, TimeUnit.MILLISECONDS)
-                    enterRetryCounter.incrementAndGet()
+                    enterRetryCounter.incrementAndFetch()
                     logger.debug { "#$id Timed out entering barrier" }
                 }
 
                 enterLatch.countDown()
                 logger.debug { "#$id Waiting to enter barrier" }
                 barrier.enter()
-                enterCounter.incrementAndGet()
+                enterCounter.incrementAndFetch()
 
                 logger.debug { "#$id Entered barrier" }
             }
@@ -91,14 +92,14 @@ class DistributedDoubleBarrierTests : StringSpec() {
                         barrier.leave(1000.random().milliseconds)
                     else
                         barrier.leave(1000, TimeUnit.MILLISECONDS)
-                    leaveRetryCounter.incrementAndGet()
+                    leaveRetryCounter.incrementAndFetch()
                     logger.debug { "#$id Timed out leaving barrier" }
                 }
 
                 leaveLatch.countDown()
                 logger.debug { "#$id Waiting to leave barrier" }
                 barrier.leave()
-                leaveCounter.incrementAndGet()
+                leaveCounter.incrementAndFetch()
                 logger.debug { "#$id Left barrier" }
                 doneLatch.countDown()
             }
@@ -134,11 +135,11 @@ class DistributedDoubleBarrierTests : StringSpec() {
                 holder.checkForException()
             }
 
-            enterRetryCounter.get() shouldBe retryAttempts * (count - 1)
-            enterCounter.get() shouldBe count
+            enterRetryCounter.load() shouldBe retryAttempts * (count - 1)
+            enterCounter.load() shouldBe count
 
-            leaveRetryCounter.get() shouldBe retryAttempts * (count - 1)
-            leaveCounter.get() shouldBe count
+            leaveRetryCounter.load() shouldBe retryAttempts * (count - 1)
+            leaveCounter.load() shouldBe count
 
             logger.debug { "Done" }
         }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/NodeCacheResyncTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/NodeCacheResyncTests.kt
@@ -36,7 +36,8 @@ import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -51,7 +52,7 @@ class NodeCacheResyncTests : StringSpec() {
   ) {
     val listeners = CopyOnWriteArrayList<Watch.Listener>()
     val options = CopyOnWriteArrayList<WatchOption>()
-    private val getCount = AtomicInteger(0)
+    private val getCount = AtomicInt(0)
 
     private fun kv(value: String): KeyValue =
       mockk {
@@ -60,7 +61,7 @@ class NodeCacheResyncTests : StringSpec() {
 
     // GET #1 (initial snapshot): value "1" at revision 10. Every later GET (resync): "2" at 20.
     private fun getResponse(): GetResponse {
-      val first = getCount.incrementAndGet() == 1
+      val first = getCount.incrementAndFetch() == 1
       return mockk {
         every { kvs } returns listOf(kv(if (first) "1" else "2"))
         every { isMore } returns false

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheApiTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheApiTests.kt
@@ -26,7 +26,8 @@ import io.etcd.recipes.common.urls
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 
 /**
  * Covers the snapshot-accessor side of [PathChildrenCache] — currentData,
@@ -80,15 +81,15 @@ class PathChildrenCacheApiTests : StringSpec() {
                 client.deleteChildren(path)
 
                 PathChildrenCache(client, path).use { cache ->
-                    val events = AtomicInteger(0)
-                    cache.addListener { events.incrementAndGet() }
+                    val events = AtomicInt(0)
+                    cache.addListener { events.incrementAndFetch() }
                     cache.clearListeners()
                     cache.start(buildInitial = true)
 
                     client.putValue("$path/x", "v")
                     // Give any incorrectly-retained listener a chance to fire.
                     Thread.sleep(1000)
-                    events.get() shouldBe 0
+                    events.load() shouldBe 0
                 }
 
                 client.deleteChildren(path)

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheRebuildTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheRebuildTests.kt
@@ -24,7 +24,7 @@ import io.etcd.recipes.common.putValue
 import io.etcd.recipes.common.urls
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
@@ -56,17 +56,17 @@ class PathChildrenCacheRebuildTests : StringSpec() {
                     val stop = AtomicBoolean(false)
                     val reader =
                         thread {
-                            while (!stop.get()) {
-                                if (cache.currentDataAsMap.isEmpty()) sawEmpty.set(true)
+                            while (!stop.load()) {
+                                if (cache.currentDataAsMap.isEmpty()) sawEmpty.store(true)
                             }
                         }
 
                     repeat(100) { cache.rebuild() }
 
-                    stop.set(true)
+                    stop.store(true)
                     reader.join(5_000)
 
-                    sawEmpty.get() shouldBe false
+                    sawEmpty.load() shouldBe false
                     cache.currentDataAsMap.size shouldBe childCount
                 }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheResyncTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheResyncTests.kt
@@ -36,7 +36,8 @@ import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -51,7 +52,7 @@ class PathChildrenCacheResyncTests : StringSpec() {
   ) {
     val listeners = CopyOnWriteArrayList<Watch.Listener>()
     val options = CopyOnWriteArrayList<WatchOption>()
-    private val getCount = AtomicInteger(0)
+    private val getCount = AtomicInt(0)
 
     private fun kv(
       name: String,
@@ -65,7 +66,7 @@ class PathChildrenCacheResyncTests : StringSpec() {
     // GET #1 (initial snapshot): {a=1} at revision 10. Every later GET (resync
     // snapshot): {a=2, b=3} at revision 20.
     private fun getResponse(): GetResponse {
-      val first = getCount.incrementAndGet() == 1
+      val first = getCount.incrementAndFetch() == 1
       return mockk {
         every { kvs } returns
           if (first) listOf(kv("a", "1")) else listOf(kv("a", "2"), kv("b", "3"))

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/cache/PathChildrenCacheTests.kt
@@ -35,7 +35,8 @@ import io.etcd.recipes.common.putValuesWithKeepAlive
 import io.etcd.recipes.common.urls
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.seconds
 
@@ -69,10 +70,10 @@ class PathChildrenCacheTests : StringSpec() {
         "listenerTestNoInitialData" {
             val count = 25
             val path = "/cache/listenerTestNoInitialData"
-            val addCount = AtomicInteger(0)
-            val updateCount = AtomicInteger(0)
-            val deleteCount = AtomicInteger(0)
-            val initCount = AtomicInteger(0)
+            val addCount = AtomicInt(0)
+            val updateCount = AtomicInt(0)
+            val deleteCount = AtomicInt(0)
+            val initCount = AtomicInt(0)
 
             connectToEtcd(urls) { client ->
 
@@ -83,10 +84,10 @@ class PathChildrenCacheTests : StringSpec() {
                 withPathChildrenCache(client, path) {
                     addListener { event: PathChildrenCacheEvent ->
                         when (event.type) {
-                            CHILD_ADDED -> addCount.incrementAndGet()
-                            CHILD_UPDATED -> updateCount.incrementAndGet()
-                            CHILD_REMOVED -> deleteCount.incrementAndGet()
-                            INITIALIZED -> initCount.incrementAndGet()
+                            CHILD_ADDED -> addCount.incrementAndFetch()
+                            CHILD_UPDATED -> updateCount.incrementAndFetch()
+                            CHILD_REMOVED -> deleteCount.incrementAndFetch()
+                            INITIALIZED -> initCount.incrementAndFetch()
                         }
                     }
 
@@ -94,10 +95,10 @@ class PathChildrenCacheTests : StringSpec() {
                     waitOnStartComplete()
                     currentData shouldBe emptyList()
 
-                    addCount.get() shouldBe 0
-                    updateCount.get() shouldBe 0
-                    deleteCount.get() shouldBe 0
-                    initCount.get() shouldBe 0
+                    addCount.load() shouldBe 0
+                    updateCount.load() shouldBe 0
+                    deleteCount.load() shouldBe 0
+                    initCount.load() shouldBe 0
 
                     val kvs = generateTestData(count)
 
@@ -106,29 +107,29 @@ class PathChildrenCacheTests : StringSpec() {
                         client.putValue("$path/${kv.first}", kv.second + suffix)
                     }
 
-                    pollUntil(settle) { addCount.get() == count && updateCount.get() == count } shouldBe true
+                    pollUntil(settle) { addCount.load() == count && updateCount.load() == count } shouldBe true
                     compareData(count, currentData, kvs, suffix)
 
                     client.deleteChildren(path)
 
-                    pollUntil(settle) { deleteCount.get() == count && currentData.isEmpty() } shouldBe true
+                    pollUntil(settle) { deleteCount.load() == count && currentData.isEmpty() } shouldBe true
                     currentData shouldBe emptyList()
                 }
             }
 
-            addCount.get() shouldBe count
-            updateCount.get() shouldBe count
-            deleteCount.get() shouldBe count
-            initCount.get() shouldBe 0
+            addCount.load() shouldBe count
+            updateCount.load() shouldBe count
+            deleteCount.load() shouldBe count
+            initCount.load() shouldBe 0
         }
 
         "listenerTestWithInitialData" {
             val count = 25
             val path = "/cache/listenerTestWithInitialData"
-            val addCount = AtomicInteger(0)
-            val updateCount = AtomicInteger(0)
-            val deleteCount = AtomicInteger(0)
-            val initCount = AtomicInteger(0)
+            val addCount = AtomicInt(0)
+            val updateCount = AtomicInt(0)
+            val deleteCount = AtomicInt(0)
+            val initCount = AtomicInt(0)
 
             connectToEtcd(urls) { client ->
 
@@ -146,10 +147,10 @@ class PathChildrenCacheTests : StringSpec() {
                 withPathChildrenCache(client, path) {
                     addListener { event: PathChildrenCacheEvent ->
                         when (event.type) {
-                            CHILD_ADDED -> addCount.incrementAndGet()
-                            CHILD_UPDATED -> updateCount.incrementAndGet()
-                            CHILD_REMOVED -> deleteCount.incrementAndGet()
-                            INITIALIZED -> initCount.incrementAndGet()
+                            CHILD_ADDED -> addCount.incrementAndFetch()
+                            CHILD_UPDATED -> updateCount.incrementAndFetch()
+                            CHILD_REMOVED -> deleteCount.incrementAndFetch()
+                            INITIALIZED -> initCount.incrementAndFetch()
                         }
                     }
 
@@ -159,31 +160,31 @@ class PathChildrenCacheTests : StringSpec() {
                     pollUntil(settle) { currentData.size == count } shouldBe true
                     compareData(count, currentData, testKvs, suffix)
 
-                    addCount.get() shouldBe 0
-                    updateCount.get() shouldBe 0
-                    deleteCount.get() shouldBe 0
-                    initCount.get() shouldBe 0
+                    addCount.load() shouldBe 0
+                    updateCount.load() shouldBe 0
+                    deleteCount.load() shouldBe 0
+                    initCount.load() shouldBe 0
 
                     client.deleteChildren(path)
 
-                    pollUntil(settle) { deleteCount.get() == count && currentData.isEmpty() } shouldBe true
+                    pollUntil(settle) { deleteCount.load() == count && currentData.isEmpty() } shouldBe true
                     currentData shouldBe emptyList()
                 }
             }
 
-            addCount.get() shouldBe 0
-            updateCount.get() shouldBe 0
-            deleteCount.get() shouldBe count
-            initCount.get() shouldBe 0
+            addCount.load() shouldBe 0
+            updateCount.load() shouldBe 0
+            deleteCount.load() shouldBe count
+            initCount.load() shouldBe 0
         }
 
         "withInitialEventTest" {
             val count = 25
             val path = "/cache/noInitialDataTest"
-            val addCount = AtomicInteger(0)
-            val updateCount = AtomicInteger(0)
-            val deleteCount = AtomicInteger(0)
-            val initCount = AtomicInteger(0)
+            val addCount = AtomicInt(0)
+            val updateCount = AtomicInt(0)
+            val deleteCount = AtomicInt(0)
+            val initCount = AtomicInt(0)
 
             connectToEtcd(urls) { client ->
 
@@ -204,19 +205,19 @@ class PathChildrenCacheTests : StringSpec() {
                     addListener { event: PathChildrenCacheEvent ->
                         when (event.type) {
                             CHILD_ADDED -> {
-                              addCount.incrementAndGet()
+                              addCount.incrementAndFetch()
                             }
 
                             CHILD_UPDATED -> {
-                              updateCount.incrementAndGet()
+                              updateCount.incrementAndFetch()
                             }
 
                             CHILD_REMOVED -> {
-                              deleteCount.incrementAndGet()
+                              deleteCount.incrementAndFetch()
                             }
 
                             INITIALIZED -> {
-                                initCount.incrementAndGet()
+                                initCount.incrementAndFetch()
                                 initData = event.initialData
                             }
                         }
@@ -225,22 +226,22 @@ class PathChildrenCacheTests : StringSpec() {
                     start(POST_INITIALIZED_EVENT)
                     waitOnStartComplete()
 
-                    pollUntil(settle) { currentData.size == count && initCount.get() == 1 } shouldBe true
+                    pollUntil(settle) { currentData.size == count && initCount.load() == 1 } shouldBe true
                     compareData(count, currentData, kvs, suffix)
 
                     client.deleteChildren(path)
 
-                    pollUntil(settle) { deleteCount.get() == count && currentData.isEmpty() } shouldBe true
+                    pollUntil(settle) { deleteCount.load() == count && currentData.isEmpty() } shouldBe true
                     currentData shouldBe emptyList()
                 }
 
                 compareData(count, initData!!, kvs, suffix)
             }
 
-            addCount.get() shouldBe 0
-            updateCount.get() shouldBe 0
-            deleteCount.get() shouldBe count
-            initCount.get() shouldBe 1
+            addCount.load() shouldBe 0
+            updateCount.load() shouldBe 0
+            deleteCount.load() shouldBe count
+            initCount.load() shouldBe 1
         }
 
         "leasedValuesTest" {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ExceptionHolder.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/ExceptionHolder.kt
@@ -18,14 +18,14 @@
 
 package io.etcd.recipes.common
 
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 
 class ExceptionHolder {
-  private val holder = lazy { AtomicReference<Throwable>() }
+  private val holder = lazy { AtomicReference<Throwable?>(null) }
 
   var exception: Throwable?
-    get() = if (holder.isInitialized()) holder.value.get() else null
+    get() = if (holder.isInitialized()) holder.value.load() else null
     set(e) {
-      e?.let { holder.value.set(it) }
+      e?.let { holder.value.store(it) }
     }
 }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/RpcRetryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/RpcRetryTests.kt
@@ -33,7 +33,8 @@ import io.kotest.matchers.string.shouldContain
 import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
@@ -51,30 +52,30 @@ class RpcRetryTests : StringSpec() {
 
   init {
     "retries retriable failures until success" {
-      val calls = AtomicInteger(0)
+      val calls = AtomicInt(0)
       val result =
         retryRpc(quick(), "test-op") {
-          if (calls.incrementAndGet() <= 2) {
+          if (calls.incrementAndFetch() <= 2) {
             CompletableFuture.failedFuture(unavailable())
           } else {
             CompletableFuture.completedFuture("ok")
           }
         }
       result shouldBe "ok"
-      calls.get() shouldBe 3
+      calls.load() shouldBe 3
     }
 
     "gives up after policy exhaustion and wraps the cause with attempt context" {
-      val calls = AtomicInteger(0)
+      val calls = AtomicInt(0)
       val rpc = RpcResilience(RetryPolicy.bounded(maxAttempts = 2, delay = 10.milliseconds), 5.seconds)
       val thrown =
         shouldThrow<EtcdRecipeRuntimeException> {
           retryRpc<String>(rpc, "doomed-op") {
-            calls.incrementAndGet()
+            calls.incrementAndFetch()
             CompletableFuture.failedFuture(unavailable())
           }
         }
-      calls.get() shouldBe 3 // initial + 2 retries
+      calls.load() shouldBe 3 // initial + 2 retries
       thrown.message!! shouldContain "doomed-op"
       thrown.message!! shouldContain "3"
       generateSequence(thrown as Throwable) { it.cause.takeIf { c -> c !== it } }
@@ -91,35 +92,35 @@ class RpcRetryTests : StringSpec() {
     }
 
     "non-retriable failures propagate without retry" {
-      val calls = AtomicInteger(0)
+      val calls = AtomicInt(0)
       shouldThrowAny {
         retryRpc<String>(quick(), "bad-request") {
-          calls.incrementAndGet()
+          calls.incrementAndFetch()
           CompletableFuture.failedFuture(IllegalArgumentException("bad key"))
         }
       }
-      calls.get() shouldBe 1
+      calls.load() shouldBe 1
     }
 
     "DISABLED reproduces one-shot semantics" {
-      val calls = AtomicInteger(0)
+      val calls = AtomicInt(0)
       shouldThrowAny {
         retryRpc<String>(RpcResilience.DISABLED, "one-shot") {
-          calls.incrementAndGet()
+          calls.incrementAndFetch()
           CompletableFuture.failedFuture(unavailable())
         }
       }
-      calls.get() shouldBe 1
+      calls.load() shouldBe 1
     }
 
     "transaction is never retried even on retriable failures" {
-      val commits = AtomicInteger(0)
+      val commits = AtomicInt(0)
       val txn =
         mockk<Txn> {
           every { If(*anyVararg()) } returns this
           every { Then(*anyVararg()) } returns this
           every { commit() } answers {
-            commits.incrementAndGet()
+            commits.incrementAndFetch()
             CompletableFuture.failedFuture<TxnResponse>(unavailable())
           }
         }
@@ -131,17 +132,17 @@ class RpcRetryTests : StringSpec() {
       shouldThrowAny {
         client.transaction { If("x".doesExist) }
       }
-      commits.get() shouldBe 1
+      commits.load() shouldBe 1
     }
 
     "reads route through the retry engine" {
-      val calls = AtomicInteger(0)
+      val calls = AtomicInt(0)
       val client =
         mockk<Client> {
           every { kvClient } returns
             mockk<KV> {
               every { get(any<ByteSequence>(), any()) } answers {
-                if (calls.incrementAndGet() <= 1) {
+                if (calls.incrementAndFetch() <= 1) {
                   CompletableFuture.failedFuture(unavailable())
                 } else {
                   CompletableFuture.completedFuture(
@@ -156,7 +157,7 @@ class RpcRetryTests : StringSpec() {
         }
 
       client.getResponse("/rpc/read").kvs.isEmpty() shouldBe true
-      calls.get() shouldBe 2
+      calls.load() shouldBe 2
     }
   }
 }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/SelfHealingKeepAliveTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/SelfHealingKeepAliveTests.kt
@@ -35,8 +35,11 @@ import io.mockk.mockk
 import io.mockk.verify
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.fetchAndDecrement
+import kotlin.concurrent.atomics.fetchAndIncrement
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -54,10 +57,10 @@ class SelfHealingKeepAliveTests : StringSpec() {
     private val nextId = AtomicLong(100)
 
     /** Heal-path grant calls that should fail before one succeeds. */
-    val grantFailures = AtomicInteger(0)
+    val grantFailures = AtomicInt(0)
 
     private fun granted(): CompletableFuture<LeaseGrantResponse> {
-      val id = nextId.getAndIncrement()
+      val id = nextId.fetchAndIncrement()
       return CompletableFuture.completedFuture(mockk<LeaseGrantResponse> { every { this@mockk.id } returns id })
     }
 
@@ -65,7 +68,7 @@ class SelfHealingKeepAliveTests : StringSpec() {
       mockk {
         every { grant(any()) } answers { granted() }
         every { grant(any(), any(), any()) } answers {
-          if (grantFailures.getAndDecrement() > 0) {
+          if (grantFailures.fetchAndDecrement() > 0) {
             CompletableFuture.failedFuture(IllegalStateException("grant refused"))
           } else {
             granted()
@@ -165,10 +168,10 @@ class SelfHealingKeepAliveTests : StringSpec() {
     "establish returning false on heal emits Failed and stops" {
       val mocks = HealMocks()
       val events = CopyOnWriteArrayList<LeaseEvent>()
-      val calls = AtomicInteger(0)
+      val calls = AtomicInt(0)
 
       mocks.client.selfHealingKeepAlive(2.seconds, quickHeals(), { events += it }) {
-        calls.incrementAndGet() == 1 // initial establish succeeds; heals decline
+        calls.incrementAndFetch() == 1 // initial establish succeeds; heals decline
       }.use { healer ->
         mocks.observers.first().onCompleted()
         pollUntil(10.seconds) { events.any { it is LeaseEvent.Failed } } shouldBe true
@@ -181,7 +184,7 @@ class SelfHealingKeepAliveTests : StringSpec() {
     "heal attempts retry grant failures under the policy" {
       val mocks = HealMocks()
       val events = CopyOnWriteArrayList<LeaseEvent>()
-      mocks.grantFailures.set(2)
+      mocks.grantFailures.store(2)
 
       mocks.client.selfHealingKeepAlive(2.seconds, quickHeals(), { events += it }) { true }
         .use { healer ->
@@ -194,7 +197,7 @@ class SelfHealingKeepAliveTests : StringSpec() {
     "policy exhaustion emits Failed" {
       val mocks = HealMocks()
       val events = CopyOnWriteArrayList<LeaseEvent>()
-      mocks.grantFailures.set(Int.MAX_VALUE)
+      mocks.grantFailures.store(Int.MAX_VALUE)
       val resilience = LeaseResilience(RetryPolicy.bounded(maxAttempts = 2, delay = 10.milliseconds))
 
       mocks.client.selfHealingKeepAlive(2.seconds, resilience, { events += it }) { true }
@@ -208,7 +211,7 @@ class SelfHealingKeepAliveTests : StringSpec() {
     "close during healing cancels further attempts" {
       val mocks = HealMocks()
       val events = CopyOnWriteArrayList<LeaseEvent>()
-      mocks.grantFailures.set(Int.MAX_VALUE)
+      mocks.grantFailures.store(Int.MAX_VALUE)
       val resilience = LeaseResilience(RetryPolicy.bounded(maxAttempts = 1000, delay = 20.milliseconds))
 
       val healer = mocks.client.selfHealingKeepAlive(2.seconds, resilience, { events += it }) { true }
@@ -217,10 +220,10 @@ class SelfHealingKeepAliveTests : StringSpec() {
       healer.close()
 
       Thread.sleep(200)
-      val grantsAtClose = mocks.grantFailures.get()
+      val grantsAtClose = mocks.grantFailures.load()
       Thread.sleep(300)
       // grantFailures decrements once per heal-grant attempt; no movement = no attempts
-      (mocks.grantFailures.get() >= grantsAtClose - 1) shouldBe true
+      (mocks.grantFailures.load() >= grantsAtClose - 1) shouldBe true
       events.none { it is LeaseEvent.Restored } shouldBe true
     }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/TestExtensions.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/common/TestExtensions.kt
@@ -25,6 +25,7 @@ import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
 import java.util.concurrent.CountDownLatch
+import kotlin.concurrent.atomics.AtomicInt
 import kotlin.concurrent.thread
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -153,5 +154,16 @@ fun captureException(
     block()
   } catch (e: Throwable) {
     holder.exception = e
+  }
+}
+
+/**
+ * Atomically raise this counter to [candidate] when it is larger (a running max). The Kotlin
+ * atomics API has no `accumulateAndGet`, so tests tracking a high-water mark use this CAS loop.
+ */
+fun AtomicInt.accumulateMax(candidate: Int) {
+  while (true) {
+    val current = load()
+    if (candidate <= current || compareAndSet(current, candidate)) break
   }
 }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendLockTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendLockTests.kt
@@ -18,6 +18,7 @@
 
 package io.etcd.recipes.coroutines
 
+import io.etcd.recipes.common.accumulateMax
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.deleteChildren
 import io.etcd.recipes.common.getChildCount
@@ -39,7 +40,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -74,8 +77,8 @@ class SuspendLockTests : StringSpec() {
     "withLock serializes concurrent coroutines" {
       connectToEtcd(urls).use { client ->
         client.deleteChildren(base)
-        val inCritical = AtomicInteger(0)
-        val maxInCritical = AtomicInteger(0)
+        val inCritical = AtomicInt(0)
+        val maxInCritical = AtomicInt(0)
         var unguarded = 0
 
         DistributedMutex(client, "$base/serialize").use { mutex ->
@@ -84,18 +87,18 @@ class SuspendLockTests : StringSpec() {
               launch(Dispatchers.Default) {
                 repeat(3) {
                   mutex.withLock {
-                    val now = inCritical.incrementAndGet()
-                    maxInCritical.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                    val now = inCritical.incrementAndFetch()
+                    maxInCritical.accumulateMax(now)
                     unguarded += 1
                     delay(50)
-                    inCritical.decrementAndGet()
+                    inCritical.decrementAndFetch()
                   }
                 }
               }
             }
           }
         }
-        maxInCritical.get() shouldBeLessThanOrEqual 1
+        maxInCritical.load() shouldBeLessThanOrEqual 1
         unguarded shouldBe 12
       }
     }
@@ -191,21 +194,21 @@ class SuspendLockTests : StringSpec() {
         client.deleteChildren(base)
         val path = "$base/rw"
         DistributedReadWriteLock(client, path).use { rw ->
-          val concurrent = AtomicInteger(0)
-          val maxConcurrent = AtomicInteger(0)
+          val concurrent = AtomicInt(0)
+          val maxConcurrent = AtomicInt(0)
           coroutineScope {
             repeat(2) {
               launch(Dispatchers.Default) {
                 rw.readLock.withLock {
-                  val now = concurrent.incrementAndGet()
-                  maxConcurrent.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                  val now = concurrent.incrementAndFetch()
+                  maxConcurrent.accumulateMax(now)
                   delay(500)
-                  concurrent.decrementAndGet()
+                  concurrent.decrementAndFetch()
                 }
               }
             }
           }
-          maxConcurrent.get() shouldBe 2
+          maxConcurrent.load() shouldBe 2
 
           coroutineScope {
             val held = CompletableDeferred<Unit>()
@@ -243,23 +246,23 @@ class SuspendLockTests : StringSpec() {
       connectToEtcd(urls).use { client ->
         client.deleteChildren(base)
         val path = "$base/permits"
-        val inFlight = AtomicInteger(0)
-        val maxInFlight = AtomicInteger(0)
+        val inFlight = AtomicInt(0)
+        val maxInFlight = AtomicInt(0)
 
         DistributedSemaphore(client, path, 2).use { sem ->
           coroutineScope {
             repeat(5) {
               launch(Dispatchers.Default) {
                 sem.withPermit {
-                  val now = inFlight.incrementAndGet()
-                  maxInFlight.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                  val now = inFlight.incrementAndFetch()
+                  maxInFlight.accumulateMax(now)
                   delay(200)
-                  inFlight.decrementAndGet()
+                  inFlight.decrementAndFetch()
                 }
               }
             }
           }
-          maxInFlight.get() shouldBeLessThanOrEqual 2
+          maxInFlight.load() shouldBeLessThanOrEqual 2
         }
 
         DistributedSemaphore(client, "$base/permit-cancel", 1).use { sem ->

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendRpcRetryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/coroutines/SuspendRpcRetryTests.kt
@@ -32,7 +32,8 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import java.util.concurrent.CompletableFuture
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -50,48 +51,48 @@ class SuspendRpcRetryTests : StringSpec() {
   init {
     "retries retriable failures until success" {
       runTest {
-        val calls = AtomicInteger(0)
+        val calls = AtomicInt(0)
         val result =
           suspendRetryRpc(quick(), "test-op") {
-            if (calls.incrementAndGet() <= 2) {
+            if (calls.incrementAndFetch() <= 2) {
               CompletableFuture.failedFuture(unavailable())
             } else {
               CompletableFuture.completedFuture("ok")
             }
           }
         result shouldBe "ok"
-        calls.get() shouldBe 3
+        calls.load() shouldBe 3
       }
     }
 
     "retriable causes are found through the exception chain" {
       runTest {
-        val calls = AtomicInteger(0)
+        val calls = AtomicInt(0)
         val result =
           suspendRetryRpc(quick(), "wrapped-op") {
-            if (calls.incrementAndGet() <= 1) {
+            if (calls.incrementAndFetch() <= 1) {
               CompletableFuture.failedFuture(RuntimeException("wrapper", unavailable()))
             } else {
               CompletableFuture.completedFuture("ok")
             }
           }
         result shouldBe "ok"
-        calls.get() shouldBe 2
+        calls.load() shouldBe 2
       }
     }
 
     "gives up after policy exhaustion and wraps the cause with attempt context" {
       runTest {
-        val calls = AtomicInteger(0)
+        val calls = AtomicInt(0)
         val rpc = RpcResilience(RetryPolicy.bounded(maxAttempts = 2, delay = 10.milliseconds), 5.seconds)
         val thrown =
           shouldThrow<EtcdRecipeRuntimeException> {
             suspendRetryRpc<String>(rpc, "doomed-op") {
-              calls.incrementAndGet()
+              calls.incrementAndFetch()
               CompletableFuture.failedFuture(unavailable())
             }
           }
-        calls.get() shouldBe 3 // initial + 2 retries
+        calls.load() shouldBe 3 // initial + 2 retries
         thrown.message!! shouldContain "doomed-op"
         thrown.message!! shouldContain "3"
         generateSequence(thrown as Throwable) { it.cause.takeIf { c -> c !== it } }
@@ -115,43 +116,43 @@ class SuspendRpcRetryTests : StringSpec() {
 
     "an attempt timeout is retriable under the policy" {
       runTest {
-        val calls = AtomicInteger(0)
+        val calls = AtomicInt(0)
         val rpc = RpcResilience(RetryPolicy.bounded(maxAttempts = 3, delay = 10.milliseconds), 100.milliseconds)
         val result =
           suspendRetryRpc(rpc, "slow-then-ok") {
-            if (calls.incrementAndGet() <= 1) {
+            if (calls.incrementAndFetch() <= 1) {
               CompletableFuture() // hangs; times out at 100ms virtual
             } else {
               CompletableFuture.completedFuture("ok")
             }
           }
         result shouldBe "ok"
-        calls.get() shouldBe 2
+        calls.load() shouldBe 2
       }
     }
 
     "non-retriable failures propagate without retry" {
       runTest {
-        val calls = AtomicInteger(0)
+        val calls = AtomicInt(0)
         shouldThrow<IllegalArgumentException> {
           suspendRetryRpc<String>(quick(), "bad-request") {
-            calls.incrementAndGet()
+            calls.incrementAndFetch()
             CompletableFuture.failedFuture(IllegalArgumentException("bad key"))
           }
         }
-        calls.get() shouldBe 1
+        calls.load() shouldBe 1
       }
     }
 
     "external cancellation during the await propagates promptly without retry" {
       runTest {
-        val calls = AtomicInteger(0)
+        val calls = AtomicInt(0)
         val futures = mutableListOf<CompletableFuture<String>>()
         val rpc = RpcResilience(RetryPolicy.bounded(maxAttempts = 5, delay = 10.milliseconds), Duration.INFINITE)
         val job =
           launch {
             suspendRetryRpc<String>(rpc, "cancelled-op") {
-              calls.incrementAndGet()
+              calls.incrementAndFetch()
               CompletableFuture<String>().also { futures += it } // hangs; no timeout configured
             }
           }
@@ -159,28 +160,28 @@ class SuspendRpcRetryTests : StringSpec() {
         job.cancel()
         job.join()
         job.isCancelled shouldBe true
-        calls.get() shouldBe 1
+        calls.load() shouldBe 1
         futures.single().isCancelled shouldBe true
       }
     }
 
     "external cancellation during backoff is prompt: no further attempt" {
       runTest {
-        val calls = AtomicInteger(0)
+        val calls = AtomicInt(0)
         val rpc = RpcResilience(RetryPolicy.bounded(maxAttempts = 5, delay = 60.seconds), 5.seconds)
         val job =
           launch {
             suspendRetryRpc<String>(rpc, "backoff-op") {
-              calls.incrementAndGet()
+              calls.incrementAndFetch()
               CompletableFuture.failedFuture(unavailable())
             }
           }
         testScheduler.runCurrent() // first attempt fails; coroutine parks in the 60s backoff delay
-        calls.get() shouldBe 1
+        calls.load() shouldBe 1
         job.cancel()
         job.join()
         job.isCancelled shouldBe true
-        calls.get() shouldBe 1
+        calls.load() shouldBe 1
       }
     }
 
@@ -226,14 +227,14 @@ class SuspendRpcRetryTests : StringSpec() {
 
     "cancellation exceptions are never swallowed as retriable" {
       runTest {
-        val calls = AtomicInteger(0)
+        val calls = AtomicInt(0)
         shouldThrow<CancellationException> {
           suspendRetryRpc<String>(quick(), "cancel-inside") {
-            calls.incrementAndGet()
+            calls.incrementAndFetch()
             CompletableFuture.failedFuture(CancellationException("externally cancelled future"))
           }
         }
-        calls.get() shouldBe 1
+        calls.load() shouldBe 1
       }
     }
   }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/design/BugFixesTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/design/BugFixesTests.kt
@@ -39,7 +39,7 @@ import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -158,16 +158,16 @@ class BugFixesTests : StringSpec() {
           // autoStart=true triggers start() inside the constructor; the
           // pre-fix code blocked on keepAliveStartedLatch indefinitely here.
           TransientKeyValue(client, path, "v", autoStart = true)
-          outcome.set(IllegalStateException("expected start() to throw"))
+          outcome.store(IllegalStateException("expected start() to throw"))
         } catch (e: Throwable) {
-          outcome.set(e)
+          outcome.store(e)
         } finally {
           done.countDown()
         }
       }
 
       done.await(15, TimeUnit.SECONDS) shouldBe true
-      val thrown = outcome.get()
+      val thrown = outcome.load()
       // Any exception (EtcdRecipeRuntimeException wrapping a jetcd failure,
       // or the underlying gRPC error itself) is acceptable — the test is
       // that we did not hang.
@@ -252,7 +252,7 @@ class BugFixesTests : StringSpec() {
               // Sleep briefly so a buggy close() that doesn't await would
               // race past this point.
               Thread.sleep(200)
-              callbackExited.set(true)
+              callbackExited.store(true)
             }
           }
 
@@ -271,7 +271,7 @@ class BugFixesTests : StringSpec() {
 
         watcher.close()
         // Post-close, the callback must have finished.
-        callbackExited.get() shouldBe true
+        callbackExited.load() shouldBe true
 
         helper.shutdownNow()
         client.deleteKey(path)

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/design/DesignFixesTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/design/DesignFixesTests.kt
@@ -45,7 +45,8 @@ import io.kotest.matchers.string.shouldStartWith
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.reflect.KVisibility
 import kotlin.reflect.full.declaredMemberProperties
 import kotlin.time.Duration.Companion.seconds
@@ -64,16 +65,16 @@ class DesignFixesTests : StringSpec() {
     // ============================================================
     "fix #1: EtcdConnector close() runs doClose() exactly once across multiple calls" {
       connectToEtcd(urls) { client ->
-        val callCount = AtomicInteger(0)
+        val callCount = AtomicInt(0)
         val connector = object : EtcdConnector(client) {
           override fun doClose() {
-            callCount.incrementAndGet()
+            callCount.incrementAndFetch()
           }
         }
         connector.close()
         connector.close()
         connector.close()
-        callCount.get() shouldBe 1
+        callCount.load() shouldBe 1
       }
     }
 
@@ -277,7 +278,7 @@ class DesignFixesTests : StringSpec() {
           val perProducer = 25
           val producers = Executors.newFixedThreadPool(producerCount)
           val consumers = Executors.newFixedThreadPool(producerCount)
-          val received = AtomicInteger(0)
+          val received = AtomicInt(0)
           val total = producerCount * perProducer
           val finishLatch = CountDownLatch(total)
 
@@ -288,15 +289,15 @@ class DesignFixesTests : StringSpec() {
           }
           repeat(producerCount) {
             consumers.execute {
-              while (received.get() < total) {
+              while (received.load() < total) {
                 queue.dequeue() // blocks until a value appears
-                received.incrementAndGet()
+                received.incrementAndFetch()
                 finishLatch.countDown()
               }
             }
           }
           finishLatch.await(60, TimeUnit.SECONDS) shouldBe true
-          received.get() shouldBe total
+          received.load() shouldBe total
           producers.shutdownNow()
           consumers.shutdownNow()
         }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceCacheResyncTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceCacheResyncTests.kt
@@ -35,7 +35,8 @@ import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -55,7 +56,7 @@ class ServiceCacheResyncTests : StringSpec() {
   private inner class CacheMocks {
     val listeners = CopyOnWriteArrayList<Watch.Listener>()
     val options = CopyOnWriteArrayList<WatchOption>()
-    private val getCount = AtomicInteger(0)
+    private val getCount = AtomicInt(0)
 
     private fun kv(
       id: String,
@@ -69,7 +70,7 @@ class ServiceCacheResyncTests : StringSpec() {
     // GET #1 (initial snapshot): {v1} at revision 10. Every later GET (resync
     // snapshot): {v1Updated, v2} at revision 20.
     private fun getResponse(): GetResponse {
-      val first = getCount.incrementAndGet() == 1
+      val first = getCount.incrementAndFetch() == 1
       return mockk {
         every { kvs } returns
           if (first) {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceCacheTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceCacheTests.kt
@@ -30,7 +30,8 @@ import io.etcd.recipes.discovery.withServiceDiscovery
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 class ServiceCacheTests : StringSpec() {
@@ -41,10 +42,10 @@ class ServiceCacheTests : StringSpec() {
       val serviceCount = 10
       val name = "ServiceCacheTest"
       val holder = ExceptionHolder()
-      val registerCounter = AtomicInteger(0)
-      val updateCounter = AtomicInteger(0)
-      val unregisterCounter = AtomicInteger(0)
-      val totalCounter = AtomicInteger(0)
+      val registerCounter = AtomicInt(0)
+      val updateCounter = AtomicInt(0)
+      val unregisterCounter = AtomicInt(0)
+      val totalCounter = AtomicInt(0)
 
       val expectedTotal = (threadCount * serviceCount) * 3
 
@@ -68,20 +69,20 @@ class ServiceCacheTests : StringSpec() {
                   serviceName.split("/").first() shouldBe name
 
                   if (eventType == EventType.PUT) {
-                    if (isAdd) registerCounter.incrementAndGet() else updateCounter.incrementAndGet()
+                    if (isAdd) registerCounter.incrementAndFetch() else updateCounter.incrementAndFetch()
 
                     serviceInstance?.name shouldBe name
                   }
 
                   if (eventType == EventType.DELETE) {
-                    unregisterCounter.incrementAndGet()
+                    unregisterCounter.incrementAndFetch()
                     serviceInstance?.name shouldBe name
                   }
                 }
               }
             })
 
-            addListenerForChanges { _, _, _, _ -> totalCounter.incrementAndGet() }
+            addListenerForChanges { _, _, _, _ -> totalCounter.incrementAndFetch() }
 
             val (finishedLatch, holder2) =
               nonblockingThreads(threadCount) {
@@ -110,16 +111,16 @@ class ServiceCacheTests : StringSpec() {
             // events. On slow runners the producer threads finish ahead of
             // the watch delivery, so polling outside this block races the
             // close path and can lose tail events.
-            pollUntil(30.seconds) { totalCounter.get() == expectedTotal } shouldBe true
+            pollUntil(30.seconds) { totalCounter.load() == expectedTotal } shouldBe true
           }
         }
       }
 
       holder.checkForException()
-      registerCounter.get() shouldBe threadCount * serviceCount
-      updateCounter.get() shouldBe threadCount * serviceCount
-      unregisterCounter.get() shouldBe threadCount * serviceCount
-      totalCounter.get() shouldBe expectedTotal
+      registerCounter.load() shouldBe threadCount * serviceCount
+      updateCounter.load() shouldBe threadCount * serviceCount
+      unregisterCounter.load() shouldBe threadCount * serviceCount
+      totalCounter.load() shouldBe expectedTotal
     }
   }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceRegistryHealTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/discovery/ServiceRegistryHealTests.kt
@@ -36,8 +36,10 @@ import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.fetchAndIncrement
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -49,7 +51,7 @@ import kotlin.time.Duration.Companion.seconds
 class ServiceRegistryHealTests : StringSpec() {
   private class RegistryHealMocks {
     val observers = CopyOnWriteArrayList<StreamObserver<LeaseKeepAliveResponse>>()
-    val txnCount = AtomicInteger(0)
+    val txnCount = AtomicInt(0)
     private val nextId = AtomicLong(100)
 
     val client: Client =
@@ -58,12 +60,12 @@ class ServiceRegistryHealTests : StringSpec() {
           mockk<Lease> {
             every { grant(any()) } answers {
               CompletableFuture.completedFuture(
-                mockk<LeaseGrantResponse> { every { id } returns nextId.getAndIncrement() },
+                mockk<LeaseGrantResponse> { every { id } returns nextId.fetchAndIncrement() },
               )
             }
             every { grant(any(), any(), any()) } answers {
               CompletableFuture.completedFuture(
-                mockk<LeaseGrantResponse> { every { id } returns nextId.getAndIncrement() },
+                mockk<LeaseGrantResponse> { every { id } returns nextId.fetchAndIncrement() },
               )
             }
             every { keepAlive(any(), any()) } answers {
@@ -75,7 +77,7 @@ class ServiceRegistryHealTests : StringSpec() {
         every { kvClient } returns
           mockk<KV> {
             every { txn() } answers {
-              txnCount.incrementAndGet()
+              txnCount.incrementAndFetch()
               mockk<Txn> {
                 every { If(*anyVararg()) } returns this
                 every { Then(*anyVararg()) } returns this
@@ -97,13 +99,13 @@ class ServiceRegistryHealTests : StringSpec() {
       ServiceRegistry(mocks.client, "/registry/heal").use { registry ->
         registry.addLeaseListener { events += it }
         registry.registerService(service)
-        mocks.txnCount.get() shouldBe 1 // initial CAS registration
+        mocks.txnCount.load() shouldBe 1 // initial CAS registration
 
         // jetcd's DeadLine service fires onCompleted when the lease expires unrenewed
         mocks.observers.first().onCompleted()
 
         pollUntil(10.seconds) { events.any { it is LeaseEvent.Restored } } shouldBe true
-        mocks.txnCount.get() shouldBe 2 // re-registration CAS under the healed lease
+        mocks.txnCount.load() shouldBe 2 // re-registration CAS under the healed lease
       }
     }
   }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorCloseDeadlockTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorCloseDeadlockTests.kt
@@ -24,7 +24,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
@@ -38,7 +38,7 @@ class LeaderSelectorCloseDeadlockTests : StringSpec() {
         client,
         path,
         takeLeadershipBlock = { selector ->
-            latchRef.get().countDown()
+            latchRef.load().countDown()
             // Block until close() signals completion. Pre-fix attemptToBecomeLeader
             // held the instance monitor across this call, so close() (also
             // @Synchronized on the instance) could never run doClose() to flip the
@@ -62,7 +62,7 @@ class LeaderSelectorCloseDeadlockTests : StringSpec() {
                 val selector = blockingLeaderSelector(client, latchRef)
 
                 selector.start()
-                latchRef.get().await(20, TimeUnit.SECONDS) shouldBe true
+                latchRef.load().await(20, TimeUnit.SECONDS) shouldBe true
 
                 val closer = thread { selector.close() }
                 closer.join(20_000)
@@ -81,9 +81,9 @@ class LeaderSelectorCloseDeadlockTests : StringSpec() {
                 val selector = blockingLeaderSelector(client, latchRef)
 
                 repeat(3) {
-                    latchRef.set(CountDownLatch(1))
+                    latchRef.store(CountDownLatch(1))
                     selector.start()
-                    latchRef.get().await(20, TimeUnit.SECONDS) shouldBe true
+                    latchRef.load().await(20, TimeUnit.SECONDS) shouldBe true
 
                     val closer = thread { selector.close() }
                     closer.join(20_000)

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorReuseTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderSelectorReuseTests.kt
@@ -24,7 +24,8 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 
 // Regression test for: LeaderSelector with the default internal executor
 // could not be re-used after close() because close() shut down the
@@ -33,7 +34,7 @@ class LeaderSelectorReuseTests : StringSpec() {
   init {
     "startWorksAfterCloseWithInternalExecutor" {
       val path = "/election/LeaderSelectorReuseTests"
-      val tookLeadership = AtomicInteger(0)
+      val tookLeadership = AtomicInt(0)
 
       connectToEtcd(urls) { client ->
         // No userExecutor — the LeaderSelector creates its own ExecutorService.
@@ -41,7 +42,7 @@ class LeaderSelectorReuseTests : StringSpec() {
           LeaderSelector(
             client,
             path,
-            takeLeadershipBlock = { tookLeadership.incrementAndGet() },
+            takeLeadershipBlock = { tookLeadership.incrementAndFetch() },
           )
 
         // First cycle.
@@ -55,7 +56,7 @@ class LeaderSelectorReuseTests : StringSpec() {
         selector.waitOnLeadershipComplete()
         selector.close()
 
-        tookLeadership.get() shouldBe 2
+        tookLeadership.load() shouldBe 2
         selector.hasExceptions shouldBe false
       }
     }
@@ -65,7 +66,7 @@ class LeaderSelectorReuseTests : StringSpec() {
     // NOT shut down the user's executor (it didn't create it).
     "startWorksAfterCloseWithUserExecutor" {
       val path = "/election/LeaderSelectorReuseTests-userExecutor"
-      val tookLeadership = AtomicInteger(0)
+      val tookLeadership = AtomicInt(0)
       val userExecutor = Executors.newFixedThreadPool(3)
 
       try {
@@ -74,7 +75,7 @@ class LeaderSelectorReuseTests : StringSpec() {
             LeaderSelector(
               client,
               path,
-              takeLeadershipBlock = { tookLeadership.incrementAndGet() },
+              takeLeadershipBlock = { tookLeadership.incrementAndFetch() },
               executorService = userExecutor,
             )
 
@@ -89,7 +90,7 @@ class LeaderSelectorReuseTests : StringSpec() {
           selector.waitOnLeadershipComplete()
           selector.close()
 
-          tookLeadership.get() shouldBe 2
+          tookLeadership.load() shouldBe 2
           selector.hasExceptions shouldBe false
           userExecutor.isShutdown shouldBe false
         }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderStepDownTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/LeaderStepDownTests.kt
@@ -26,7 +26,8 @@ import io.etcd.recipes.common.pollUntil
 import io.etcd.recipes.common.urls
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -54,8 +55,8 @@ class LeaderStepDownTests : StringSpec() {
     "leader steps down when its leadership lease is lost" {
       connectToEtcd(urls) { client ->
         val electionPath = "$path/stepdown"
-        val relinquishCount = AtomicInteger(0)
-        val bLeaderships = AtomicInteger(0)
+        val relinquishCount = AtomicInt(0)
+        val bLeaderships = AtomicInt(0)
         val aElected = BooleanMonitor(false)
 
         val selectorA =
@@ -67,13 +68,13 @@ class LeaderStepDownTests : StringSpec() {
               // Parks on the finished monitor: step-down must release it.
               selector.waitUntilFinished()
             },
-            relinquishLeadershipBlock = { relinquishCount.incrementAndGet() },
+            relinquishLeadershipBlock = { relinquishCount.incrementAndFetch() },
           )
         val selectorB =
           LeaderSelector(
             client,
             electionPath,
-            takeLeadershipBlock = { bLeaderships.incrementAndGet() },
+            takeLeadershipBlock = { bLeaderships.incrementAndFetch() },
           )
 
         selectorA.use { a ->
@@ -87,10 +88,10 @@ class LeaderStepDownTests : StringSpec() {
 
             pollUntil(20.seconds) { !a.isLeader } shouldBe true
             a.waitOnLeadershipComplete(20.seconds) shouldBe true
-            pollUntil(10.seconds) { relinquishCount.get() == 1 } shouldBe true
+            pollUntil(10.seconds) { relinquishCount.load() == 1 } shouldBe true
 
             // The other candidate takes over (no split brain: A already stepped down)
-            pollUntil(20.seconds) { bLeaderships.get() == 1 } shouldBe true
+            pollUntil(20.seconds) { bLeaderships.load() == 1 } shouldBe true
             b.waitOnLeadershipComplete(20.seconds) shouldBe true
           }
         }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/ReportLeaderTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/ReportLeaderTests.kt
@@ -27,7 +27,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.Executors
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.seconds
 
 @Suppress("MaxLineLength")
@@ -39,8 +40,8 @@ class ReportLeaderTests : StringSpec() {
         // jetcd lease grant. Same code passed under JUnit — root cause not yet diagnosed.
         "reportLeaderTest" {
             val count = 2
-            val takeLeadershipCounter = AtomicInteger(0)
-            val relinquishLeadershipCounter = AtomicInteger(0)
+            val takeLeadershipCounter = AtomicInt(0)
+            val relinquishLeadershipCounter = AtomicInt(0)
 
             val executor = Executors.newSingleThreadExecutor()
             LeaderSelector.reportLeader(
@@ -49,11 +50,11 @@ class ReportLeaderTests : StringSpec() {
                 object : LeaderListener {
                     override fun takeLeadership(leaderName: String) {
                         logger.debug { "$leaderName elected leader" }
-                        takeLeadershipCounter.incrementAndGet()
+                        takeLeadershipCounter.incrementAndFetch()
                     }
 
                     override fun relinquishLeadership() {
-                        relinquishLeadershipCounter.incrementAndGet()
+                        relinquishLeadershipCounter.incrementAndFetch()
                     }
                 },
                 executor,
@@ -84,8 +85,8 @@ class ReportLeaderTests : StringSpec() {
             // This requires a pause because reportLeader() needs to get notified (via a watcher) of the change in leadership
             sleep(10.seconds)
 
-            takeLeadershipCounter.get() shouldBe count
-            relinquishLeadershipCounter.get() shouldBe count
+            takeLeadershipCounter.load() shouldBe count
+            relinquishLeadershipCounter.load() shouldBe count
 
             executor.shutdown()
         }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/SerialLeaderSelectorTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/SerialLeaderSelectorTests.kt
@@ -24,7 +24,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 
 class SerialLeaderSelectorTests : StringSpec() {
     val path = "/election/${javaClass.simpleName}"
@@ -38,18 +39,18 @@ class SerialLeaderSelectorTests : StringSpec() {
 
         "serialElectionTest" {
             val count = 5
-            val takeLeadershiptCounter = AtomicInteger(0)
-            val relinquishLeadershiptCounter = AtomicInteger(0)
+            val takeLeadershiptCounter = AtomicInt(0)
+            val relinquishLeadershiptCounter = AtomicInt(0)
 
             val leadershipAction = { selector: LeaderSelector ->
                 logger.info { "${selector.clientId} elected leader" }
-                takeLeadershiptCounter.incrementAndGet()
+                takeLeadershiptCounter.incrementAndFetch()
                 Unit
             }
 
             val relinquishAction = { selector: LeaderSelector ->
                 logger.info { "${selector.clientId} relinquished" }
-                relinquishLeadershiptCounter.incrementAndGet()
+                relinquishLeadershiptCounter.incrementAndFetch()
                 Unit
             }
 
@@ -63,12 +64,12 @@ class SerialLeaderSelectorTests : StringSpec() {
                 }
             }
 
-            takeLeadershiptCounter.get() shouldBe count
-            relinquishLeadershiptCounter.get() shouldBe count
+            takeLeadershiptCounter.load() shouldBe count
+            relinquishLeadershiptCounter.load() shouldBe count
 
             // Reset counters
-            takeLeadershiptCounter.set(0)
-            relinquishLeadershiptCounter.set(0)
+            takeLeadershiptCounter.store(0)
+            relinquishLeadershiptCounter.store(0)
 
             connectToEtcd(urls) { client ->
                 repeat(count) {
@@ -80,8 +81,8 @@ class SerialLeaderSelectorTests : StringSpec() {
                 }
             }
 
-            takeLeadershiptCounter.get() shouldBe count
-            relinquishLeadershiptCounter.get() shouldBe count
+            takeLeadershiptCounter.load() shouldBe count
+            relinquishLeadershiptCounter.load() shouldBe count
         }
     }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/ThreadedLeaderSelectorTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/election/ThreadedLeaderSelectorTests.kt
@@ -25,7 +25,8 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.Collections.synchronizedList
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 
 class ThreadedLeaderSelectorTests : StringSpec() {
     val path = "/election/${javaClass.simpleName}"
@@ -33,20 +34,20 @@ class ThreadedLeaderSelectorTests : StringSpec() {
 
     init {
         "threadedElection1Test" {
-            val takeLeadershiptCounter = AtomicInteger(0)
-            val relinquishLeadershiptCounter = AtomicInteger(0)
+            val takeLeadershiptCounter = AtomicInt(0)
+            val relinquishLeadershiptCounter = AtomicInt(0)
 
             blockingThreads(count) {
                 val takeAction =
                     { selector: LeaderSelector ->
                         logger.info { "${selector.clientId} elected leader" }
-                        takeLeadershiptCounter.incrementAndGet()
+                        takeLeadershiptCounter.incrementAndFetch()
                         Unit
                     }
 
                 val relinquishAction =
                     { selector: LeaderSelector ->
-                        relinquishLeadershiptCounter.incrementAndGet()
+                        relinquishLeadershiptCounter.incrementAndFetch()
                         logger.info { "${selector.clientId} relinquished leadership" }
                     }
 
@@ -58,25 +59,25 @@ class ThreadedLeaderSelectorTests : StringSpec() {
                 }
             }
 
-            takeLeadershiptCounter.get() shouldBe count
-            relinquishLeadershiptCounter.get() shouldBe count
+            takeLeadershiptCounter.load() shouldBe count
+            relinquishLeadershiptCounter.load() shouldBe count
         }
 
         "threadedElection2Test" {
-            val takeLeadershiptCounter = AtomicInteger(0)
-            val relinquishLeadershiptCounter = AtomicInteger(0)
+            val takeLeadershiptCounter = AtomicInt(0)
+            val relinquishLeadershiptCounter = AtomicInt(0)
             val electionList: MutableList<LeaderSelector> = synchronizedList(mutableListOf())
 
             val takeAction =
                 { selector: LeaderSelector ->
                     logger.info { "${selector.clientId} elected leader" }
-                    takeLeadershiptCounter.incrementAndGet()
+                    takeLeadershiptCounter.incrementAndFetch()
                     Unit
                 }
 
             val relinquishAction =
                 { selector: LeaderSelector ->
-                    relinquishLeadershiptCounter.incrementAndGet()
+                    relinquishLeadershiptCounter.incrementAndFetch()
                     logger.info { "${selector.clientId} relinquished leadership" }
                 }
 
@@ -96,8 +97,8 @@ class ThreadedLeaderSelectorTests : StringSpec() {
                     .forEach { it.close() }
             }
 
-            takeLeadershiptCounter.get() shouldBe count
-            relinquishLeadershiptCounter.get() shouldBe count
+            takeLeadershiptCounter.load() shouldBe count
+            relinquishLeadershiptCounter.load() shouldBe count
         }
     }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/RecipeFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/RecipeFaultTests.kt
@@ -32,8 +32,9 @@ import io.etcd.recipes.election.LeaderSelector
 import io.etcd.recipes.queue.DistributedQueue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
@@ -91,8 +92,8 @@ class RecipeFaultTests : StringSpec() {
       assumeFaultInjection()
       val electionPath = "$path/election"
       val releaseLeader = BooleanMonitor(false)
-      val aLeaderships = AtomicInteger(0)
-      val bLeaderships = AtomicInteger(0)
+      val aLeaderships = AtomicInt(0)
+      val bLeaderships = AtomicInt(0)
 
       connectToEtcd(urls) { clientA ->
         connectToEtcd(urls) { clientB ->
@@ -101,7 +102,7 @@ class RecipeFaultTests : StringSpec() {
               clientA,
               electionPath,
               takeLeadershipBlock = { _ ->
-                aLeaderships.incrementAndGet()
+                aLeaderships.incrementAndFetch()
                 releaseLeader.waitUntilTrue()
               },
             )
@@ -109,13 +110,13 @@ class RecipeFaultTests : StringSpec() {
             LeaderSelector(
               clientB,
               electionPath,
-              takeLeadershipBlock = { _ -> bLeaderships.incrementAndGet() },
+              takeLeadershipBlock = { _ -> bLeaderships.incrementAndFetch() },
             )
 
           selectorA.use { a ->
             selectorB.use { b ->
               a.start()
-              pollUntil(15.seconds) { aLeaderships.get() == 1 } shouldBe true
+              pollUntil(15.seconds) { aLeaderships.load() == 1 } shouldBe true
               b.start()
 
               // The candidate's leader-key watch must survive the restart to ever
@@ -123,7 +124,7 @@ class RecipeFaultTests : StringSpec() {
               EtcdTestContainer.restart()
 
               releaseLeader.set(true)
-              pollUntil(60.seconds) { bLeaderships.get() == 1 } shouldBe true
+              pollUntil(60.seconds) { bLeaderships.load() == 1 } shouldBe true
               a.waitOnLeadershipComplete(30.seconds) shouldBe true
               b.waitOnLeadershipComplete(30.seconds) shouldBe true
             }
@@ -137,14 +138,14 @@ class RecipeFaultTests : StringSpec() {
       connectToEtcd(urls) { client ->
         val queuePath = "$path/queue"
         DistributedQueue(client, queuePath).use { queue ->
-          val result = AtomicReference<String?>()
-          val error = AtomicReference<Throwable?>()
+          val result = AtomicReference<String?>(null)
+          val error = AtomicReference<Throwable?>(null)
           val consumer =
             thread(name = "fault-dequeue") {
               try {
-                result.set(queue.dequeue().asString)
+                result.store(queue.dequeue().asString)
               } catch (e: Throwable) {
-                error.set(e)
+                error.store(e)
               }
             }
 
@@ -154,9 +155,9 @@ class RecipeFaultTests : StringSpec() {
 
           connectToEtcd(urls) { producer -> DistributedQueue(producer, queuePath).use { it.enqueue("recovered") } }
 
-          pollUntil(60.seconds) { result.get() != null || error.get() != null } shouldBe true
-          error.get() shouldBe null
-          result.get() shouldBe "recovered"
+          pollUntil(60.seconds) { result.load() != null || error.load() != null } shouldBe true
+          error.load() shouldBe null
+          result.load() shouldBe "recovered"
           consumer.join(5_000)
         }
       }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/ResilientRpcFaultTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/fault/ResilientRpcFaultTests.kt
@@ -28,7 +28,7 @@ import io.etcd.recipes.common.urls
 import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -76,9 +76,9 @@ class ResilientRpcFaultTests : StringSpec() {
             try {
               // Per-attempt timeout of 3s; retries ride out the pause window.
               val patient = RpcResilience(RetryPolicy.bounded(maxAttempts = 20, delay = 500.milliseconds), 3.seconds)
-              result.set(client.getValue("$path/patient", "default", patient))
+              result.store(client.getValue("$path/patient", "default", patient))
             } catch (e: Throwable) {
-              error.set(e)
+              error.store(e)
             }
           }
         try {
@@ -89,8 +89,8 @@ class ResilientRpcFaultTests : StringSpec() {
         EtcdTestContainer.awaitReady()
 
         reader.join(60_000)
-        error.get() shouldBe null
-        result.get() shouldBe "survives"
+        error.load() shouldBe null
+        result.load() shouldBe "survives"
       }
     }
   }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueHealTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/keyvalue/TransientKeyValueHealTests.kt
@@ -37,7 +37,8 @@ import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicLong
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.fetchAndIncrement
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -60,14 +61,14 @@ class TransientKeyValueHealTests : StringSpec() {
             every { grant(any()) } answers {
               CompletableFuture.completedFuture(
                 mockk<LeaseGrantResponse> {
-                  every { id } returns nextId.getAndIncrement()
+                  every { id } returns nextId.fetchAndIncrement()
                 },
               )
             }
             every { grant(any(), any(), any()) } answers {
               CompletableFuture.completedFuture(
                 mockk<LeaseGrantResponse> {
-                  every { id } returns nextId.getAndIncrement()
+                  every { id } returns nextId.fetchAndIncrement()
                 },
               )
             }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedMutexTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedMutexTests.kt
@@ -24,7 +24,7 @@ import io.etcd.recipes.common.urls
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicReference
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
@@ -61,15 +61,15 @@ class DistributedMutexTests : StringSpec() {
         client.deleteChildren(base)
         DistributedMutex(client, "$base/non-owner").use { mutex ->
           mutex.lock()
-          val thrown = AtomicReference<Throwable?>()
+          val thrown = AtomicReference<Throwable?>(null)
           thread {
             try {
               mutex.unlock()
             } catch (e: Throwable) {
-              thrown.set(e)
+              thrown.store(e)
             }
           }.join(10_000)
-          (thrown.get() is IllegalMonitorStateException) shouldBe true
+          (thrown.load() is IllegalMonitorStateException) shouldBe true
           mutex.unlock() shouldBe true
         }
       }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedReadWriteLockTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedReadWriteLockTests.kt
@@ -19,6 +19,7 @@
 package io.etcd.recipes.lock
 
 import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.common.accumulateMax
 import io.etcd.recipes.common.blockingThreads
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.deleteChildren
@@ -30,7 +31,9 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.ints.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
@@ -47,22 +50,22 @@ class DistributedReadWriteLockTests : StringSpec() {
       connectToEtcd(urls) { client ->
         client.deleteChildren(base)
         val path = "$base/shared-readers"
-        val concurrent = AtomicInteger(0)
-        val maxConcurrent = AtomicInteger(0)
+        val concurrent = AtomicInt(0)
+        val maxConcurrent = AtomicInt(0)
 
         blockingThreads(4) {
           connectToEtcd(urls) { c ->
             DistributedReadWriteLock(c, path).use { rw ->
               rw.readLock.withLock {
-                val now = concurrent.incrementAndGet()
-                maxConcurrent.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                val now = concurrent.incrementAndFetch()
+                maxConcurrent.accumulateMax(now)
                 Thread.sleep(500)
-                concurrent.decrementAndGet()
+                concurrent.decrementAndFetch()
               }
             }
           }
         }
-        maxConcurrent.get() shouldBe 4
+        maxConcurrent.load() shouldBe 4
       }
     }
 
@@ -70,8 +73,8 @@ class DistributedReadWriteLockTests : StringSpec() {
       connectToEtcd(urls) { client ->
         client.deleteChildren(base)
         val path = "$base/writer-excludes"
-        val inCritical = AtomicInteger(0)
-        val maxInCritical = AtomicInteger(0)
+        val inCritical = AtomicInt(0)
+        val maxInCritical = AtomicInt(0)
         var unguarded = 0
 
         blockingThreads(4) { i ->
@@ -81,19 +84,19 @@ class DistributedReadWriteLockTests : StringSpec() {
               repeat(5) {
                 lock.withLock {
                   if (i % 2 == 0) {
-                    val now = inCritical.incrementAndGet()
-                    maxInCritical.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                    val now = inCritical.incrementAndFetch()
+                    maxInCritical.accumulateMax(now)
                     unguarded += 1
-                    inCritical.decrementAndGet()
+                    inCritical.decrementAndFetch()
                   } else {
-                    inCritical.get() shouldBe 0 // no writer while a reader holds
+                    inCritical.load() shouldBe 0 // no writer while a reader holds
                   }
                 }
               }
             }
           }
         }
-        maxInCritical.get() shouldBeLessThanOrEqual 1
+        maxInCritical.load() shouldBeLessThanOrEqual 1
         unguarded shouldBe 10
       }
     }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedSemaphoreTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/DistributedSemaphoreTests.kt
@@ -19,6 +19,7 @@
 package io.etcd.recipes.lock
 
 import com.pambrose.common.concurrent.BooleanMonitor
+import io.etcd.recipes.common.accumulateMax
 import io.etcd.recipes.common.blockingThreads
 import io.etcd.recipes.common.connectToEtcd
 import io.etcd.recipes.common.deleteChildren
@@ -32,7 +33,9 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.ints.shouldBeLessThanOrEqual
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.decrementAndFetch
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
@@ -49,25 +52,25 @@ class DistributedSemaphoreTests : StringSpec() {
       connectToEtcd(urls) { client ->
         client.deleteChildren(base)
         val path = "$base/capacity"
-        val inFlight = AtomicInteger(0)
-        val maxInFlight = AtomicInteger(0)
-        val completions = AtomicInteger(0)
+        val inFlight = AtomicInt(0)
+        val maxInFlight = AtomicInt(0)
+        val completions = AtomicInt(0)
 
         blockingThreads(8) {
           connectToEtcd(urls) { c ->
             DistributedSemaphore(c, path, 3).use { sem ->
               sem.withPermit {
-                val now = inFlight.incrementAndGet()
-                maxInFlight.accumulateAndGet(now) { a, b -> maxOf(a, b) }
+                val now = inFlight.incrementAndFetch()
+                maxInFlight.accumulateMax(now)
                 Thread.sleep(300)
-                inFlight.decrementAndGet()
-                completions.incrementAndGet()
+                inFlight.decrementAndFetch()
+                completions.incrementAndFetch()
               }
             }
           }
         }
-        maxInFlight.get() shouldBeLessThanOrEqual 3
-        completions.get() shouldBe 8
+        maxInFlight.load() shouldBeLessThanOrEqual 3
+        completions.load() shouldBe 8
       }
     }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/MutexLockLostTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/MutexLockLostTests.kt
@@ -30,7 +30,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.atomics.AtomicBoolean
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
@@ -134,14 +134,14 @@ class MutexLockLostTests : StringSpec() {
               try {
                 Thread.sleep(4_000)
               } catch (e: InterruptedException) {
-                interrupted.set(true)
+                interrupted.store(true)
               }
               finished.set(true)
             }
           heldOff.waitUntilTrue(15.seconds) shouldBe true
           revokeHolderLease(client, cooperativePath)
           finished.waitUntilTrue(20.seconds) shouldBe true
-          interrupted.get() shouldBe false
+          interrupted.load() shouldBe false
           pollUntil(10.seconds) { !mutex.isHeldByCurrentThread } shouldBe true
           holder.join(10_000)
         }

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/RecipeMetricsTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/lock/RecipeMetricsTests.kt
@@ -31,7 +31,8 @@ import io.etcd.recipes.queue.DistributedQueue
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -45,7 +46,7 @@ class RecipeMetricsTests : StringSpec() {
 
   private class RecordingMetrics : EtcdMetrics {
     val lockWaits = CopyOnWriteArrayList<Boolean>()
-    val lockHolds = AtomicInteger(0)
+    val lockHolds = AtomicInt(0)
     val leadership = CopyOnWriteArrayList<Boolean>()
     val queueOps = CopyOnWriteArrayList<String>()
     val cacheSyncs = CopyOnWriteArrayList<Int>()
@@ -62,7 +63,7 @@ class RecipeMetricsTests : StringSpec() {
       path: String,
       duration: Duration,
     ) {
-      lockHolds.incrementAndGet()
+      lockHolds.incrementAndFetch()
     }
 
     override fun incrementLeadershipTransition(
@@ -100,7 +101,7 @@ class RecipeMetricsTests : StringSpec() {
             mutex.unlock()
           }
         metrics.lockWaits shouldBe listOf(true)
-        metrics.lockHolds.get() shouldBe 1
+        metrics.lockHolds.load() shouldBe 1
       }
     }
 
@@ -114,7 +115,7 @@ class RecipeMetricsTests : StringSpec() {
             semaphore.release()
           }
         metrics.lockWaits shouldBe listOf(true)
-        metrics.lockHolds.get() shouldBe 1
+        metrics.lockHolds.load() shouldBe 1
       }
     }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueueTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedPriorityQueueTest.kt
@@ -31,7 +31,8 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import java.util.Collections.synchronizedList
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
@@ -282,7 +283,7 @@ class DistributedPriorityQueueTest : StringSpec() {
         // Same code passed under JUnit — root cause not yet diagnosed.
         "pingPongTest" {
             val queuePath = "$basePath/pingPongTest"
-            val counter = AtomicInteger(0)
+            val counter = AtomicInt(0)
             val token = "Pong"
             val latch = CountDownLatch(threadCount)
             val iterCount = 100
@@ -298,7 +299,7 @@ class DistributedPriorityQueueTest : StringSpec() {
                                 val v = dequeue().asString
                                 v shouldBe token
                                 enqueue(v, 1u)
-                                counter.incrementAndGet()
+                                counter.incrementAndFetch()
                             }
                         }
                     }
@@ -312,7 +313,7 @@ class DistributedPriorityQueueTest : StringSpec() {
                 }
             }
 
-            counter.get() shouldBe threadCount * iterCount
+            counter.load() shouldBe threadCount * iterCount
         }
 
         "serialTestNoWaitWithPriorities" {

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedQueueTest.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/DistributedQueueTest.kt
@@ -30,7 +30,8 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import java.util.Collections.synchronizedList
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicInteger
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.incrementAndFetch
 
 class DistributedQueueTest : StringSpec() {
     // Namespace etcd paths by class name so concurrent test forks (and the
@@ -218,7 +219,7 @@ class DistributedQueueTest : StringSpec() {
         // Same code passed under JUnit — root cause not yet diagnosed.
         "pingPongTest" {
             val queuePath = "$basePath/pingPongTest"
-            val counter = AtomicInteger(0)
+            val counter = AtomicInt(0)
             val token = "Pong"
             val latch = CountDownLatch(threadCount)
             val iterCount = 100
@@ -234,7 +235,7 @@ class DistributedQueueTest : StringSpec() {
                                 val v = dequeue().asString
                                 v shouldBe token
                                 enqueue(v)
-                                counter.incrementAndGet()
+                                counter.incrementAndFetch()
                             }
                         }
                     }
@@ -248,7 +249,7 @@ class DistributedQueueTest : StringSpec() {
                 }
             }
 
-            counter.get() shouldBe threadCount * iterCount
+            counter.load() shouldBe threadCount * iterCount
         }
     }
 

--- a/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueueWatchRecoveryTests.kt
+++ b/etcd-recipes/src/test/kotlin/io/etcd/recipes/queue/QueueWatchRecoveryTests.kt
@@ -39,8 +39,9 @@ import io.mockk.every
 import io.mockk.mockk
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.AtomicReference
+import kotlin.concurrent.atomics.incrementAndFetch
 import kotlin.concurrent.thread
 import kotlin.time.Duration.Companion.seconds
 
@@ -57,7 +58,7 @@ class QueueWatchRecoveryTests : StringSpec() {
   ) {
     val listeners = CopyOnWriteArrayList<Watch.Listener>()
     val options = CopyOnWriteArrayList<WatchOption>()
-    val getCount = AtomicInteger(0)
+    val getCount = AtomicInt(0)
 
     private val item: KeyValue =
       mockk {
@@ -67,7 +68,7 @@ class QueueWatchRecoveryTests : StringSpec() {
       }
 
     private fun getResponse(): GetResponse {
-      val empty = getCount.incrementAndGet() <= emptyGets
+      val empty = getCount.incrementAndFetch() <= emptyGets
       return mockk {
         every { kvs } returns if (empty) emptyList() else listOf(item)
         every { isMore } returns false
@@ -132,25 +133,25 @@ class QueueWatchRecoveryTests : StringSpec() {
       // GET #1 (fast path) and #2 (pre-live gap poll) see an empty queue; the
       // recovery re-poll and everything after see the item.
       val mocks = QueueMocks(emptyGets = 2)
-      val result = AtomicReference<ByteSequence?>()
-      val error = AtomicReference<Throwable?>()
+      val result = AtomicReference<ByteSequence?>(null)
+      val error = AtomicReference<Throwable?>(null)
 
       DistributedQueue(mocks.client, "/queue/recovery").use { queue ->
         val worker =
           thread(name = "dequeue-under-test") {
             try {
-              result.set(queue.dequeue())
+              result.store(queue.dequeue())
             } catch (e: Throwable) {
-              error.set(e)
+              error.store(e)
             }
           }
 
         pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
         mocks.listeners.first().die()
 
-        pollUntil(10.seconds) { result.get() != null || error.get() != null } shouldBe true
-        error.get() shouldBe null
-        result.get()!!.asString shouldBe "hello"
+        pollUntil(10.seconds) { result.load() != null || error.load() != null } shouldBe true
+        error.load() shouldBe null
+        result.load()!!.asString shouldBe "hello"
         worker.join(5_000)
       }
     }
@@ -159,25 +160,25 @@ class QueueWatchRecoveryTests : StringSpec() {
       // Queue stays empty forever and recovery is disabled: the dequeue must
       // surface an error instead of parking forever.
       val mocks = QueueMocks(emptyGets = Int.MAX_VALUE)
-      val error = AtomicReference<Throwable?>()
-      val result = AtomicReference<ByteSequence?>()
+      val error = AtomicReference<Throwable?>(null)
+      val result = AtomicReference<ByteSequence?>(null)
 
       DistributedQueue(mocks.client, "/queue/recovery", ResilienceConfig.DISABLED).use { queue ->
         val worker =
           thread(name = "dequeue-under-test") {
             try {
-              result.set(queue.dequeue())
+              result.store(queue.dequeue())
             } catch (e: Throwable) {
-              error.set(e)
+              error.store(e)
             }
           }
 
         pollUntil(5.seconds) { mocks.listeners.size == 1 } shouldBe true
         mocks.listeners.first().die()
 
-        pollUntil(10.seconds) { error.get() != null } shouldBe true
-        error.get().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
-        result.get() shouldBe null
+        pollUntil(10.seconds) { error.load() != null } shouldBe true
+        error.load().shouldBeInstanceOf<EtcdRecipeRuntimeException>()
+        result.load() shouldBe null
         worker.join(5_000)
       }
     }


### PR DESCRIPTION
## Summary

Finishes the migration to the Kotlin stdlib atomics the repo already standardized on. `EtcdConnector` and ~16 files already used `kotlin.concurrent.atomics.*` (with `ExperimentalAtomicApi` opted in compiler-wide, per `CLAUDE.md`), but 9 library files, 2 examples, and the test suite still used `java.util.concurrent.atomic.*` — several mixing both styles within one file. This standardizes on one.

**Behavior-preserving and API-neutral.** On the JVM the Kotlin atomics compile to the same primitives (no perf change); the win is a uniform, idiomatic codebase.

## The translation

- `AtomicInteger` → `AtomicInt`; `java` → `kotlin` `AtomicReference` / `AtomicBoolean` / `AtomicLong`
- `.get()` / `.set(v)` → `.load()` / `.store(v)`
- `getAndIncrement`/`incrementAndGet` → `fetchAndIncrement`/`incrementAndFetch` (and the decrement/add peers), with the fetch/get value semantics preserved
- no-arg `AtomicReference<T>()` → `AtomicReference<T>(null)` (Kotlin has no no-arg constructor)
- `accumulateAndGet` has **no** Kotlin equivalent — the test high-water-mark sites now use a new `accumulateMax` CAS-loop helper in `TestExtensions`

## Scope

50 files, +517/−459: **9 library files** (barrier, discovery, election, lock, queue), **2 examples**, **39 test files** (all test-body atomics incl. `AtomicLong`).

## Not touched

The three fields deliberately kept as plain `var`s — `DistributedBarrier.keepAliveLease`, `PathChildrenCache.watcher`, `ServiceCache.watcher` — are unchanged, so the `DesignFixesTests` reflection assertions (`field.type.name` not `AtomicReference`) still hold.

## Verification

Full CI-equivalent gate (`clean check koverXmlReport -PuseTestcontainers`) passes locally: **BUILD SUCCESSFUL**, zero failures. The frozen `design.*` oracle (35/35) plus the full lock/queue/election/barrier concurrency suites confirm no behavior changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwzFKGUKMvom7uGB8VVMWP