### PR TITLE
Upgrade Spring Boot to 4.1.0

### DIFF
--- a/etcd-recipes-spring-boot-starter/build.gradle.kts
+++ b/etcd-recipes-spring-boot-starter/build.gradle.kts
@@ -3,8 +3,10 @@ dependencies {
   api(libs.spring.boot.autoconfigure)
   // Actuator is optional — the health indicator only loads when it's on the app's classpath.
   compileOnly(libs.spring.boot.actuator)
+  compileOnly(libs.spring.boot.health)
 
   // starter-test brings ApplicationContextRunner + AssertJ (AssertableApplicationContext's supertype), version-aligned.
   testImplementation(libs.spring.boot.starter.test)
   testImplementation(libs.spring.boot.actuator)
+  testImplementation(libs.spring.boot.health)
 }

--- a/etcd-recipes-spring-boot-starter/src/main/kotlin/io/etcd/recipes/spring/EtcdAutoConfiguration.kt
+++ b/etcd-recipes-spring-boot-starter/src/main/kotlin/io/etcd/recipes/spring/EtcdAutoConfiguration.kt
@@ -21,11 +21,11 @@ package io.etcd.recipes.spring
 import io.etcd.jetcd.Client
 import io.etcd.recipes.common.EtcdRecipes
 import io.etcd.recipes.common.connectToEtcd
-import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 

--- a/etcd-recipes-spring-boot-starter/src/main/kotlin/io/etcd/recipes/spring/EtcdHealthIndicator.kt
+++ b/etcd-recipes-spring-boot-starter/src/main/kotlin/io/etcd/recipes/spring/EtcdHealthIndicator.kt
@@ -20,8 +20,8 @@ package io.etcd.recipes.spring
 
 import io.etcd.jetcd.Client
 import io.etcd.recipes.common.ping
-import org.springframework.boot.actuate.health.Health
-import org.springframework.boot.actuate.health.HealthIndicator
+import org.springframework.boot.health.contributor.Health
+import org.springframework.boot.health.contributor.HealthIndicator
 
 /**
  * Spring Boot Actuator health for etcd: an active [Client.ping] (bounded count-only GET) maps to

--- a/etcd-recipes-spring-boot-starter/src/test/kotlin/io/etcd/recipes/spring/EtcdAutoConfigurationTests.kt
+++ b/etcd-recipes-spring-boot-starter/src/test/kotlin/io/etcd/recipes/spring/EtcdAutoConfigurationTests.kt
@@ -24,8 +24,8 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
-import org.springframework.boot.actuate.health.HealthIndicator
 import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.health.contributor.HealthIndicator
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import java.util.function.Supplier
 

--- a/etcd-recipes-spring-boot-starter/src/test/kotlin/io/etcd/recipes/spring/EtcdHealthIndicatorTests.kt
+++ b/etcd-recipes-spring-boot-starter/src/test/kotlin/io/etcd/recipes/spring/EtcdHealthIndicatorTests.kt
@@ -25,7 +25,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import org.springframework.boot.actuate.health.Status
+import org.springframework.boot.health.contributor.Status
 import java.util.concurrent.CompletableFuture
 
 /** The health indicator maps the client's reachability probe to Actuator UP / DOWN. */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ logback = "1.5.38"
 jackson = "2.22.1"
 ktor = "3.5.1"
 micrometer = "1.17.0"
-spring-boot = "3.5.16"
+spring-boot = "4.1.0"
 
 # Testing
 junit = "6.1.2"
@@ -58,6 +58,7 @@ ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref 
 micrometer-core = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
 spring-boot-actuator = { module = "org.springframework.boot:spring-boot-actuator", version.ref = "spring-boot" }
 spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure", version.ref = "spring-boot" }
+spring-boot-health = { module = "org.springframework.boot:spring-boot-health", version.ref = "spring-boot" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot" }
 
 # Testing


### PR DESCRIPTION
Upgrades the spring-boot-starter module from 3.5.16 to 4.1.0.

Spring Boot 4 extracts the health API out of `spring-boot-actuator` into a separate `spring-boot-health` artifact and moves the types from `org.springframework.boot.actuate.health` to `org.springframework.boot.health.contributor`. This adds the new artifact (`compileOnly`, matching actuator's optional treatment) and repackages the `Health`, `HealthIndicator`, and `Status` imports. The API shape is unchanged (`Health.up().build()`, `health(): Health`), so no logic changed.

Verified under a full `-PuseTestcontainers` gate: 449 tests, 0 failures.

> **Stacked on #84.** Base is `version-catalog-consolidation` because this change depends on the catalog restructuring (`libs.spring.boot.health`, the `spring-boot` version key). GitHub will retarget this to `master` once #84 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)